### PR TITLE
refactor(backend/types): centralize JWTPayload, drop `as any` on req.user

### DIFF
--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -9,29 +9,11 @@
 
 import { Request, Response, NextFunction } from 'express';
 import jwt from 'jsonwebtoken';
-import { User } from '../types';
+import { JWTPayload } from '../types';
 import { UserService } from '../services/UserService';
 import { config } from '../config';
 import { logger } from '../config/logger';
 import { database } from '../config/database';
-
-// Extend Express Request to include user
-declare module 'express-serve-static-core' {
-  interface Request {
-    user?: User;
-  }
-}
-
-/**
- * JWT Token Payload Interface
- */
-interface JWTPayload {
-  userId: string;
-  email: string;
-  role: 'admin' | 'manager' | 'employee';
-  iat?: number;
-  exp?: number;
-}
 
 /**
  * Main Authentication Middleware

--- a/backend/src/middleware/tenant.ts
+++ b/backend/src/middleware/tenant.ts
@@ -15,12 +15,6 @@
 import { NextFunction, Request, Response } from 'express';
 import { Pool, RowDataPacket } from 'mysql2/promise';
 
-declare module 'express-serve-static-core' {
-  interface Request {
-    tenantId?: number;
-  }
-}
-
 export const DEFAULT_TENANT_ID = 1;
 
 export const resolveTenant = (pool: Pool) => {

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -18,14 +18,8 @@ import { Pool } from 'mysql2/promise';
 import { UserService } from '../services/UserService';
 import { authenticate } from '../middleware/auth';
 import jwt from 'jsonwebtoken';
-
-// Extend Express Request to include user
-declare module 'express-serve-static-core' {
-  interface Request {
-    user?: import('../types').User;
-  }
-}
 import { config } from '../config';
+import { UserWithSecrets } from '../types';
 
 export const createAuthRouter = (pool: Pool) => {
   const router = Router();
@@ -136,7 +130,7 @@ router.get('/verify', authenticate, async (req: Request, res: Response) => {
     }
 
     // Remove sensitive fields before sending response
-    const { password_hash: _password_hash, salt: _salt, ...userWithoutPassword } = user as any;
+    const { password_hash: _password_hash, salt: _salt, ...userWithoutPassword } = user as UserWithSecrets;
     res.json({
       success: true,
       data: userWithoutPassword
@@ -174,7 +168,7 @@ router.post('/refresh', authenticate, async (req: Request, res: Response) => {
       });
     }
 
-    const { password_hash: _password_hash, salt: _salt, ...userWithoutPassword } = user as any;
+    const { password_hash: _password_hash, salt: _salt, ...userWithoutPassword } = user as UserWithSecrets;
 
     const token = jwt.sign(
       { userId: user.id, email: user.email, role: user.role },

--- a/backend/src/routes/departments.ts
+++ b/backend/src/routes/departments.ts
@@ -14,7 +14,7 @@ export const createDepartmentsRouter = (pool: Pool) => {
   // Get all departments
   router.get('/', authenticate, async (req, res) => {
     try {
-      const user = (req as any).user;
+      const user = req.user!;
 
       let departments;
       if (user.role === 'admin') {
@@ -36,7 +36,7 @@ export const createDepartmentsRouter = (pool: Pool) => {
   // Get single department
   router.get('/:id', authenticate, async (req, res) => {
     try {
-      const user = (req as any).user;
+      const user = req.user!;
       const departmentId = parseInt(req.params.id);
 
       if (user.role !== 'admin') {
@@ -72,7 +72,7 @@ export const createDepartmentsRouter = (pool: Pool) => {
   // Create new department
   router.post('/', authenticate, async (req, res) => {
     try {
-      const user = (req as any).user;
+      const user = req.user!;
 
       if (!['admin', 'manager'].includes(user.role)) {
         return res.status(403).json({
@@ -122,7 +122,7 @@ export const createDepartmentsRouter = (pool: Pool) => {
   // Update department
   router.put('/:id', authenticate, async (req, res) => {
     try {
-      const user = (req as any).user;
+      const user = req.user!;
       const departmentId = parseInt(req.params.id);
       const departmentData: UpdateDepartmentRequest = req.body;
 
@@ -177,7 +177,7 @@ export const createDepartmentsRouter = (pool: Pool) => {
   // Delete department
   router.delete('/:id', authenticate, async (req, res) => {
     try {
-      const user = (req as any).user;
+      const user = req.user!;
       const departmentId = parseInt(req.params.id);
 
       if (user.role !== 'admin') {
@@ -210,7 +210,7 @@ export const createDepartmentsRouter = (pool: Pool) => {
   // Add user to department
   router.post('/:id/users', authenticate, async (req, res) => {
     try {
-      const user = (req as any).user;
+      const user = req.user!;
       const departmentId = parseInt(req.params.id);
       const { userId } = req.body;
 
@@ -264,7 +264,7 @@ export const createDepartmentsRouter = (pool: Pool) => {
   // Remove user from department
   router.delete('/:id/users/:userId', authenticate, async (req, res) => {
     try {
-      const user = (req as any).user;
+      const user = req.user!;
       const departmentId = parseInt(req.params.id);
       const targetUserId = parseInt(req.params.userId);
 
@@ -302,7 +302,7 @@ export const createDepartmentsRouter = (pool: Pool) => {
   // Get department statistics
   router.get('/:id/stats', authenticate, async (req, res) => {
     try {
-      const user = (req as any).user;
+      const user = req.user!;
       const departmentId = parseInt(req.params.id);
 
       if (user.role !== 'admin') {

--- a/backend/src/routes/settings.ts
+++ b/backend/src/routes/settings.ts
@@ -20,13 +20,6 @@ import { authenticate } from '../middleware/auth';
 import { UpdateSystemSettingRequest } from '../types';
 import { logger } from '../config/logger';
 
-// Extend Express Request to include user
-declare module 'express-serve-static-core' {
-  interface Request {
-    user?: import('../types').User;
-  }
-}
-
 export const createSystemSettingsRouter = (pool: Pool) => {
   const router = Router();
   const settingsService = new SystemSettingsService(pool);

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -12,7 +12,7 @@ export const createUsersRouter = (pool: Pool) => {
   // Get all users (with role-based filtering)
   router.get('/', authenticate, async (req, res) => {
     try {
-      const user = (req as any).user;
+      const user = req.user!;
       const { search, department, role } = req.query;
 
       let users;
@@ -59,7 +59,7 @@ export const createUsersRouter = (pool: Pool) => {
   // Create new user
   router.post('/', authenticate, async (req, res) => {
     try {
-      const user = (req as any).user;
+      const user = req.user!;
 
       if (!['admin', 'manager'].includes(user.role)) {
         return res.status(403).json({
@@ -100,7 +100,7 @@ export const createUsersRouter = (pool: Pool) => {
   // Get user by ID
   router.get('/:id', authenticate, async (req, res) => {
     try {
-      const user = (req as any).user;
+      const user = req.user!;
       const userId = parseInt(req.params.id);
 
       if (!userId) {
@@ -139,7 +139,7 @@ export const createUsersRouter = (pool: Pool) => {
   // Update user
   router.put('/:id', authenticate, async (req, res) => {
     try {
-      const user = (req as any).user;
+      const user = req.user!;
       const userId = parseInt(req.params.id);
 
       if (!userId) {
@@ -201,7 +201,7 @@ export const createUsersRouter = (pool: Pool) => {
   // Delete user
   router.delete('/:id', authenticate, async (req, res) => {
     try {
-      const user = (req as any).user;
+      const user = req.user!;
       const userId = parseInt(req.params.id);
 
       if (!userId) {

--- a/backend/src/types/express.d.ts
+++ b/backend/src/types/express.d.ts
@@ -1,7 +1,9 @@
 /**
  * Global Type Declarations
- * 
- * Extends Express types and other global interfaces.
+ *
+ * Extends Express types and other global interfaces. This is the single
+ * source of truth for Express request augmentation; do not redeclare
+ * `Request.user` or `Request.tenantId` in route or middleware files.
  */
 
 import { User } from './index';
@@ -10,6 +12,7 @@ declare global {
   namespace Express {
     interface Request {
       user?: User;
+      tenantId?: number;
     }
   }
 }

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -65,6 +65,27 @@ export interface LoginRequest {
   password: string;
 }
 
+/**
+ * Single source of truth for the JWT payload issued by `/api/auth/login`
+ * and consumed by `authenticate` middleware. Do not redefine locally.
+ */
+export interface JWTPayload {
+  userId: string;
+  email: string;
+  role: 'admin' | 'manager' | 'employee';
+  iat?: number;
+  exp?: number;
+}
+
+/**
+ * Internal-only widening of `User` for routes that need to defensively
+ * strip secret columns before serializing the user record.
+ */
+export type UserWithSecrets = User & {
+  password_hash?: string;
+  salt?: string;
+};
+
 export interface LoginResponse {
   success: boolean;
   data?: {


### PR DESCRIPTION
## Summary

- Centralize `JWTPayload` and `UserWithSecrets` in `backend/src/types/index.ts`
- Move all Express request augmentation (`user`, `tenantId`) into the single declaration in `backend/src/types/express.d.ts`
- Remove duplicate `declare module 'express-serve-static-core'` blocks from `routes/auth.ts`, `routes/settings.ts`, `middleware/tenant.ts`, `middleware/auth.ts`
- Replace `(req as any).user` with `req.user` in `routes/users.ts` and `routes/departments.ts`
- Replace `user as any` with `user as UserWithSecrets` for defensive secret-stripping in `routes/auth.ts`

## Test plan

- [x] `npm run build` (tsc)
- [x] `npm run lint`
- [x] `npm run deadcode` (knip)
- [x] `npm test` — 1078 tests pass

Closes #50

Made with [Cursor](https://cursor.com)