### PR TITLE
refactor(backend): unify login through AuthService

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,7 @@
   "description": "Backend API for Staff Scheduler - Advanced Workforce Management System",
   "main": "dist/index.js",
   "scripts": {
-    "dev": "nodemon src/index.ts",
+    "dev": "nodemon --exec \"ts-node --files\" src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",
     "test": "jest",

--- a/backend/src/__tests__/auth.route.extended.test.ts
+++ b/backend/src/__tests__/auth.route.extended.test.ts
@@ -10,11 +10,13 @@ import express from 'express';
 import request from 'supertest';
 import jwt from 'jsonwebtoken';
 import { UserService } from '../services/UserService';
+import { AuthService } from '../services/AuthService';
 import { database } from '../config/database';
 import { config } from '../config';
 import { createAuthRouter } from '../routes/auth';
 
 jest.mock('../services/UserService');
+jest.mock('../services/AuthService');
 jest.mock('../config/database', () => ({
   database: { getPool: jest.fn().mockReturnValue({}) },
 }));
@@ -105,14 +107,17 @@ describe('POST /api/auth/logout', () => {
   });
 });
 
-describe('POST /api/auth/login — service throws', () => {
-  it('returns 401 with the error message when validatePassword throws', async () => {
-    (UserService.prototype.validatePassword as jest.Mock) = jest.fn().mockRejectedValue(new Error('service failure'));
+describe('POST /api/auth/login — service surfaces an error', () => {
+  it('returns 401 with the error envelope when AuthService.login fails', async () => {
+    (AuthService.prototype.login as jest.Mock) = jest.fn().mockResolvedValue({
+      success: false,
+      error: { code: 'LOGIN_ERROR', message: 'service failure' },
+    });
 
     const res = await request(buildApp()).post('/api/auth/login').send({ email: 'a@x.com', password: 'pw' });
 
     expect(res.status).toBe(401);
-    expect(res.body.error.code).toBe('LOGIN_FAILED');
+    expect(res.body.error.code).toBe('LOGIN_ERROR');
     expect(res.body.error.message).toBe('service failure');
   });
 });

--- a/backend/src/__tests__/auth.route.test.ts
+++ b/backend/src/__tests__/auth.route.test.ts
@@ -9,19 +9,38 @@
 import express from 'express';
 import request from 'supertest';
 import jwt from 'jsonwebtoken';
-import { UserService } from '../services/UserService';
+import { AuthService } from '../services/AuthService';
 import { config } from '../config';
 import { createAuthRouter } from '../routes/auth';
 
-jest.mock('../services/UserService');
+jest.mock('../services/AuthService');
 
 const buildApp = (): express.Express => {
   const app = express();
   app.use(express.json());
-  // Pool is irrelevant — UserService is mocked.
+  // Pool is irrelevant — AuthService is mocked.
   app.use('/api/auth', createAuthRouter({} as never));
   return app;
 };
+
+const successResponse = (overrides: Record<string, unknown> = {}) => ({
+  success: true,
+  data: {
+    token: jwt.sign(
+      { userId: 7, email: 'a@x.com', role: 'manager' },
+      config.jwt.secret,
+      { expiresIn: config.jwt.expiresIn as jwt.SignOptions['expiresIn'] }
+    ),
+    user: {
+      id: 7,
+      email: 'a@x.com',
+      firstName: 'A',
+      lastName: 'B',
+      role: 'manager',
+    },
+    ...overrides,
+  },
+});
 
 describe('POST /api/auth/login', () => {
   beforeEach(() => {
@@ -29,13 +48,20 @@ describe('POST /api/auth/login', () => {
   });
 
   it('returns 400 when credentials are missing', async () => {
+    (AuthService.prototype.login as jest.Mock) = jest.fn().mockResolvedValue({
+      success: false,
+      error: { code: 'VALIDATION_ERROR', message: 'Email and password are required' },
+    });
     const res = await request(buildApp()).post('/api/auth/login').send({});
     expect(res.status).toBe(400);
     expect(res.body.error.code).toBe('VALIDATION_ERROR');
   });
 
   it('returns 401 when credentials are invalid', async () => {
-    (UserService.prototype.validatePassword as jest.Mock) = jest.fn().mockResolvedValue(null);
+    (AuthService.prototype.login as jest.Mock) = jest.fn().mockResolvedValue({
+      success: false,
+      error: { code: 'LOGIN_FAILED', message: 'Invalid email or password' },
+    });
     const res = await request(buildApp())
       .post('/api/auth/login')
       .send({ email: 'a@x.com', password: 'wrong' });
@@ -44,13 +70,7 @@ describe('POST /api/auth/login', () => {
   });
 
   it('returns a JWT and user payload on success', async () => {
-    (UserService.prototype.validatePassword as jest.Mock) = jest.fn().mockResolvedValue({
-      id: 7,
-      email: 'a@x.com',
-      firstName: 'A',
-      lastName: 'B',
-      role: 'manager',
-    });
+    (AuthService.prototype.login as jest.Mock) = jest.fn().mockResolvedValue(successResponse());
     const res = await request(buildApp())
       .post('/api/auth/login')
       .send({ email: 'a@x.com', password: 'pw' });
@@ -62,13 +82,7 @@ describe('POST /api/auth/login', () => {
   });
 
   it('issues a token whose TTL respects config.jwt.expiresIn', async () => {
-    (UserService.prototype.validatePassword as jest.Mock) = jest.fn().mockResolvedValue({
-      id: 7,
-      email: 'a@x.com',
-      firstName: 'A',
-      lastName: 'B',
-      role: 'manager',
-    });
+    (AuthService.prototype.login as jest.Mock) = jest.fn().mockResolvedValue(successResponse());
     const res = await request(buildApp())
       .post('/api/auth/login')
       .send({ email: 'a@x.com', password: 'pw' });

--- a/backend/src/__tests__/routes.expanded.test.ts
+++ b/backend/src/__tests__/routes.expanded.test.ts
@@ -31,6 +31,7 @@ jest.mock('../services/ShiftService');
 jest.mock('../services/EmployeeService');
 jest.mock('../services/DepartmentService');
 jest.mock('../services/UserService');
+jest.mock('../services/AuthService');
 jest.mock('../services/SystemSettingsService');
 jest.mock('../services/TimeOffService');
 jest.mock('../services/ShiftSwapService');
@@ -49,6 +50,7 @@ import { ShiftService } from '../services/ShiftService';
 import { EmployeeService } from '../services/EmployeeService';
 import { DepartmentService } from '../services/DepartmentService';
 import { UserService } from '../services/UserService';
+import { AuthService } from '../services/AuthService';
 import { SystemSettingsService } from '../services/SystemSettingsService';
 import { TimeOffService } from '../services/TimeOffService';
 import { ShiftSwapService } from '../services/ShiftSwapService';
@@ -1810,12 +1812,19 @@ describe('auth router (extended)', () => {
   const app = () => mountApp('/api/auth', createAuthRouter(fakePool));
 
   it('POST /login 400 on missing fields', async () => {
+    (AuthService.prototype.login as jest.Mock) = jest.fn().mockResolvedValue({
+      success: false,
+      error: { code: 'VALIDATION_ERROR', message: 'Email and password are required' },
+    });
     const res = await request(app()).post('/api/auth/login').send({});
     expect(res.status).toBe(400);
   });
 
   it('POST /login 401 on invalid credentials', async () => {
-    (UserService.prototype.validatePassword as jest.Mock) = jest.fn().mockResolvedValue(null);
+    (AuthService.prototype.login as jest.Mock) = jest.fn().mockResolvedValue({
+      success: false,
+      error: { code: 'LOGIN_FAILED', message: 'Invalid email or password' },
+    });
     const res = await request(app()).post('/api/auth/login').send({
       email: 'x@y.com',
       password: 'bad',
@@ -1824,12 +1833,12 @@ describe('auth router (extended)', () => {
   });
 
   it('POST /login 200 on valid credentials', async () => {
-    (UserService.prototype.validatePassword as jest.Mock) = jest.fn().mockResolvedValue({
-      id: 1,
-      email: 'a@x',
-      firstName: 'A',
-      lastName: 'B',
-      role: 'admin',
+    (AuthService.prototype.login as jest.Mock) = jest.fn().mockResolvedValue({
+      success: true,
+      data: {
+        token: 'token',
+        user: { id: 1, email: 'a@x', firstName: 'A', lastName: 'B', role: 'admin' },
+      },
     });
     const res = await request(app()).post('/api/auth/login').send({
       email: 'a@x',
@@ -1840,7 +1849,10 @@ describe('auth router (extended)', () => {
   });
 
   it('POST /login 401 on service throw', async () => {
-    (UserService.prototype.validatePassword as jest.Mock) = jest.fn().mockRejectedValue(new Error('x'));
+    (AuthService.prototype.login as jest.Mock) = jest.fn().mockResolvedValue({
+      success: false,
+      error: { code: 'LOGIN_ERROR', message: 'x' },
+    });
     const res = await request(app()).post('/api/auth/login').send({
       email: 'a@x',
       password: 'pw',

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -15,7 +15,7 @@
 
 import { Router, Request, Response } from 'express';
 import { Pool } from 'mysql2/promise';
-import { UserService } from '../services/UserService';
+import { AuthService } from '../services/AuthService';
 import { authenticate } from '../middleware/auth';
 import jwt from 'jsonwebtoken';
 import { config } from '../config';
@@ -23,7 +23,7 @@ import { UserWithSecrets } from '../types';
 
 export const createAuthRouter = (pool: Pool) => {
   const router = Router();
-  const userService = new UserService(pool);
+  const authService = new AuthService(pool);
 
 /**
  * User login endpoint.
@@ -50,59 +50,24 @@ export const createAuthRouter = (pool: Pool) => {
  */
 router.post('/login', async (req: Request, res: Response) => {
   try {
-    const { email, password } = req.body;
+    const { email, password } = req.body ?? {};
+    const result = await authService.login({ email, password });
 
-    // Input validation
-    if (!email || !password) {
-      return res.status(400).json({
-        success: false,
-        error: {
-          code: 'VALIDATION_ERROR',
-          message: 'Email and password are required'
-        }
-      });
+    if (!result.success) {
+      const code = result.error?.code ?? 'LOGIN_FAILED';
+      const status =
+        code === 'VALIDATION_ERROR' ? 400 : code === 'ACCOUNT_INACTIVE' ? 403 : 401;
+      return res.status(status).json(result);
     }
 
-    // Authenticate user and generate token
-    const user = await userService.validatePassword(email, password);
-    
-    if (!user) {
-      return res.status(401).json({
-        success: false,
-        error: {
-          code: 'LOGIN_FAILED',
-          message: 'Invalid email or password'
-        }
-      });
-    }
-
-    // Generate JWT token
-    const token = jwt.sign(
-      { userId: user.id, email: user.email, role: user.role },
-      config.jwt.secret,
-      { expiresIn: config.jwt.expiresIn as jwt.SignOptions['expiresIn'] }
-    );
-    
-    res.json({
-      success: true,
-      data: { 
-        token,
-        user: {
-          id: user.id,
-          email: user.email,
-          firstName: user.firstName,
-          lastName: user.lastName,
-          role: user.role
-        }
-      }
-    });
+    return res.json(result);
   } catch (error) {
-    res.status(401).json({
+    return res.status(401).json({
       success: false,
       error: {
         code: 'LOGIN_FAILED',
-        message: (error as Error).message
-      }
+        message: (error as Error).message,
+      },
     });
   }
 });

--- a/backend/src/services/AuthService.ts
+++ b/backend/src/services/AuthService.ts
@@ -113,7 +113,7 @@ export class AuthService {
         },
         config.jwt.secret,
         {
-          expiresIn: '7d'
+          expiresIn: config.jwt.expiresIn as jwt.SignOptions['expiresIn']
         }
       );
 
@@ -256,7 +256,7 @@ export class AuthService {
         },
         config.jwt.secret,
         {
-          expiresIn: '7d'
+          expiresIn: config.jwt.expiresIn as jwt.SignOptions['expiresIn']
         }
       );
 

--- a/backend/src/types/express.d.ts
+++ b/backend/src/types/express.d.ts
@@ -6,15 +6,11 @@
  * `Request.user` or `Request.tenantId` in route or middleware files.
  */
 
-import { User } from './index';
+import type { User } from './index';
 
-declare global {
-  namespace Express {
-    interface Request {
-      user?: User;
-      tenantId?: number;
-    }
+declare module 'express-serve-static-core' {
+  interface Request {
+    user?: User;
+    tenantId?: number;
   }
 }
-
-export {};

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -20,6 +20,6 @@
     "emitDecoratorMetadata": true,
     "moduleResolution": "node"
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "src/**/*.d.ts"],
   "exclude": ["node_modules", "dist", "**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary

- Route `POST /api/auth/login` through `AuthService.login` instead of `UserService.validatePassword`
- Normalize JWT TTL handling in AuthService using `config.jwt.expiresIn`
- Update route test suites to mock `AuthService` for login paths

## Test plan

- [x] `cd backend && npm run build`
- [x] `cd backend && npm run lint`
- [x] `cd backend && npm run deadcode`
- [x] `cd backend && npm test` — 1081 tests pass

Closes #48

Made with [Cursor](https://cursor.com)