### PR TITLE
fix(tenant): make resolveTenant middleware fault-tolerant

### DIFF
--- a/backend/src/__tests__/tenant.middleware.test.ts
+++ b/backend/src/__tests__/tenant.middleware.test.ts
@@ -42,4 +42,20 @@ describe('resolveTenant', () => {
     expect(res.status).toBe(200);
     expect(res.body.tenantId).toBe(7);
   });
+
+  it('forwards DB errors to the Express error handler instead of hanging', async () => {
+    const execute = jest.fn().mockRejectedValueOnce(new Error('connection lost'));
+    const res = await request(buildApp(execute)).get('/probe').set('X-Tenant-Id', '7');
+    expect(res.status).toBe(500);
+  });
+
+  it('calls next with the error on a DB failure', async () => {
+    const execute = jest.fn().mockRejectedValueOnce(new Error('connection lost'));
+    const next = jest.fn();
+    const req = { header: () => '7' } as never;
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as never;
+    await resolveTenant({ execute } as never)(req, res, next);
+    expect(next).toHaveBeenCalledWith(expect.any(Error));
+    expect((next.mock.calls[0][0] as Error).message).toBe('connection lost');
+  });
 });

--- a/backend/src/middleware/tenant.ts
+++ b/backend/src/middleware/tenant.ts
@@ -14,6 +14,7 @@
 
 import { NextFunction, Request, Response } from 'express';
 import { Pool, RowDataPacket } from 'mysql2/promise';
+import { logger } from '../config/logger';
 
 declare module 'express-serve-static-core' {
   interface Request {
@@ -38,18 +39,23 @@ export const resolveTenant = (pool: Pool) => {
       });
       return;
     }
-    const [rows] = await pool.execute<RowDataPacket[]>(
-      `SELECT id FROM tenants WHERE id = ? AND is_active = 1 LIMIT 1`,
-      [tenantId]
-    );
-    if (rows.length === 0) {
-      res.status(404).json({
-        success: false,
-        error: { code: 'TENANT_NOT_FOUND', message: 'Unknown or inactive tenant' },
-      });
-      return;
+    try {
+      const [rows] = await pool.execute<RowDataPacket[]>(
+        `SELECT id FROM tenants WHERE id = ? AND is_active = 1 LIMIT 1`,
+        [tenantId]
+      );
+      if (rows.length === 0) {
+        res.status(404).json({
+          success: false,
+          error: { code: 'TENANT_NOT_FOUND', message: 'Unknown or inactive tenant' },
+        });
+        return;
+      }
+      req.tenantId = tenantId;
+      next();
+    } catch (err) {
+      logger.error('Tenant lookup failed', { tenantId, error: err });
+      next(err);
     }
-    req.tenantId = tenantId;
-    next();
   };
 };


### PR DESCRIPTION
## Problem

`resolveTenant` awaited `pool.execute(...)` with no error handling. If the DB query threw, the async middleware rejected and the error was never passed to Express, causing an unhandled promise rejection and a hung request.

## Change

- Wrap the tenant lookup in try/catch. On failure, forward the error via `next(err)` so the central Express error handler responds.
- Log the failure through the Winston `logger`.
- Preserve all existing behavior: default tenant fallback, invalid header 400 (`INVALID_TENANT`), unknown/inactive tenant 404 (`TENANT_NOT_FOUND`), and success path.

## Tests

Added two cases to `tenant.middleware.test.ts`:
- DB rejection is forwarded to the Express error handler (500 instead of a hang).
- `next` is invoked with the original error.

Full suite green (6/6). Backend builds clean.