### PR TITLE
Harden auth route: login throttling and config-driven JWT expiry

### DIFF
--- a/backend/src/__tests__/auth.route.extended.test.ts
+++ b/backend/src/__tests__/auth.route.extended.test.ts
@@ -117,3 +117,49 @@ describe('POST /api/auth/login — service throws', () => {
   });
 });
 
+describe('POST /api/auth/login — rate limiting', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+    jest.resetModules();
+  });
+
+  it('eventually returns 429 once the per-IP login threshold is exceeded', async () => {
+    // Force the strict (non-test) limiter by building a router in a module
+    // registry where NODE_ENV is not 'test'. 'development' is used rather than
+    // 'production' to avoid tripping the production secret guard in config.
+    process.env.NODE_ENV = 'development';
+
+    let limitedStatus = 0;
+    let limitedBody: any;
+
+    await jest.isolateModulesAsync(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { UserService: IsolatedUserService } = require('../services/UserService');
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { createAuthRouter: isolatedCreateAuthRouter } = require('../routes/auth');
+
+      (IsolatedUserService.prototype.validatePassword as jest.Mock) = jest.fn().mockResolvedValue(null);
+
+      const app = express();
+      app.use(express.json());
+      app.use('/api/auth', isolatedCreateAuthRouter({} as never));
+
+      // Strict limiter allows 10 attempts per window; the 11th must be blocked.
+      for (let i = 0; i < 10; i += 1) {
+        const res = await request(app).post('/api/auth/login').send({ email: 'a@x.com', password: 'wrong' });
+        expect(res.status).toBe(401);
+      }
+
+      const blocked = await request(app).post('/api/auth/login').send({ email: 'a@x.com', password: 'wrong' });
+      limitedStatus = blocked.status;
+      limitedBody = blocked.body;
+    });
+
+    expect(limitedStatus).toBe(429);
+    expect(limitedBody.success).toBe(false);
+    expect(limitedBody.error.code).toBe('TOO_MANY_REQUESTS');
+  });
+});
+

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -15,9 +15,10 @@
 
 import { Router, Request, Response } from 'express';
 import { Pool } from 'mysql2/promise';
+import rateLimit from 'express-rate-limit';
 import { UserService } from '../services/UserService';
 import { authenticate } from '../middleware/auth';
-import jwt from 'jsonwebtoken';
+import jwt, { SignOptions } from 'jsonwebtoken';
 
 // Extend Express Request to include user
 declare module 'express-serve-static-core' {
@@ -30,6 +31,36 @@ import { config } from '../config';
 export const createAuthRouter = (pool: Pool) => {
   const router = Router();
   const userService = new UserService(pool);
+
+  // Shared JWT signing options, driven by configuration rather than hardcoded.
+  const jwtSignOptions: SignOptions = {
+    expiresIn: config.jwt.expiresIn as SignOptions['expiresIn']
+  };
+
+  /**
+   * Brute-force protection for the login endpoint.
+   *
+   * Limits each client IP to a small number of login attempts per window,
+   * returning the standard error envelope once the threshold is exceeded.
+   * The limiter is intentionally lenient under `NODE_ENV === 'test'` so the
+   * integration suites can call `/login` repeatedly without hitting 429.
+   */
+  const isTestEnv = process.env.NODE_ENV === 'test';
+  const loginLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: isTestEnv ? 1000 : 10,
+    standardHeaders: true,
+    legacyHeaders: false,
+    handler: (_req: Request, res: Response) => {
+      res.status(429).json({
+        success: false,
+        error: {
+          code: 'TOO_MANY_REQUESTS',
+          message: 'Too many login attempts, please try again later.'
+        }
+      });
+    }
+  });
 
 /**
  * User login endpoint.
@@ -54,7 +85,7 @@ export const createAuthRouter = (pool: Pool) => {
  *   }
  * }
  */
-router.post('/login', async (req: Request, res: Response) => {
+router.post('/login', loginLimiter, async (req: Request, res: Response) => {
   try {
     const { email, password } = req.body;
 
@@ -86,7 +117,7 @@ router.post('/login', async (req: Request, res: Response) => {
     const token = jwt.sign(
       { userId: user.id, email: user.email, role: user.role },
       config.jwt.secret,
-      { expiresIn: '7d' }
+      jwtSignOptions
     );
     
     res.json({
@@ -179,7 +210,7 @@ router.post('/refresh', authenticate, async (req: Request, res: Response) => {
     const token = jwt.sign(
       { userId: user.id, email: user.email, role: user.role },
       config.jwt.secret,
-      { expiresIn: '7d' }
+      jwtSignOptions
     );
     
     res.json({


### PR DESCRIPTION
## Summary

Hardens `backend/src/routes/auth.ts`:

- **Login throttling**: adds an `express-rate-limit` limiter scoped to `POST /login` only (10 attempts / 15 min per IP), mitigating credential brute-forcing. On limit it returns the standard error envelope with code `TOO_MANY_REQUESTS`. The limiter is intentionally lenient under `NODE_ENV=test` so the supertest suites are unaffected. This also makes the long-standing "Rate limiting for login attempts" docstring claim accurate.
- **Config-driven JWT expiry**: replaces the hardcoded `'7d'` expiry in both `jwt.sign` calls with `config.jwt.expiresIn` (driven by `JWT_EXPIRES_IN`, default `24h`). The response contract is unchanged.

## Testing

- New test in `auth.route.extended.test.ts` builds the router with the strict limiter (via an isolated module registry) and asserts the 11th attempt returns `429` with the expected envelope.
- Full backend suite green: 1079 passed. Build and lint clean.

## Scope

Touches only `backend/src/routes/auth.ts` and `backend/src/__tests__/auth.route.extended.test.ts`.