### PR TITLE
perf(frontend): memoize AuthContext value and stabilize callbacks

### DIFF
--- a/frontend/src/contexts/AuthContext.test.tsx
+++ b/frontend/src/contexts/AuthContext.test.tsx
@@ -149,6 +149,20 @@ describe('AuthProvider actions', () => {
     expect(localStorage.getItem('token')).toBe('new');
   });
 
+  it('keeps callback identities stable across renders', async () => {
+    const { result, rerender } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    const first = {
+      login: result.current.login,
+      logout: result.current.logout,
+      refreshToken: result.current.refreshToken,
+    };
+    rerender();
+    expect(result.current.login).toBe(first.login);
+    expect(result.current.logout).toBe(first.logout);
+    expect(result.current.refreshToken).toBe(first.refreshToken);
+  });
+
   it('refreshToken failure logs out', async () => {
     localStorage.setItem('token', 'old');
     mockedAuthService.verifyToken.mockResolvedValue({

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -20,7 +20,7 @@
  * @author Luca Ostinelli
  */
 
-import React, { createContext, useContext, useReducer, useEffect, ReactNode } from 'react';
+import React, { createContext, useContext, useReducer, useEffect, useCallback, useMemo, ReactNode } from 'react';
 import { User, LoginRequest, LoginResponse, ApiResponse } from '../types';
 import * as authService from '../services/authService';
 
@@ -174,12 +174,12 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     initializeAuth();
   }, []);
 
-  const login = async (credentials: LoginRequest): Promise<void> => {
+  const login = useCallback(async (credentials: LoginRequest): Promise<void> => {
     dispatch({ type: 'LOGIN_START' });
-    
+
     try {
       const response: ApiResponse<LoginResponse> = await authService.login(credentials);
-      
+
       if (response.success && response.data) {
         const { user, token } = response.data;
         localStorage.setItem('token', token);
@@ -194,14 +194,14 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       dispatch({ type: 'LOGIN_FAILURE', payload: error instanceof Error ? error.message : 'Login failed' });
       throw error;
     }
-  };
+  }, []);
 
-  const logout = (): void => {
+  const logout = useCallback((): void => {
     localStorage.removeItem('token');
     dispatch({ type: 'LOGOUT' });
-  };
+  }, []);
 
-  const refreshToken = async (): Promise<void> => {
+  const refreshToken = useCallback(async (): Promise<void> => {
     const token = localStorage.getItem('token');
     if (!token) {
       logout();
@@ -222,14 +222,17 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     } catch (error) {
       logout();
     }
-  };
+  }, [logout]);
 
-  const value: AuthContextType = {
-    ...state,
-    login,
-    logout,
-    refreshToken,
-  };
+  const value: AuthContextType = useMemo(
+    () => ({
+      ...state,
+      login,
+      logout,
+      refreshToken,
+    }),
+    [state, login, logout, refreshToken]
+  );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 };


### PR DESCRIPTION
## Summary

`AuthProvider` previously rebuilt the context `value` object inline on every render, so every consumer re-rendered whenever the provider re-rendered.

This change:
- Wraps `login`, `logout`, and `refreshToken` in `useCallback` with correct dependency arrays so their identities are stable (`refreshToken` depends on `logout`; the others have no reactive dependencies, relying on the stable `dispatch`).
- Wraps the context `value` in `useMemo` keyed on the state and the three callbacks, so it only changes when auth state actually changes.

Behavior is identical; only referential stability improves. The public `AuthContextType` API and all exported symbols are unchanged.

## Testing
- Added a test asserting callback identities stay stable across renders.
- `CI=true npm test -- AuthContext`: 12/12 passing.