### PR TITLE
fix(optimizer): add timeout and kill to Python optimizer spawn

### DIFF
--- a/backend/src/__tests__/scheduleOptimizer.test.ts
+++ b/backend/src/__tests__/scheduleOptimizer.test.ts
@@ -6,7 +6,33 @@
  * _timesOverlap, _calculateShiftHours) via the public surface.
  */
 
+import { EventEmitter } from 'events';
+import { spawn } from 'child_process';
+import { config } from '../config';
 import { ScheduleOptimizer, OptimizationProblem } from '../optimization/ScheduleOptimizerORTools';
+
+jest.mock('child_process', () => ({
+  spawn: jest.fn(),
+}));
+
+const mockedSpawn = spawn as unknown as jest.Mock;
+
+/**
+ * Build a fake child process that accepts stdin and emits stdout/stderr,
+ * but never fires 'close' or 'error' — simulating a hanging Python optimizer.
+ */
+const buildHangingProcess = (): any => {
+  const proc = new EventEmitter() as any;
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.stdin = { write: jest.fn(), end: jest.fn() };
+  proc.killed = false;
+  proc.kill = jest.fn(() => {
+    proc.killed = true;
+    return true;
+  });
+  return proc;
+};
 
 const buildProblem = (overrides: Partial<OptimizationProblem> = {}): OptimizationProblem => ({
   shifts: [],
@@ -128,5 +154,37 @@ describe('ScheduleOptimizer.optimize falls back to greedy when Python is unavail
       })
     );
     expect(result).toHaveLength(1);
+  });
+});
+
+describe('ScheduleOptimizer._callPythonOptimizer timeout', () => {
+  const originalTimeout = config.optimization.timeout;
+
+  beforeEach(() => {
+    mockedSpawn.mockReset();
+  });
+
+  afterEach(() => {
+    config.optimization.timeout = originalTimeout;
+  });
+
+  it('kills the process and rejects when the optimizer never settles', async () => {
+    // Use a small timeout so the test is fast.
+    config.optimization.timeout = 50;
+
+    const proc = buildHangingProcess();
+    mockedSpawn.mockReturnValue(proc);
+
+    const opt = new ScheduleOptimizer();
+    const problem = buildProblem({
+      shifts: [buildShift({ id: 's1', min_staff: 1 })],
+      employees: [buildEmployee({ id: 'e1' })],
+    });
+
+    // Access the private method via the public-ish surface.
+    const promise = (opt as any)._callPythonOptimizer(problem, 300);
+
+    await expect(promise).rejects.toThrow(/timed out after 50ms/);
+    expect(proc.kill).toHaveBeenCalledWith('SIGTERM');
   });
 });

--- a/backend/src/optimization/ScheduleOptimizerORTools.ts
+++ b/backend/src/optimization/ScheduleOptimizerORTools.ts
@@ -16,6 +16,7 @@
 
 import { spawn } from 'child_process';
 import { join } from 'path';
+import { config } from '../config';
 import logger from '../config/logger';
 
 interface ScheduleAssignment {
@@ -186,15 +187,50 @@ export class ScheduleOptimizer {
         '--time-limit',
         timeLimitSeconds.toString()
       ]);
-      
+
       let stdoutData = '';
       let stderrData = '';
-      
+      let settled = false;
+      let timeoutHandle: NodeJS.Timeout | undefined;
+
+      // Ensure the Promise settles exactly once and the watchdog timer is
+      // always cleared, so it can never fire after the process has finished.
+      const finalize = (action: () => void): void => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        if (timeoutHandle) {
+          clearTimeout(timeoutHandle);
+          timeoutHandle = undefined;
+        }
+        action();
+      };
+
+      // Watchdog: kill the process and reject if it never settles, so a
+      // hanging Python optimizer cannot leak the child process forever.
+      const timeoutMs = config.optimization.timeout;
+      timeoutHandle = setTimeout(() => {
+        if (settled) {
+          return;
+        }
+        logger.error(`Python optimizer timed out after ${timeoutMs}ms; killing process`);
+        // Request graceful termination, then force-kill if it ignores SIGTERM.
+        pythonProcess.kill('SIGTERM');
+        setTimeout(() => {
+          if (!pythonProcess.killed) {
+            pythonProcess.kill('SIGKILL');
+          }
+        }, 5000).unref?.();
+        finalize(() => reject(new Error(`Python optimizer timed out after ${timeoutMs}ms`)));
+      }, timeoutMs);
+      timeoutHandle.unref?.();
+
       // Collect stdout (JSON result)
       pythonProcess.stdout.on('data', (data) => {
         stdoutData += data.toString();
       });
-      
+
       // Collect stderr (logs)
       pythonProcess.stderr.on('data', (data) => {
         const message = data.toString();
@@ -202,28 +238,30 @@ export class ScheduleOptimizer {
         // Log Python script output
         logger.debug(`[Python Optimizer] ${message.trim()}`);
       });
-      
+
       // Handle process completion
       pythonProcess.on('close', (code) => {
-        if (code === 0 || code === 1) {
-          // Success (0) or infeasible (1)
-          try {
-            const result = JSON.parse(stdoutData);
-            resolve(result);
-          } catch (error) {
-            reject(new Error(`Failed to parse optimizer output: ${error instanceof Error ? error.message : 'Unknown error'}`));
+        finalize(() => {
+          if (code === 0 || code === 1) {
+            // Success (0) or infeasible (1)
+            try {
+              const result = JSON.parse(stdoutData);
+              resolve(result);
+            } catch (error) {
+              reject(new Error(`Failed to parse optimizer output: ${error instanceof Error ? error.message : 'Unknown error'}`));
+            }
+          } else {
+            // Error
+            reject(new Error(`Optimizer failed with code ${code}: ${stderrData}`));
           }
-        } else {
-          // Error
-          reject(new Error(`Optimizer failed with code ${code}: ${stderrData}`));
-        }
+        });
       });
-      
+
       // Handle process errors
       pythonProcess.on('error', (error) => {
-        reject(new Error(`Failed to start Python optimizer: ${error.message}`));
+        finalize(() => reject(new Error(`Failed to start Python optimizer: ${error.message}`)));
       });
-      
+
       // Send problem data to stdin
       pythonProcess.stdin.write(JSON.stringify(problem));
       pythonProcess.stdin.end();


### PR DESCRIPTION
## Summary

`_callPythonOptimizer` in `ScheduleOptimizerORTools.ts` previously returned a Promise that settled only on the child process `close`/`error` events. If the spawned `python3` optimizer hung, the Promise never settled and the child process leaked — even though `config.optimization.timeout` already existed.

## Changes

- After spawning, start a watchdog timer for `config.optimization.timeout` ms.
- On timeout: send `SIGTERM` (with a `SIGKILL` fallback after 5s) and reject with a clear timeout error.
- Clear the timer in both the `close` and `error` handlers via a shared `finalize` helper.
- A `settled` guard ensures the Promise resolves or rejects exactly once.
- Added a test that simulates a process which never closes and asserts the Promise rejects after a small injected timeout and that the process is killed.

## Testing

- `npm run build` clean.
- Full backend suite green: 1079 tests across 69 suites.
- New timeout test passes.