### PR TITLE
Protect system info endpoint with admin authentication

### DIFF
--- a/backend/src/__tests__/system.route.test.ts
+++ b/backend/src/__tests__/system.route.test.ts
@@ -1,15 +1,33 @@
 /**
  * Integration test for the /api/system/info route.
  *
- * Mounts the router on a tiny Express app and exercises both the demo and
- * production paths plus the failure fallback.
+ * The endpoint is administrative: it runs the real `authenticate` and
+ * `requireAdmin` middleware. Tests sign a valid JWT and mock the UserService
+ * so the middleware resolves an active admin user, then exercise both the
+ * demo and production paths plus the failure fallback. A dedicated test
+ * asserts that an unauthenticated request is rejected with 401.
  */
 
 import express from 'express';
 import request from 'supertest';
+import jwt from 'jsonwebtoken';
 import { createSystemRouter } from '../routes/system';
+import { config } from '../config';
+import { UserService } from '../services/UserService';
+import { database } from '../config/database';
+
+jest.mock('../services/UserService');
+jest.mock('../config/database', () => ({
+  database: { getPool: jest.fn().mockReturnValue({}) },
+}));
 
 type ExecuteResult = [unknown[], unknown];
+
+const adminToken = jwt.sign(
+  { userId: '1', email: 'admin@example', role: 'admin' },
+  config.jwt.secret,
+  { expiresIn: '1h' }
+);
 
 const buildApp = (executeImpl: jest.Mock): express.Express => {
   const fakePool = { execute: executeImpl } as unknown as Parameters<typeof createSystemRouter>[0];
@@ -18,13 +36,40 @@ const buildApp = (executeImpl: jest.Mock): express.Express => {
   return app;
 };
 
+const mockActiveAdmin = (): void => {
+  (UserService.prototype.getUserById as jest.Mock) = jest
+    .fn()
+    .mockResolvedValue({ id: 1, email: 'admin@example', role: 'admin', isActive: true });
+};
+
 describe('GET /api/system/info', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (database.getPool as jest.Mock).mockReturnValue({});
+    mockActiveAdmin();
+  });
+
+  it('rejects an unauthenticated request with 401', async () => {
+    const execute = jest.fn<Promise<ExecuteResult>, [string, unknown[]?]>();
+    const app = buildApp(execute);
+
+    const res = await request(app).get('/api/system/info');
+
+    expect(res.status).toBe(401);
+    expect(res.body.success).toBe(false);
+    expect(res.body.error.code).toBe('MISSING_TOKEN');
+    // The query must never run for an unauthenticated caller.
+    expect(execute).not.toHaveBeenCalled();
+  });
+
   it('reports mode=demo when system_settings has the demo row', async () => {
     const execute = jest.fn<Promise<ExecuteResult>, [string, unknown[]?]>();
     execute.mockResolvedValueOnce([[{ value: 'demo' }], null]);
     const app = buildApp(execute);
 
-    const res = await request(app).get('/api/system/info');
+    const res = await request(app)
+      .get('/api/system/info')
+      .set('Authorization', `Bearer ${adminToken}`);
 
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ success: true, data: { mode: 'demo' } });
@@ -35,7 +80,9 @@ describe('GET /api/system/info', () => {
     execute.mockResolvedValueOnce([[], null]);
     const app = buildApp(execute);
 
-    const res = await request(app).get('/api/system/info');
+    const res = await request(app)
+      .get('/api/system/info')
+      .set('Authorization', `Bearer ${adminToken}`);
 
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ success: true, data: { mode: 'production' } });
@@ -46,9 +93,11 @@ describe('GET /api/system/info', () => {
     execute.mockRejectedValueOnce(new Error('DB down'));
     const app = buildApp(execute);
 
-    const res = await request(app).get('/api/system/info');
+    const res = await request(app)
+      .get('/api/system/info')
+      .set('Authorization', `Bearer ${adminToken}`);
 
-    // The endpoint must never 500 — it's polled at app boot.
+    // The endpoint must never 500 — it falls back to production mode.
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ success: true, data: { mode: 'production' } });
   });

--- a/backend/src/routes/system.ts
+++ b/backend/src/routes/system.ts
@@ -1,8 +1,9 @@
 /**
  * System info route.
  *
- * Public endpoint (no authentication) returning runtime metadata that the
- * frontend uses to decide chrome-level UI choices, e.g. the demo banner.
+ * Administrative endpoint returning runtime metadata. Access requires an
+ * authenticated admin user, since system/version information should not be
+ * disclosed anonymously.
  *
  * The only field reported today is `mode`, sourced from
  * `system_settings(category='runtime', key='mode')`. Defaults to
@@ -14,13 +15,14 @@
 import { Pool, RowDataPacket } from 'mysql2/promise';
 import { Router } from 'express';
 import { logger } from '../config/logger';
+import { authenticate, requireAdmin } from '../middleware/auth';
 
 type RuntimeMode = 'production' | 'demo' | 'development';
 
 export const createSystemRouter = (pool: Pool): Router => {
   const router = Router();
 
-  router.get('/info', async (_req, res) => {
+  router.get('/info', authenticate, requireAdmin, async (_req, res) => {
     try {
       const [rows] = await pool.execute<RowDataPacket[]>(
         `SELECT value FROM system_settings WHERE category = 'runtime' AND \`key\` = 'mode' LIMIT 1`


### PR DESCRIPTION
## Summary

`GET /api/system/info` was an anonymous endpoint that could disclose runtime/system metadata to unauthenticated callers. This change gates it behind authentication and admin authorization.

## Changes

- Add `authenticate` and `requireAdmin` middleware to `GET /api/system/info` (`backend/src/routes/system.ts`). The response shape is unchanged for authorized admin callers.
- Update the route comment to reflect that the endpoint is now administrative.
- Update `backend/src/__tests__/system.route.test.ts`:
  - Sign a valid admin JWT and mock `UserService`/`database` so the real middleware resolves an active admin for the demo, production, and DB-failure paths.
  - Add a test asserting an unauthenticated request returns `401` (`MISSING_TOKEN`) and never runs the underlying query.

## Testing

- `npm run build` clean.
- Full backend suite green: 69 suites, 1079 tests passing.

## Note

The system info endpoint is now admin-only; any anonymous frontend caller (e.g. a boot-time poll for the demo banner) will need to send an authenticated admin request or be adjusted separately. That frontend change is outside the scope of this PR.