### PR TITLE
fix(auth): reduce PII in authentication middleware logging

### DIFF
--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -85,11 +85,10 @@ export const authenticate = async (req: Request, res: Response, next: NextFuncti
     // Attach user to request object
     req.user = user;
 
-    // Log authentication success
-    logger.info(`User authenticated: ${user.email}`, { 
-      userId: user.id, 
-      role: user.role,
-      endpoint: req.path 
+    // Log authentication success at debug level without PII (no email/path)
+    logger.debug('User authenticated', {
+      userId: user.id,
+      role: user.role
     });
 
     next();


### PR DESCRIPTION
## Summary

The `authenticate` middleware logged the user's email, id, role and request path at `info` level on **every** authenticated request. This exposes PII and produces high log volume on a hot path.

## Change

- Downgrade the per-request success log from `logger.info` to `logger.debug`.
- Drop the email and request path; log only `userId` and `role`.
- Failure/error logging (`warn`/`error`) is unchanged.
- No change to authentication behavior or the response envelope.

## Testing

- `npm run build` passes.
- Full backend suite green: 1078 tests, 69 suites passed.