### PR TITLE
feat(backend/auth): password reset HTTP flow

### DIFF
--- a/backend/database/init.sql
+++ b/backend/database/init.sql
@@ -51,6 +51,25 @@ CREATE TABLE IF NOT EXISTS users (
 );
 
 -- ================================================================
+-- PASSWORD RESET TOKENS - One-time tokens for account recovery
+-- ================================================================
+CREATE TABLE IF NOT EXISTS password_reset_tokens (
+    id INT PRIMARY KEY AUTO_INCREMENT,
+    user_id INT NOT NULL,
+    token_hash CHAR(64) NOT NULL,
+    expires_at TIMESTAMP NOT NULL,
+    used_at TIMESTAMP NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+
+    UNIQUE KEY uniq_token_hash (token_hash),
+    INDEX idx_user (user_id),
+    INDEX idx_expires (expires_at),
+    INDEX idx_used (used_at),
+
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+-- ================================================================
 -- DEPARTMENTS TABLE - Organizational structure
 -- ================================================================
 CREATE TABLE IF NOT EXISTS departments (

--- a/backend/src/__tests__/auth.route.extended.test.ts
+++ b/backend/src/__tests__/auth.route.extended.test.ts
@@ -122,3 +122,46 @@ describe('POST /api/auth/login — service surfaces an error', () => {
   });
 });
 
+describe('POST /api/auth/forgot-password', () => {
+  it('returns 400 when email is missing', async () => {
+    const res = await request(buildApp()).post('/api/auth/forgot-password').send({});
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns success without enumerating users', async () => {
+    (AuthService.prototype.initiatePasswordReset as jest.Mock) = jest.fn().mockResolvedValue(null);
+    const res = await request(buildApp())
+      .post('/api/auth/forgot-password')
+      .send({ email: 'unknown@example.com' });
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+});
+
+describe('POST /api/auth/reset-password', () => {
+  it('returns 400 when inputs are missing', async () => {
+    const res = await request(buildApp()).post('/api/auth/reset-password').send({});
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns 400 when reset token is invalid', async () => {
+    (AuthService.prototype.completePasswordReset as jest.Mock) = jest.fn().mockResolvedValue(false);
+    const res = await request(buildApp())
+      .post('/api/auth/reset-password')
+      .send({ resetToken: 'bad', newPassword: 'new' });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('RESET_FAILED');
+  });
+
+  it('returns 200 when reset succeeds', async () => {
+    (AuthService.prototype.completePasswordReset as jest.Mock) = jest.fn().mockResolvedValue(true);
+    const res = await request(buildApp())
+      .post('/api/auth/reset-password')
+      .send({ resetToken: 'ok', newPassword: 'new' });
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+});
+

--- a/backend/src/__tests__/auth.service.extended.test.ts
+++ b/backend/src/__tests__/auth.service.extended.test.ts
@@ -198,10 +198,12 @@ describe('AuthService.initiatePasswordReset / completePasswordReset', () => {
 
   it('initiate returns reset token for known user', async () => {
     const { pool, conn } = makePool();
-    conn.execute.mockResolvedValueOnce([[{ id: 1 }], null]);
+    conn.execute
+      .mockResolvedValueOnce([[{ id: 1 }], null]) // lookup user
+      .mockResolvedValueOnce([{ affectedRows: 1 }, null]); // insert token
     const svc = new AuthService(pool);
     const t = await svc.initiatePasswordReset('a@b');
-    expect(t).toMatch(/^[\w-]+\.[\w-]+\.[\w-]+$/);
+    expect(t).toMatch(/^[A-Za-z0-9_-]{40,}$/);
   });
 
   it('initiate returns null and rolls back on DB error', async () => {
@@ -218,19 +220,14 @@ describe('AuthService.initiatePasswordReset / completePasswordReset', () => {
     expect(await svc.completePasswordReset('garbage', 'np')).toBe(false);
   });
 
-  it('complete returns false for token of wrong purpose', async () => {
-    const { pool } = makePool();
-    const svc = new AuthService(pool);
-    const t = sign({ userId: 1, purpose: 'login' });
-    expect(await svc.completePasswordReset(t, 'np')).toBe(false);
-  });
-
   it('complete updates password and commits', async () => {
     const { pool, conn } = makePool();
-    conn.execute.mockResolvedValueOnce([{ affectedRows: 1 }, null]);
+    conn.execute
+      .mockResolvedValueOnce([[{ id: 9, user_id: 1 }], null]) // token lookup
+      .mockResolvedValueOnce([{ affectedRows: 1 }, null]) // update user pw
+      .mockResolvedValueOnce([{ affectedRows: 1 }, null]); // mark token used
     const svc = new AuthService(pool);
-    const t = sign({ userId: 1, purpose: 'password_reset' });
-    expect(await svc.completePasswordReset(t, 'np')).toBe(true);
+    expect(await svc.completePasswordReset('valid-token', 'np')).toBe(true);
     expect(conn.commit).toHaveBeenCalled();
   });
 });

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -18,12 +18,19 @@ import { Pool } from 'mysql2/promise';
 import { AuthService } from '../services/AuthService';
 import { authenticate } from '../middleware/auth';
 import jwt from 'jsonwebtoken';
+import rateLimit from 'express-rate-limit';
 import { config } from '../config';
 import { UserWithSecrets } from '../types';
 
 export const createAuthRouter = (pool: Pool) => {
   const router = Router();
   const authService = new AuthService(pool);
+
+  const passwordResetLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000,
+    max: 10,
+    message: 'Too many password reset attempts, please try again later.',
+  });
 
 /**
  * User login endpoint.
@@ -70,6 +77,60 @@ router.post('/login', async (req: Request, res: Response) => {
       },
     });
   }
+});
+
+/**
+ * Initiate password reset.
+ *
+ * Always returns success to avoid email enumeration. In non-production
+ * environments, the reset token is returned in `data.resetToken` to support
+ * local development and tests (no email service is wired).
+ *
+ * @route POST /api/auth/forgot-password
+ */
+router.post('/forgot-password', passwordResetLimiter, async (req: Request, res: Response) => {
+  const { email } = req.body ?? {};
+  if (!email) {
+    return res.status(400).json({
+      success: false,
+      error: { code: 'VALIDATION_ERROR', message: 'Email is required' },
+    });
+  }
+
+  const token = await authService.initiatePasswordReset(String(email));
+  const payload: any = {
+    success: true,
+    message: 'If the email exists, a reset link has been sent.',
+  };
+  if (config.server.env !== 'production') {
+    payload.data = { resetToken: token };
+  }
+  return res.json(payload);
+});
+
+/**
+ * Complete password reset.
+ *
+ * @route POST /api/auth/reset-password
+ */
+router.post('/reset-password', passwordResetLimiter, async (req: Request, res: Response) => {
+  const { resetToken, newPassword } = req.body ?? {};
+  if (!resetToken || !newPassword) {
+    return res.status(400).json({
+      success: false,
+      error: { code: 'VALIDATION_ERROR', message: 'resetToken and newPassword are required' },
+    });
+  }
+
+  const ok = await authService.completePasswordReset(String(resetToken), String(newPassword));
+  if (!ok) {
+    return res.status(400).json({
+      success: false,
+      error: { code: 'RESET_FAILED', message: 'Invalid or expired reset token' },
+    });
+  }
+
+  return res.json({ success: true, message: 'Password reset successful' });
 });
 
 /**

--- a/backend/src/services/AuthService.ts
+++ b/backend/src/services/AuthService.ts
@@ -10,6 +10,7 @@
 import { Pool, RowDataPacket } from 'mysql2/promise';
 import jwt from 'jsonwebtoken';
 import bcrypt from 'bcrypt';
+import crypto from 'crypto';
 import { User, LoginRequest, LoginResponse } from '../types';
 import { logger } from '../config/logger';
 import { config } from '../config';
@@ -399,15 +400,17 @@ export class AuthService {
 
       const userId = userRows[0].id;
 
-      // Generate reset token
-      const resetToken = jwt.sign(
-        { userId, purpose: 'password_reset' },
-        config.jwt.secret,
-        { expiresIn: '1h' }
+      // Generate a one-time token (store only its hash).
+      const resetToken = crypto.randomBytes(32).toString('base64url');
+      const tokenHash = crypto.createHash('sha256').update(resetToken).digest('hex');
+
+      // 1 hour expiry
+      await connection.execute(
+        `INSERT INTO password_reset_tokens (user_id, token_hash, expires_at)
+         VALUES (?, ?, DATE_ADD(NOW(), INTERVAL 1 HOUR))`,
+        [userId, tokenHash]
       );
 
-      // Store reset token (in a real system, you'd have a password_reset_tokens table)
-      // For now, we just log it
       await connection.commit();
 
       logger.info(`Password reset initiated for user: ${email}`, { userId });
@@ -438,12 +441,27 @@ export class AuthService {
     try {
       await connection.beginTransaction();
 
-      // Verify reset token
-      const decoded: any = jwt.verify(resetToken, config.jwt.secret);
-      
-      if (!decoded || !decoded.userId || decoded.purpose !== 'password_reset') {
+      if (!resetToken || !newPassword) {
         throw new Error('Invalid reset token');
       }
+
+      const tokenHash = crypto.createHash('sha256').update(resetToken).digest('hex');
+
+      const [rows] = await connection.execute<RowDataPacket[]>(
+        `SELECT id, user_id
+           FROM password_reset_tokens
+          WHERE token_hash = ?
+            AND used_at IS NULL
+            AND expires_at > NOW()
+          LIMIT 1`,
+        [tokenHash]
+      );
+
+      if (rows.length === 0) {
+        throw new Error('Invalid reset token');
+      }
+
+      const resetRow = rows[0];
 
       // Hash new password
       const hashedPassword = await bcrypt.hash(newPassword, config.security.bcryptRounds);
@@ -451,12 +469,16 @@ export class AuthService {
       // Update password
       await connection.execute(
         'UPDATE users SET password_hash = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?',
-        [hashedPassword, decoded.userId]
+        [hashedPassword, resetRow.user_id]
       );
+
+      await connection.execute('UPDATE password_reset_tokens SET used_at = NOW() WHERE id = ?', [
+        resetRow.id,
+      ]);
 
       await connection.commit();
 
-      logger.info(`Password reset completed for user: ${decoded.userId}`);
+      logger.info(`Password reset completed for user: ${resetRow.user_id}`);
       return true;
     } catch (error) {
       await connection.rollback();


### PR DESCRIPTION
## Summary

- Add `password_reset_tokens` table (hash-only storage, expiry, one-time use)
- Implement `AuthService.initiatePasswordReset` + `completePasswordReset` against the table
- Add endpoints:
  - `POST /api/auth/forgot-password`
  - `POST /api/auth/reset-password`
- Add route + service test coverage

## Test plan

- [x] `cd backend && npm run build`
- [x] `cd backend && npm test`

Closes #58

Made with [Cursor](https://cursor.com)