### PR TITLE
fix(backend/db): unify MySQL pool through database.getPool()

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -8,26 +8,17 @@
  * @author Luca Ostinelli
  */
 
-import { createPool } from 'mysql2/promise';
 import { config } from './config';
 import { logger } from './config/logger';
 import { buildApp } from './app';
+import { database } from './config/database';
 
 export async function startServer(): Promise<void> {
   try {
-    const pool = createPool({
-      host: config.database.host,
-      port: config.database.port,
-      user: config.database.user,
-      password: config.database.password,
-      database: config.database.database,
-      waitForConnections: true,
-      connectionLimit: 10,
-      queueLimit: 0,
-    });
+    const pool = database.getPool();
 
     try {
-      await pool.execute('SELECT 1');
+      await database.testConnection();
       logger.info('Database connection test successful');
     } catch (error) {
       logger.error('Database connection test failed:', error);


### PR DESCRIPTION
## Summary

- Drop the standalone `createPool` call in `backend/src/index.ts` and source the connection pool from the `database` singleton in `backend/src/config/database.ts` instead
- The middleware (`middleware/auth.ts`) already used the singleton, so both layers now share one pool
- `connectionLimit` now consistently respects `config.database.connectionLimit` instead of being hardcoded to 10 in two different places

## Test plan

- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm test` — 1078 tests pass

Closes #43

Made with [Cursor](https://cursor.com)