### PR TITLE
Fix privilege escalation in user routes

### DIFF
--- a/backend/src/__tests__/routes.users.test.ts
+++ b/backend/src/__tests__/routes.users.test.ts
@@ -130,6 +130,39 @@ describe('users router POST /', () => {
     expect(res.body.data.id).toBe(11);
   });
 
+  it('returns 403 when a manager tries to create an admin', async () => {
+    currentUser = { id: 9, role: 'manager', email: 'm@x' };
+    const create = jest.fn().mockResolvedValue({ id: 11 });
+    (UserService.prototype.createUser as jest.Mock) = create;
+    const res = await request(mountApp())
+      .post('/api/users')
+      .send({
+        email: 'a@x.com',
+        password: 'pw1234',
+        firstName: 'A',
+        lastName: 'B',
+        role: 'admin',
+      });
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe('FORBIDDEN');
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('allows an admin to create an admin', async () => {
+    (UserService.prototype.createUser as jest.Mock) = jest.fn().mockResolvedValue({ id: 12 });
+    const res = await request(mountApp())
+      .post('/api/users')
+      .send({
+        email: 'a@x.com',
+        password: 'pw1234',
+        firstName: 'A',
+        lastName: 'B',
+        role: 'admin',
+      });
+    expect(res.status).toBe(201);
+    expect(res.body.data.id).toBe(12);
+  });
+
   it('returns 409 on duplicate', async () => {
     const dup: any = new Error('dup');
     dup.code = 'ER_DUP_ENTRY';
@@ -209,6 +242,32 @@ describe('users router PUT /:id', () => {
     currentUser = { id: 5, role: 'employee', email: 'e@x' };
     const res = await request(mountApp()).put('/api/users/5').send({ role: 'admin' });
     expect(res.status).toBe(403);
+  });
+
+  it('returns 403 when a manager tries to change a role', async () => {
+    currentUser = { id: 9, role: 'manager', email: 'm@x' };
+    const update = jest.fn().mockResolvedValue({ id: 3 });
+    (UserService.prototype.updateUser as jest.Mock) = update;
+    const res = await request(mountApp()).put('/api/users/3').send({ role: 'admin' });
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe('FORBIDDEN');
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when a user tries to promote themselves', async () => {
+    const update = jest.fn().mockResolvedValue({ id: 1 });
+    (UserService.prototype.updateUser as jest.Mock) = update;
+    const res = await request(mountApp()).put('/api/users/1').send({ role: 'admin' });
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe('FORBIDDEN');
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('allows an admin to change another user role', async () => {
+    (UserService.prototype.updateUser as jest.Mock) = jest.fn().mockResolvedValue({ id: 9 });
+    const res = await request(mountApp()).put('/api/users/9').send({ role: 'manager' });
+    expect(res.status).toBe(200);
+    expect(res.body.data.id).toBe(9);
   });
 
   it('returns 404 when service returns null', async () => {

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -77,6 +77,15 @@ export const createUsersRouter = (pool: Pool) => {
         });
       }
 
+      // Only admins may create admin accounts. A manager must not be able to
+      // escalate privileges by creating an admin user.
+      if (userData.role === 'admin' && user.role !== 'admin') {
+        return res.status(403).json({
+          success: false,
+          error: { code: 'FORBIDDEN', message: 'Only admins can create admin users' }
+        });
+      }
+
       const createdUser = await userService.createUser(userData);
 
       res.status(201).json({ success: true, data: createdUser });
@@ -167,6 +176,24 @@ export const createUsersRouter = (pool: Pool) => {
           return res.status(403).json({
             success: false,
             error: { code: 'FORBIDDEN', message: `Employees cannot update: ${invalidFields.join(', ')}` }
+          });
+        }
+      }
+
+      // Role changes are restricted to admins, and no one may change their own
+      // role. This prevents privilege escalation and self-promotion.
+      if (updateData.role !== undefined) {
+        if (user.role !== 'admin') {
+          return res.status(403).json({
+            success: false,
+            error: { code: 'FORBIDDEN', message: 'Only admins can change user roles' }
+          });
+        }
+
+        if (user.id === userId) {
+          return res.status(403).json({
+            success: false,
+            error: { code: 'FORBIDDEN', message: 'You cannot change your own role' }
           });
         }
       }


### PR DESCRIPTION
## Summary
Closes a privilege-escalation gap in the user management endpoints.

### POST /api/users
Previously any admin/manager could create a user with any role. A manager could therefore mint an admin account. Now a non-admin attempting to create a user with `role: 'admin'` receives `403 FORBIDDEN`. Only admins may create admins.

### PUT /api/users/:id
Previously any non-employee could update any field, including `role`, allowing managers to promote users and any user to self-promote. Now:
- Role changes are restricted to admins (non-admins get `403 FORBIDDEN`).
- No user may change their own role (self-promotion blocked with `403 FORBIDDEN`).
- Existing employee field restrictions are preserved.

All responses use the standard `{ success: false, error: { code, message } }` envelope.

## Tests
Extended `routes.users.test.ts` with cases for: manager creating an admin (403), manager changing a role (403), admin changing a role (allowed), and self-promotion attempt (403). Full backend suite passes (1083 tests).