### PR TITLE
fix: register 404 catch-all before error handler in buildApp

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -119,6 +119,13 @@ export function buildApp(pool: Pool, options: BuildAppOptions = {}): express.Exp
   app.use('/api/org', createOrgRouter(pool));
   app.use('/api/policies', createPoliciesRouter(pool));
 
+  app.use('*', (_req: express.Request, res: express.Response) => {
+    res.status(404).json({
+      success: false,
+      error: { code: 'NOT_FOUND', message: 'Endpoint not found' },
+    });
+  });
+
   app.use(
     (err: any, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
       logger.error('Unhandled error:', err);
@@ -132,13 +139,6 @@ export function buildApp(pool: Pool, options: BuildAppOptions = {}): express.Exp
       });
     }
   );
-
-  app.use('*', (_req: express.Request, res: express.Response) => {
-    res.status(404).json({
-      success: false,
-      error: { code: 'NOT_FOUND', message: 'Endpoint not found' },
-    });
-  });
 
   return app;
 }


### PR DESCRIPTION
## Summary

Fixes Express middleware ordering in `backend/src/app.ts`. The 4-arg error-handling middleware was registered *before* the wildcard `app.use('*', ...)` 404 catch-all.

This reorders them to the conventional Express sequence:

routes → 404 catch-all → error handler

The error handler is now the last `app.use`, so it catches errors from all prior middleware (including the 404 handler).

## Changes

- Move the `*` 404 catch-all above the error-handling middleware.
- Error handler is now registered last.

Handler bodies, status codes, and the `{ success, error: { code, message } }` response envelopes are unchanged. The `silent` option behavior is unaffected.

## Testing

- `npm run build` clean.
- Full backend suite green: 69 suites, 1078 tests passing (including `app.test.ts` and `app.extended.test.ts` which assert 404 and error responses via supertest).