### PR TITLE
feat(rbac): replace hardcoded role ENUM with configurable permissions/roles (hard cutover)

### DIFF
--- a/backend/database/init.sql
+++ b/backend/database/init.sql
@@ -31,7 +31,6 @@ CREATE TABLE IF NOT EXISTS users (
     password_hash VARCHAR(255) NOT NULL,
     first_name VARCHAR(100) NOT NULL,
     last_name VARCHAR(100) NOT NULL,
-    role ENUM('admin', 'manager', 'employee') NOT NULL DEFAULT 'employee',
     employee_id VARCHAR(50) UNIQUE,
     position VARCHAR(100),
     hourly_rate DECIMAL(10, 2) DEFAULT 0,
@@ -46,8 +45,73 @@ CREATE TABLE IF NOT EXISTS users (
 
     INDEX idx_email (email),
     INDEX idx_employee_id (employee_id),
-    INDEX idx_role (role),
     INDEX idx_active (is_active)
+);
+
+-- ================================================================
+-- RBAC: Configurable roles and permissions (no hardcoded roles)
+-- ----------------------------------------------------------------
+-- Authorization is permission-based. Application code references only
+-- permission CODES; roles are editable DATA that group permissions, so an
+-- organization can define any role at any level of its hierarchy.
+--   permissions       - the fixed catalog of capability codes the code checks
+--   roles             - configurable named bundles of permissions (data)
+--   role_permissions  - which permissions each role grants (M:N)
+--   user_roles        - role grants to users, optionally scoped to an org_unit
+--                       subtree and optionally time-bound (expires_at)
+-- `roles.is_system` only protects the bootstrap super-admin from deletion;
+-- every other role is fully editable and removable.
+-- ================================================================
+CREATE TABLE IF NOT EXISTS permissions (
+    id INT PRIMARY KEY AUTO_INCREMENT,
+    code VARCHAR(80) NOT NULL UNIQUE,
+    resource VARCHAR(60) NOT NULL,
+    action VARCHAR(40) NOT NULL,
+    description VARCHAR(255) NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+
+    INDEX idx_resource (resource)
+);
+
+CREATE TABLE IF NOT EXISTS roles (
+    id INT PRIMARY KEY AUTO_INCREMENT,
+    name VARCHAR(80) NOT NULL UNIQUE,
+    description VARCHAR(255) NULL,
+    is_system BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+    INDEX idx_system (is_system)
+);
+
+CREATE TABLE IF NOT EXISTS role_permissions (
+    role_id INT NOT NULL,
+    permission_id INT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+
+    PRIMARY KEY (role_id, permission_id),
+    INDEX idx_role (role_id),
+    INDEX idx_permission (permission_id),
+    FOREIGN KEY (role_id) REFERENCES roles(id) ON DELETE CASCADE,
+    FOREIGN KEY (permission_id) REFERENCES permissions(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS user_roles (
+    id INT PRIMARY KEY AUTO_INCREMENT,
+    user_id INT NOT NULL,
+    role_id INT NOT NULL,
+    scope_org_unit_id INT NULL,
+    expires_at TIMESTAMP NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+
+    UNIQUE KEY unique_user_role_scope (user_id, role_id, scope_org_unit_id),
+    INDEX idx_user (user_id),
+    INDEX idx_role (role_id),
+    INDEX idx_scope (scope_org_unit_id),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (role_id) REFERENCES roles(id) ON DELETE CASCADE
+    -- scope_org_unit_id intentionally has no FK: org_units is created later in
+    -- this script and scope integrity is enforced at the application layer.
 );
 
 -- ================================================================
@@ -634,7 +698,7 @@ CREATE TABLE IF NOT EXISTS policy_exception_requests (
 --   - `policy_owner`        - owner of the policy at hand
 --   - `unit_manager`        - manager of the involved org_unit
 --   - `unit_manager_chain`  - escalate up the org tree until a manager is found
---   - `company_role`        - any user with the role stored in `approver_role`
+--   - `company_role`        - any user holding the role stored in `approver_role_id`
 --   - `company_user`        - the specific user stored in `approver_user_id`
 -- The `auto_approve_for_owner` flag controls "if actor is the resolved
 -- approver, auto-approve and write an audit log row".
@@ -649,7 +713,7 @@ CREATE TABLE IF NOT EXISTS approval_matrix (
         'company_role',
         'company_user'
     ) NOT NULL,
-    approver_role ENUM('admin', 'manager', 'employee') NULL,
+    approver_role_id INT NULL,
     approver_user_id INT NULL,
     auto_approve_for_owner BOOLEAN NOT NULL DEFAULT TRUE,
     description TEXT,
@@ -658,6 +722,7 @@ CREATE TABLE IF NOT EXISTS approval_matrix (
 
     UNIQUE KEY unique_change_type (change_type),
 
+    FOREIGN KEY (approver_role_id) REFERENCES roles(id) ON DELETE SET NULL,
     FOREIGN KEY (approver_user_id) REFERENCES users(id) ON DELETE SET NULL
 );
 
@@ -665,6 +730,71 @@ CREATE TABLE IF NOT EXISTS approval_matrix (
 -- DEFAULT DATA INSERTION
 -- Minimal essential data - users and departments will be created by init-database.ts
 -- ================================================================
+
+-- ----------------------------------------------------------------
+-- RBAC catalog: permission codes (referenced by name in application code)
+-- ----------------------------------------------------------------
+INSERT IGNORE INTO permissions (code, resource, action, description) VALUES
+('employee.read',     'employee',  'read',    'View staff / employee records'),
+('employee.manage',   'employee',  'manage',  'Create, update and delete staff records and their skills'),
+('schedule.read',     'schedule',  'read',    'View schedules'),
+('schedule.manage',   'schedule',  'manage',  'Create, update, delete, duplicate and archive schedules'),
+('schedule.publish',  'schedule',  'publish', 'Publish schedules'),
+('schedule.optimize', 'schedule',  'optimize','Run the optimizer / auto-generate schedules'),
+('assignment.manage', 'assignment','manage',  'Create, update and delete shift assignments'),
+('shift.manage',      'shift',     'manage',  'Manage shift templates and shifts'),
+('department.read',   'department','read',    'View departments'),
+('department.manage', 'department','manage',  'Create, update and delete departments'),
+('org_unit.read',     'org_unit',  'read',    'View the organization tree'),
+('org_unit.manage',   'org_unit',  'manage',  'Create, update and delete organization units'),
+('oncall.manage',     'oncall',    'manage',  'Manage on-call periods and assignments'),
+('policy.read',       'policy',    'read',    'View policies'),
+('policy.manage',     'policy',    'manage',  'Create, update and delete policies'),
+('policy.approve',    'policy',    'approve', 'Approve or reject policy exception requests'),
+('approval.manage',   'approval',  'manage',  'Configure the approval matrix / workflows'),
+('loan.request',      'loan',      'request', 'Create employee loan requests'),
+('loan.approve',      'loan',      'approve', 'Approve or reject employee loan requests'),
+('timeoff.approve',   'timeoff',   'approve', 'Approve or reject time-off requests'),
+('shiftswap.approve', 'shiftswap', 'approve', 'Approve or decline shift-swap requests'),
+('preferences.manage','preferences','manage', 'View and edit other users'' preferences'),
+('report.read',       'report',    'read',    'View reports and analytics'),
+('audit.read',        'audit',     'read',    'View audit logs'),
+('user.read',         'user',      'read',    'View user accounts and the directory'),
+('user.manage',       'user',      'manage',  'Create, update and delete user accounts and assign roles'),
+('settings.manage',   'settings',  'manage',  'Edit system settings'),
+('role.manage',       'role',      'manage',  'Create roles and assign permissions to them');
+
+-- ----------------------------------------------------------------
+-- Default roles (editable data; not hardcoded in application code).
+-- Administrator is a protected system role; Manager and Employee are
+-- ordinary, fully-editable starter roles.
+-- ----------------------------------------------------------------
+INSERT IGNORE INTO roles (name, description, is_system) VALUES
+('Administrator', 'Full, unrestricted system access', TRUE),
+('Manager',       'Manages staff, schedules and approvals', FALSE),
+('Employee',      'Self-service access for scheduled staff', FALSE);
+
+-- Administrator gets every permission.
+INSERT IGNORE INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id FROM roles r CROSS JOIN permissions p WHERE r.name = 'Administrator';
+
+-- Manager gets the day-to-day management subset (no system settings, role or
+-- org-tree administration, which stay with Administrator).
+INSERT IGNORE INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id FROM roles r JOIN permissions p ON p.code IN (
+  'employee.read','employee.manage','schedule.read','schedule.manage','schedule.publish',
+  'schedule.optimize','assignment.manage','shift.manage','department.read','department.manage',
+  'org_unit.read','oncall.manage','policy.read','policy.manage','policy.approve',
+  'loan.request','loan.approve','timeoff.approve','shiftswap.approve','preferences.manage',
+  'report.read','audit.read','user.read','user.manage'
+) WHERE r.name = 'Manager';
+
+-- Employee gets read-only visibility; self-service actions (creating own
+-- time-off / swap / loan requests) require only authentication, not a permission.
+INSERT IGNORE INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id FROM roles r JOIN permissions p ON p.code IN (
+  'schedule.read','department.read','org_unit.read','policy.read','employee.read'
+) WHERE r.name = 'Employee';
 
 -- Default skills
 INSERT IGNORE INTO skills (name, description, is_active) VALUES
@@ -682,16 +812,16 @@ INSERT IGNORE INTO system_settings (category, `key`, value, type, default_value,
 
 -- Default approval matrix
 -- These rows ensure the workflow has sane defaults from the very first run.
-INSERT IGNORE INTO approval_matrix (change_type, approver_scope, approver_role, auto_approve_for_owner, description) VALUES
-('Loan.Request',          'unit_manager',       NULL,    TRUE, 'Cross-department employee loans approved by the receiving unit manager'),
-('Loan.Cancel',           'unit_manager',       NULL,    TRUE, 'Cancellation of an approved loan requires receiving unit manager approval'),
-('Policy.Create',         'company_role',       'admin', TRUE, 'New policy creation goes through admin'),
-('Policy.Update',         'policy_owner',       NULL,    TRUE, 'Edits to a policy require approval by the policy owner'),
-('Policy.Exception',      'policy_owner',       NULL,    TRUE, 'Derogations to a policy require approval by its owner'),
-('Schedule.Publish',      'unit_manager',       NULL,    TRUE, 'Publishing a schedule requires the receiving unit manager'),
-('Schedule.Override',     'unit_manager_chain', NULL,    TRUE, 'Schedule overrides escalate up the org tree if needed'),
-('OrgUnit.Update',        'company_role',       'admin', TRUE, 'Org tree edits go through admin'),
-('Membership.Update',     'unit_manager',       NULL,    TRUE, 'User membership changes need the unit manager');
+INSERT IGNORE INTO approval_matrix (change_type, approver_scope, approver_role_id, auto_approve_for_owner, description) VALUES
+('Loan.Request',          'unit_manager',       NULL, TRUE, 'Cross-department employee loans approved by the receiving unit manager'),
+('Loan.Cancel',           'unit_manager',       NULL, TRUE, 'Cancellation of an approved loan requires receiving unit manager approval'),
+('Policy.Create',         'company_role',       (SELECT id FROM roles WHERE name = 'Administrator'), TRUE, 'New policy creation goes through an administrator'),
+('Policy.Update',         'policy_owner',       NULL, TRUE, 'Edits to a policy require approval by the policy owner'),
+('Policy.Exception',      'policy_owner',       NULL, TRUE, 'Derogations to a policy require approval by its owner'),
+('Schedule.Publish',      'unit_manager',       NULL, TRUE, 'Publishing a schedule requires the receiving unit manager'),
+('Schedule.Override',     'unit_manager_chain', NULL, TRUE, 'Schedule overrides escalate up the org tree if needed'),
+('OrgUnit.Update',        'company_role',       (SELECT id FROM roles WHERE name = 'Administrator'), TRUE, 'Org tree edits go through an administrator'),
+('Membership.Update',     'unit_manager',       NULL, TRUE, 'User membership changes need the unit manager');
 
 -- ================================================================
 -- END OF SCHEMA

--- a/backend/scripts/seed-demo.ts
+++ b/backend/scripts/seed-demo.ts
@@ -111,6 +111,7 @@ const wipeAll = async (conn: mysql.Connection): Promise<void> => {
     'user_custom_fields',
     'user_skills',
     'user_departments',
+    'user_roles',
     'policy_exception_requests',
     'policies',
     'employee_loans',
@@ -120,7 +121,8 @@ const wipeAll = async (conn: mysql.Connection): Promise<void> => {
     'departments',
     'users',
     // Keep system_settings as-is; we set the mode key explicitly below.
-    // Keep approval_matrix as-is; defaults are seeded by init.sql.
+    // Keep approval_matrix, roles, permissions and role_permissions as-is;
+    // they are seeded by init.sql and are configuration, not demo data.
   ];
   for (const table of tables) {
     await conn.query(`TRUNCATE TABLE \`${table}\``);
@@ -176,7 +178,8 @@ const insertBulkOperationsDepartment = async (
   conn: mysql.Connection,
   deptIds: Map<string, number>,
   skillIds: Map<string, number>,
-  userIds: Map<string, number>
+  userIds: Map<string, number>,
+  roleIds: Map<string, number>
 ): Promise<void> => {
   // 1. Department
   const [deptRes] = await conn.execute<mysql.ResultSetHeader>(
@@ -205,13 +208,14 @@ const insertBulkOperationsDepartment = async (
     const lastName = padded;
 
     const [userRes] = await conn.execute<mysql.ResultSetHeader>(
-      `INSERT INTO users (email, password_hash, first_name, last_name, role,
+      `INSERT INTO users (email, password_hash, first_name, last_name,
                           employee_id, position, phone, is_active)
-       VALUES (?, ?, ?, ?, 'employee', ?, '[DEMO] Operations', '+39 000 0000000', 1)`,
+       VALUES (?, ?, ?, ?, ?, '[DEMO] Operations', '+39 000 0000000', 1)`,
       [email, passwordHash, firstName, lastName, employeeId]
     );
     const userId = userRes.insertId;
     userIds.set(email, userId);
+    await assignRole(conn, userId, roleIds.get('Employee'));
 
     await conn.execute(
       'INSERT INTO user_departments (user_id, department_id) VALUES (?, ?)',
@@ -232,24 +236,56 @@ const insertBulkOperationsDepartment = async (
   );
 };
 
+/**
+ * Maps the fixture's shorthand role keys to the seeded role names created by
+ * init.sql. Roles are data, so the seed assigns users to roles by name.
+ */
+const ROLE_NAME_BY_KEY: Record<DemoUser['role'], string> = {
+  admin: 'Administrator',
+  manager: 'Manager',
+  employee: 'Employee',
+};
+
+/** Resolves seeded role ids by name so the demo can assign user_roles rows. */
+const loadRoleIds = async (conn: mysql.Connection): Promise<Map<string, number>> => {
+  const [rows] = await conn.execute<mysql.RowDataPacket[]>('SELECT id, name FROM roles');
+  const map = new Map<string, number>();
+  for (const row of rows as Array<{ id: number; name: string }>) map.set(row.name, row.id);
+  return map;
+};
+
+const assignRole = async (
+  conn: mysql.Connection,
+  userId: number,
+  roleId: number | undefined
+): Promise<void> => {
+  if (!roleId) return;
+  await conn.execute(
+    'INSERT IGNORE INTO user_roles (user_id, role_id, scope_org_unit_id) VALUES (?, ?, NULL)',
+    [userId, roleId]
+  );
+};
+
 const insertUsers = async (
   conn: mysql.Connection,
   fixture: DemoFixture,
   deptIds: Map<string, number>,
-  skillIds: Map<string, number>
+  skillIds: Map<string, number>,
+  roleIds: Map<string, number>
 ): Promise<Map<string, number>> => {
   const passwordHash = await bcrypt.hash(DEMO_PASSWORD, 4);
   const map = new Map<string, number>();
 
   for (const user of fixture.users) {
     const [res] = await conn.execute<mysql.ResultSetHeader>(
-      `INSERT INTO users (email, password_hash, first_name, last_name, role,
+      `INSERT INTO users (email, password_hash, first_name, last_name,
                           employee_id, position, phone, is_active)
-       VALUES (?, ?, ?, ?, ?, ?, '[DEMO]', '+39 000 0000000', 1)`,
-      [user.email, passwordHash, user.firstName, user.lastName, user.role, user.employeeId]
+       VALUES (?, ?, ?, ?, ?, '[DEMO]', '+39 000 0000000', 1)`,
+      [user.email, passwordHash, user.firstName, user.lastName, user.employeeId]
     );
     const userId = res.insertId;
     map.set(user.email, userId);
+    await assignRole(conn, userId, roleIds.get(ROLE_NAME_BY_KEY[user.role]));
 
     for (const deptName of user.departments) {
       const deptId = deptIds.get(deptName);
@@ -859,10 +895,11 @@ export async function seedDemo(): Promise<void> {
 
     await wipeAll(conn);
 
+    const roleIds = await loadRoleIds(conn);
     const deptIds = await insertDepartments(conn, fixture);
     const skillIds = await insertSkills(conn, fixture);
-    const userIds = await insertUsers(conn, fixture, deptIds, skillIds);
-    await insertBulkOperationsDepartment(conn, deptIds, skillIds, userIds);
+    const userIds = await insertUsers(conn, fixture, deptIds, skillIds, roleIds);
+    await insertBulkOperationsDepartment(conn, deptIds, skillIds, userIds, roleIds);
     const templateIds = await insertShiftTemplates(conn, fixture, deptIds, skillIds);
     await insertScheduleWithShifts(
       conn,

--- a/backend/src/__tests__/auth.middleware.extended.test.ts
+++ b/backend/src/__tests__/auth.middleware.extended.test.ts
@@ -2,14 +2,14 @@
  * Extended auth middleware tests — covers:
  *   - The outer catch in `authenticate`: when `getUserById` throws (not just
  *     returns null), the middleware returns 500 AUTH_ERROR.
- *   - `requireRole` called without a preceding `authenticate`: `req.user` is
- *     undefined, so the middleware returns 401 UNAUTHORIZED.
+ *   - `requirePermission` called without a preceding `authenticate`: `req.user`
+ *     is undefined, so the middleware returns 401 UNAUTHORIZED.
  */
 
 import express from 'express';
 import request from 'supertest';
 import jwt from 'jsonwebtoken';
-import { authenticate, requireRole } from '../middleware/auth';
+import { authenticate, requirePermission } from '../middleware/auth';
 import { config } from '../config';
 import { UserService } from '../services/UserService';
 import { database } from '../config/database';
@@ -36,7 +36,7 @@ describe('authenticate — outer catch returns 500 AUTH_ERROR', () => {
       res.json({ success: true });
     });
 
-    const token = signToken({ userId: 1, email: 'a@x', role: 'admin' });
+    const token = signToken({ userId: 1, email: 'a@x' });
     const res = await request(app).get('/protected').set('Authorization', `Bearer ${token}`);
 
     expect(res.status).toBe(500);
@@ -44,12 +44,12 @@ describe('authenticate — outer catch returns 500 AUTH_ERROR', () => {
   });
 });
 
-describe('requireRole — returns 401 UNAUTHORIZED when req.user is not set', () => {
+describe('requirePermission — returns 401 UNAUTHORIZED when req.user is not set', () => {
   it('returns 401 when the route has no authenticate middleware before it', async () => {
     const app = express();
     app.use(express.json());
-    // requireRole is mounted directly without authenticate — req.user stays undefined.
-    app.get('/admin-only', requireRole(['admin']), (_req, res) => {
+    // requirePermission is mounted directly without authenticate — req.user stays undefined.
+    app.get('/admin-only', requirePermission('settings.manage'), (_req, res) => {
       res.json({ success: true });
     });
 

--- a/backend/src/__tests__/auth.middleware.test.ts
+++ b/backend/src/__tests__/auth.middleware.test.ts
@@ -1,28 +1,35 @@
 /**
  * Auth middleware tests.
  *
- * Mounts a tiny app with `authenticate` and the role guards in front of a
+ * Mounts a tiny app with `authenticate` and the permission guard in front of a
  * test handler so we can exercise:
  *   - missing Authorization header
  *   - malformed / non-Bearer header
  *   - expired or tampered JWT
  *   - inactive user
  *   - happy path
- *   - requireRole / requireAdmin / requireManager
+ *   - requirePermission
  */
 
 import express from 'express';
 import request from 'supertest';
 import jwt from 'jsonwebtoken';
-import { authenticate, requireRole, requireAdmin, requireManager } from '../middleware/auth';
+import { authenticate, requirePermission } from '../middleware/auth';
 import { config } from '../config';
 import { UserService } from '../services/UserService';
+import { RbacService } from '../services/RbacService';
 import { database } from '../config/database';
 
 jest.mock('../services/UserService');
+jest.mock('../services/RbacService');
 jest.mock('../config/database', () => ({
   database: { getPool: jest.fn().mockReturnValue({}) },
 }));
+
+const setPermissions = (perms: string[]): void => {
+  (RbacService.prototype.getEffectivePermissions as jest.Mock) = jest.fn().mockResolvedValue(perms);
+  (RbacService.prototype.getUserRoles as jest.Mock) = jest.fn().mockResolvedValue([]);
+};
 
 const buildApp = (extraMiddleware: express.RequestHandler[] = []): express.Express => {
   const app = express();
@@ -40,6 +47,7 @@ describe('authenticate', () => {
   beforeEach(() => {
     (UserService as jest.MockedClass<typeof UserService>).mockClear();
     (database.getPool as jest.Mock).mockReturnValue({});
+    setPermissions([]);
   });
 
   it('returns 401 MISSING_TOKEN with no Authorization header', async () => {
@@ -63,7 +71,7 @@ describe('authenticate', () => {
   });
 
   it('returns 401 INVALID_TOKEN with a JWT signed by a different secret', async () => {
-    const token = signToken({ userId: 1, email: 'a@x', role: 'admin' }, 'wrong-secret');
+    const token = signToken({ userId: 1, email: 'a@x' }, 'wrong-secret');
     const res = await request(buildApp())
       .get('/protected')
       .set('Authorization', `Bearer ${token}`);
@@ -73,7 +81,7 @@ describe('authenticate', () => {
 
   it('returns 401 USER_NOT_FOUND when the user is missing or inactive', async () => {
     (UserService.prototype.getUserById as jest.Mock) = jest.fn().mockResolvedValue(null);
-    const token = signToken({ userId: 1, email: 'a@x', role: 'admin' });
+    const token = signToken({ userId: 1, email: 'a@x' });
     const res = await request(buildApp())
       .get('/protected')
       .set('Authorization', `Bearer ${token}`);
@@ -85,10 +93,9 @@ describe('authenticate', () => {
     (UserService.prototype.getUserById as jest.Mock) = jest.fn().mockResolvedValue({
       id: 7,
       email: 'a@x',
-      role: 'manager',
       isActive: true,
     });
-    const token = signToken({ userId: 7, email: 'a@x', role: 'manager' });
+    const token = signToken({ userId: 7, email: 'a@x' });
     const res = await request(buildApp())
       .get('/protected')
       .set('Authorization', `Bearer ${token}`);
@@ -97,60 +104,29 @@ describe('authenticate', () => {
   });
 });
 
-describe('requireRole / requireAdmin / requireManager', () => {
+describe('requirePermission', () => {
   beforeEach(() => {
     (UserService.prototype.getUserById as jest.Mock) = jest.fn().mockResolvedValue({
       id: 7,
       email: 'a@x',
-      role: 'employee',
       isActive: true,
     });
   });
 
-  it('returns 403 FORBIDDEN when role does not match the allow list', async () => {
-    const token = signToken({ userId: 7, email: 'a@x', role: 'employee' });
-    const res = await request(buildApp([requireRole(['admin'])]))
+  it('returns 403 FORBIDDEN when the user lacks the required permission', async () => {
+    setPermissions(['schedule.read']);
+    const token = signToken({ userId: 7, email: 'a@x' });
+    const res = await request(buildApp([requirePermission('settings.manage')]))
       .get('/protected')
       .set('Authorization', `Bearer ${token}`);
     expect(res.status).toBe(403);
     expect(res.body.error.code).toBe('FORBIDDEN');
   });
 
-  it('requireAdmin lets admins through and blocks managers', async () => {
-    (UserService.prototype.getUserById as jest.Mock) = jest.fn().mockResolvedValue({
-      id: 7,
-      email: 'admin@x',
-      role: 'admin',
-      isActive: true,
-    });
-    const adminToken = signToken({ userId: 7, email: 'admin@x', role: 'admin' });
-    const ok = await request(buildApp([requireAdmin]))
-      .get('/protected')
-      .set('Authorization', `Bearer ${adminToken}`);
-    expect(ok.status).toBe(200);
-
-    (UserService.prototype.getUserById as jest.Mock) = jest.fn().mockResolvedValue({
-      id: 8,
-      email: 'm@x',
-      role: 'manager',
-      isActive: true,
-    });
-    const mgrToken = signToken({ userId: 8, email: 'm@x', role: 'manager' });
-    const blocked = await request(buildApp([requireAdmin]))
-      .get('/protected')
-      .set('Authorization', `Bearer ${mgrToken}`);
-    expect(blocked.status).toBe(403);
-  });
-
-  it('requireManager admits both admin and manager', async () => {
-    (UserService.prototype.getUserById as jest.Mock) = jest.fn().mockResolvedValue({
-      id: 8,
-      email: 'm@x',
-      role: 'manager',
-      isActive: true,
-    });
-    const token = signToken({ userId: 8, email: 'm@x', role: 'manager' });
-    const res = await request(buildApp([requireManager]))
+  it('lets a user through when they hold the required permission', async () => {
+    setPermissions(['settings.manage', 'schedule.read']);
+    const token = signToken({ userId: 7, email: 'a@x' });
+    const res = await request(buildApp([requirePermission('settings.manage')]))
       .get('/protected')
       .set('Authorization', `Bearer ${token}`);
     expect(res.status).toBe(200);

--- a/backend/src/__tests__/auth.route.extended.test.ts
+++ b/backend/src/__tests__/auth.route.extended.test.ts
@@ -15,9 +15,12 @@ import { config } from '../config';
 import { createAuthRouter } from '../routes/auth';
 
 jest.mock('../services/UserService');
+jest.mock('../services/RbacService');
 jest.mock('../config/database', () => ({
   database: { getPool: jest.fn().mockReturnValue({}) },
 }));
+
+import { RbacService } from '../services/RbacService';
 
 const buildApp = () => {
   const app = express();
@@ -42,6 +45,8 @@ describe('GET /api/auth/verify', () => {
   beforeEach(() => {
     (UserService as jest.MockedClass<typeof UserService>).mockClear();
     (database.getPool as jest.Mock).mockReturnValue({});
+    (RbacService.prototype.getEffectivePermissions as jest.Mock) = jest.fn().mockResolvedValue([]);
+    (RbacService.prototype.getUserRoles as jest.Mock) = jest.fn().mockResolvedValue([]);
   });
 
   it('returns 200 with the user payload (minus sensitive fields) on success', async () => {
@@ -64,6 +69,8 @@ describe('POST /api/auth/refresh', () => {
   beforeEach(() => {
     (UserService as jest.MockedClass<typeof UserService>).mockClear();
     (database.getPool as jest.Mock).mockReturnValue({});
+    (RbacService.prototype.getEffectivePermissions as jest.Mock) = jest.fn().mockResolvedValue([]);
+    (RbacService.prototype.getUserRoles as jest.Mock) = jest.fn().mockResolvedValue([]);
   });
 
   it('issues a new token for a valid user', async () => {
@@ -91,6 +98,8 @@ describe('POST /api/auth/logout', () => {
   beforeEach(() => {
     (UserService as jest.MockedClass<typeof UserService>).mockClear();
     (database.getPool as jest.Mock).mockReturnValue({});
+    (RbacService.prototype.getEffectivePermissions as jest.Mock) = jest.fn().mockResolvedValue([]);
+    (RbacService.prototype.getUserRoles as jest.Mock) = jest.fn().mockResolvedValue([]);
   });
 
   it('returns 200 with a logout confirmation for an authenticated user', async () => {

--- a/backend/src/__tests__/auth.route.test.ts
+++ b/backend/src/__tests__/auth.route.test.ts
@@ -10,10 +10,12 @@ import express from 'express';
 import request from 'supertest';
 import jwt from 'jsonwebtoken';
 import { UserService } from '../services/UserService';
+import { RbacService } from '../services/RbacService';
 import { config } from '../config';
 import { createAuthRouter } from '../routes/auth';
 
 jest.mock('../services/UserService');
+jest.mock('../services/RbacService');
 
 const buildApp = (): express.Express => {
   const app = express();
@@ -49,13 +51,19 @@ describe('POST /api/auth/login', () => {
       email: 'a@x.com',
       firstName: 'A',
       lastName: 'B',
-      role: 'manager',
     });
+    (RbacService.prototype.getEffectivePermissions as jest.Mock) = jest
+      .fn()
+      .mockResolvedValue(['schedule.manage', 'schedule.read']);
+    (RbacService.prototype.getUserRoles as jest.Mock) = jest
+      .fn()
+      .mockResolvedValue([{ roleId: 2, roleName: 'Manager', scopeOrgUnitId: null, expiresAt: null }]);
     const res = await request(buildApp())
       .post('/api/auth/login')
       .send({ email: 'a@x.com', password: 'pw' });
     expect(res.status).toBe(200);
-    expect(res.body.data.user.role).toBe('manager');
+    expect(res.body.data.user.permissions).toContain('schedule.manage');
+    expect(res.body.data.user.roles[0].roleName).toBe('Manager');
     expect(typeof res.body.data.token).toBe('string');
     const decoded = jwt.verify(res.body.data.token, config.jwt.secret) as { userId: number };
     expect(decoded.userId).toBe(7);

--- a/backend/src/__tests__/bulkImport.service.test.ts
+++ b/backend/src/__tests__/bulkImport.service.test.ts
@@ -44,12 +44,12 @@ describe('mapEmployeeRows', () => {
     expect(out.errors[0].message).toMatch(/Missing required columns/);
   });
 
-  it('rejects an invalid role and continues with the rest', () => {
+  it('rejects rows with an empty role and continues with the rest', () => {
     const csv = parseCsv(
       'email,firstName,lastName,role\n' +
-        'a@x.com,A,A,manager\n' +
-        'b@x.com,B,B,king\n' +
-        'c@x.com,C,C,employee\n'
+        'a@x.com,A,A,Manager\n' +
+        'b@x.com,B,B,\n' +
+        'c@x.com,C,C,Employee\n'
     );
     const out = mapEmployeeRows(csv);
     expect(out.rows.map((r) => r.email)).toEqual(['a@x.com', 'c@x.com']);
@@ -131,14 +131,18 @@ describe('BulkImportService.importEmployees', () => {
   it('inserts every valid row in one transaction', async () => {
     const csv =
       'email,firstName,lastName,role\n' +
-      'a@x.com,A,A,employee\n' +
-      'b@x.com,B,B,manager\n';
+      'a@x.com,A,A,Employee\n' +
+      'b@x.com,B,B,Manager\n';
     const { pool, conn } = makePool();
     conn.execute
-      .mockResolvedValueOnce([[], null])
-      .mockResolvedValueOnce([{ insertId: 1, affectedRows: 1 }, null])
-      .mockResolvedValueOnce([[], null])
-      .mockResolvedValueOnce([{ insertId: 2, affectedRows: 1 }, null]);
+      .mockResolvedValueOnce([[], null])                         // email check row 1
+      .mockResolvedValueOnce([[{ id: 3 }], null])               // role lookup row 1
+      .mockResolvedValueOnce([{ insertId: 1, affectedRows: 1 }, null]) // INSERT user row 1
+      .mockResolvedValueOnce([{ affectedRows: 1 }, null])       // INSERT IGNORE user_roles row 1
+      .mockResolvedValueOnce([[], null])                         // email check row 2
+      .mockResolvedValueOnce([[{ id: 2 }], null])               // role lookup row 2
+      .mockResolvedValueOnce([{ insertId: 2, affectedRows: 1 }, null]) // INSERT user row 2
+      .mockResolvedValueOnce([{ affectedRows: 1 }, null]);      // INSERT IGNORE user_roles row 2
 
     const service = new BulkImportService(pool);
     const out = await service.importEmployees(csv, 'pw');

--- a/backend/src/__tests__/employee.service.test.ts
+++ b/backend/src/__tests__/employee.service.test.ts
@@ -38,40 +38,35 @@ describe('EmployeeService', () => {
     mockUserService = (UserService as jest.MockedClass<typeof UserService>).mock.instances[0] as jest.Mocked<UserService>;
   });
 
-  it('getAllEmployees forces role=employee on the underlying call', async () => {
+  it('getAllEmployees forwards filters without forcing a role', async () => {
     mockUserService.getAllUsers = jest.fn().mockResolvedValue([buildUser()]);
     await service.getAllEmployees({ departmentId: 5 });
-    expect(mockUserService.getAllUsers).toHaveBeenCalledWith({ departmentId: 5, role: 'employee' });
+    expect(mockUserService.getAllUsers).toHaveBeenCalledWith({ departmentId: 5 });
   });
 
-  it('getEmployeeById returns null if the user has a different role', async () => {
-    mockUserService.getUserById = jest.fn().mockResolvedValue(buildUser({ role: 'admin' }));
-    const result = await service.getEmployeeById(7);
-    expect(result).toBeNull();
-  });
-
-  it('getEmployeeById returns the user when role matches', async () => {
+  it('getEmployeeById returns the user regardless of their roles', async () => {
     mockUserService.getUserById = jest.fn().mockResolvedValue(buildUser());
     const result = await service.getEmployeeById(7);
     expect(result?.id).toBe(7);
   });
 
-  it('getEmployeeStatistics aggregates active vs inactive', async () => {
+  it('getEmployeeById returns null when the user does not exist', async () => {
+    mockUserService.getUserById = jest.fn().mockResolvedValue(null);
+    const result = await service.getEmployeeById(7);
+    expect(result).toBeNull();
+  });
+
+  it('getEmployeeStatistics reflects the overall user headcount', async () => {
     mockUserService.getUserStatistics = jest.fn().mockResolvedValue({
       total: 10,
       active: 8,
       inactive: 2,
-      byRole: [{ role: 'employee', count: 8 }],
+      byRole: [{ role: 'Employee', count: 8 }],
     });
-    mockUserService.getAllUsers = jest.fn().mockResolvedValue([
-      buildUser({ id: 1, isActive: true }),
-      buildUser({ id: 2, isActive: false }),
-      buildUser({ id: 3, isActive: true }),
-    ]);
     const stats = await service.getEmployeeStatistics();
-    expect(stats.total).toBe(8);
-    expect(stats.active).toBe(2);
-    expect(stats.inactive).toBe(6);
+    expect(stats.total).toBe(10);
+    expect(stats.active).toBe(8);
+    expect(stats.inactive).toBe(2);
   });
 
   it('getEmployeesByDepartment delegates with no role filter override', async () => {
@@ -80,16 +75,16 @@ describe('EmployeeService', () => {
     expect(mockUserService.getUsersByDepartment).toHaveBeenCalledWith(3);
   });
 
-  it('createEmployee always sets role=employee', async () => {
+  it('createEmployee forwards the supplied data (roles via roleIds)', async () => {
     mockUserService.createUser = jest.fn().mockResolvedValue(buildUser());
-    await service.createEmployee({ email: 'a@x.com', role: 'admin' });
+    await service.createEmployee({ email: 'a@x.com', roleIds: [3] });
     expect(mockUserService.createUser).toHaveBeenCalledWith(
-      expect.objectContaining({ role: 'employee' })
+      expect.objectContaining({ email: 'a@x.com', roleIds: [3] })
     );
   });
 
-  it('updateEmployee throws when target is not an employee', async () => {
-    mockUserService.getUserById = jest.fn().mockResolvedValue(buildUser({ role: 'manager' }));
+  it('updateEmployee throws when the target user does not exist', async () => {
+    mockUserService.getUserById = jest.fn().mockResolvedValue(null);
     await expect(service.updateEmployee(7, { firstName: 'X' })).rejects.toThrow(/Employee not found/);
   });
 

--- a/backend/src/__tests__/helpers/permissions.ts
+++ b/backend/src/__tests__/helpers/permissions.ts
@@ -1,0 +1,50 @@
+/**
+ * Test helper: maps the legacy role shorthand used by the test fixtures
+ * ('admin' | 'manager' | 'employee') to the effective permission codes the
+ * corresponding seeded role grants. Mirrors the grants defined in
+ * `database/init.sql` so route tests can exercise permission-based handlers
+ * without standing up the real RBAC tables.
+ */
+
+export const ALL_PERMISSIONS: string[] = [
+  'employee.read', 'employee.manage',
+  'schedule.read', 'schedule.manage', 'schedule.publish', 'schedule.optimize',
+  'assignment.manage', 'shift.manage',
+  'department.read', 'department.manage',
+  'org_unit.read', 'org_unit.manage',
+  'oncall.manage',
+  'policy.read', 'policy.manage', 'policy.approve',
+  'approval.manage',
+  'loan.request', 'loan.approve',
+  'timeoff.approve', 'shiftswap.approve',
+  'preferences.manage',
+  'report.read', 'audit.read',
+  'user.read', 'user.manage',
+  'settings.manage', 'role.manage',
+];
+
+export const MANAGER_PERMISSIONS: string[] = [
+  'employee.read', 'employee.manage',
+  'schedule.read', 'schedule.manage', 'schedule.publish', 'schedule.optimize',
+  'assignment.manage', 'shift.manage',
+  'department.read', 'department.manage',
+  'org_unit.read',
+  'oncall.manage',
+  'policy.read', 'policy.manage', 'policy.approve',
+  'loan.request', 'loan.approve',
+  'timeoff.approve', 'shiftswap.approve',
+  'preferences.manage',
+  'report.read', 'audit.read',
+  'user.read', 'user.manage',
+];
+
+export const EMPLOYEE_PERMISSIONS: string[] = [
+  'schedule.read', 'department.read', 'org_unit.read', 'policy.read', 'employee.read',
+];
+
+export const permissionsForRole = (role?: string): string[] => {
+  if (role === 'admin') return ALL_PERMISSIONS;
+  if (role === 'manager') return MANAGER_PERMISSIONS;
+  if (role === 'employee') return EMPLOYEE_PERMISSIONS;
+  return [];
+};

--- a/backend/src/__tests__/routes.dashboard.test.ts
+++ b/backend/src/__tests__/routes.dashboard.test.ts
@@ -10,12 +10,12 @@ import request from 'supertest';
 
 jest.mock('../middleware/auth', () => ({
   authenticate: (req: any, _res: any, next: any) => {
-    req.user = { id: 1, role: 'admin', email: 'a@x', isActive: true };
+    req.user = { id: 1, role: 'admin', email: 'a@x', isActive: true, permissions: require('./helpers/permissions').ALL_PERMISSIONS };
     next();
   },
-  requireRole: () => (_req: any, _res: any, next: any) => next(),
-  requireAdmin: (_req: any, _res: any, next: any) => next(),
-  requireManager: (_req: any, _res: any, next: any) => next(),
+  requirePermission: () => (_req: any, _res: any, next: any) => next(),
+  userHasPermission: (user: any, code: string) =>
+    Boolean(user && user.permissions && user.permissions.includes(code)),
 }));
 
 const queryOne = jest.fn();

--- a/backend/src/__tests__/routes.expanded.test.ts
+++ b/backend/src/__tests__/routes.expanded.test.ts
@@ -17,12 +17,12 @@ let currentUser: { id: number; role: 'admin' | 'manager' | 'employee'; email: st
 
 jest.mock('../middleware/auth', () => ({
   authenticate: (req: any, _res: any, next: any) => {
-    req.user = { ...currentUser, isActive: true };
+    req.user = { ...currentUser, isActive: true, permissions: require("./helpers/permissions").permissionsForRole(currentUser.role) };
     next();
   },
-  requireRole: () => (_req: any, _res: any, next: any) => next(),
-  requireAdmin: (_req: any, _res: any, next: any) => next(),
-  requireManager: (_req: any, _res: any, next: any) => next(),
+  requirePermission: () => (_req: any, _res: any, next: any) => next(),
+  userHasPermission: (user: any, code: string) =>
+    Boolean(user && user.permissions && user.permissions.includes(code)),
 }));
 
 jest.mock('../services/AssignmentService');
@@ -42,6 +42,7 @@ jest.mock('../services/OnCallService');
 jest.mock('../services/UserDirectoryService');
 jest.mock('../services/BulkImportService');
 jest.mock('../services/NotificationService');
+jest.mock('../services/RbacService');
 
 import { AssignmentService } from '../services/AssignmentService';
 import { ScheduleService } from '../services/ScheduleService';
@@ -78,8 +79,21 @@ import { createDirectoryRouter } from '../routes/directory';
 import { createBulkImportRouter } from '../routes/bulkImport';
 import { createNotificationsRouter } from '../routes/notifications';
 import { createAuthRouter } from '../routes/auth';
+import { RbacService } from '../services/RbacService';
 
 const fakePool = {} as never;
+
+// Default RbacService stub so auth route tests that call RbacService don't fail.
+beforeEach(() => {
+  if ((RbacService.prototype.getEffectivePermissions as jest.Mock)?.mockReset) {
+    (RbacService.prototype.getEffectivePermissions as jest.Mock).mockReset();
+    (RbacService.prototype.getEffectivePermissions as jest.Mock).mockResolvedValue([]);
+  }
+  if ((RbacService.prototype.getUserRoles as jest.Mock)?.mockReset) {
+    (RbacService.prototype.getUserRoles as jest.Mock).mockReset();
+    (RbacService.prototype.getUserRoles as jest.Mock).mockResolvedValue([]);
+  }
+});
 
 const mountApp = (prefix: string, router: express.Router): express.Express => {
   const app = express();
@@ -935,15 +949,10 @@ describe('departments router (extended)', () => {
     res = await request(app()).post('/api/departments').send({ name: 'X', managerId: 5 });
     expect(res.status).toBe(400);
 
+    // Any active user can be a department manager — no role restriction.
     (UserService.prototype.getUserById as jest.Mock) = jest
       .fn()
-      .mockResolvedValue({ id: 5, role: 'employee' });
-    res = await request(app()).post('/api/departments').send({ name: 'X', managerId: 5 });
-    expect(res.status).toBe(400);
-
-    (UserService.prototype.getUserById as jest.Mock) = jest
-      .fn()
-      .mockResolvedValue({ id: 5, role: 'manager' });
+      .mockResolvedValue({ id: 5 });
     (DepartmentService.prototype.createDepartment as jest.Mock) = jest
       .fn()
       .mockResolvedValue({ id: 1 });
@@ -989,11 +998,15 @@ describe('departments router (extended)', () => {
     res = await request(app()).put('/api/departments/1').send({ managerId: 9 });
     expect(res.status).toBe(400);
 
+    // Any existing user can be a department manager (no role restriction).
     (UserService.prototype.getUserById as jest.Mock) = jest
       .fn()
-      .mockResolvedValue({ id: 9, role: 'employee' });
+      .mockResolvedValue({ id: 9 });
+    (DepartmentService.prototype.updateDepartment as jest.Mock) = jest
+      .fn()
+      .mockResolvedValue({ id: 1 });
     res = await request(app()).put('/api/departments/1').send({ managerId: 9 });
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(200);
 
     currentUser = { id: 1, role: 'admin', email: 'a@x' };
     (DepartmentService.prototype.updateDepartment as jest.Mock) = jest

--- a/backend/src/__tests__/routes.feature.happy.test.ts
+++ b/backend/src/__tests__/routes.feature.happy.test.ts
@@ -11,12 +11,12 @@ import request from 'supertest';
 
 jest.mock('../middleware/auth', () => ({
   authenticate: (req: any, _res: any, next: any) => {
-    req.user = { id: 1, email: 'admin@example', role: 'admin', isActive: true };
+    req.user = { id: 1, email: 'admin@example', role: 'admin', isActive: true, permissions: require('./helpers/permissions').ALL_PERMISSIONS };
     next();
   },
-  requireRole: () => (_req: any, _res: any, next: any) => next(),
-  requireAdmin: (_req: any, _res: any, next: any) => next(),
-  requireManager: (_req: any, _res: any, next: any) => next(),
+  requirePermission: () => (_req: any, _res: any, next: any) => next(),
+  userHasPermission: (user: any, code: string) =>
+    Boolean(user && user.permissions && user.permissions.includes(code)),
 }));
 
 jest.mock('../services/TimeOffService');

--- a/backend/src/__tests__/routes.legacy.happy.test.ts
+++ b/backend/src/__tests__/routes.legacy.happy.test.ts
@@ -14,12 +14,12 @@ import request from 'supertest';
 
 jest.mock('../middleware/auth', () => ({
   authenticate: (req: any, _res: any, next: any) => {
-    req.user = { id: 1, email: 'admin@example', role: 'admin', isActive: true };
+    req.user = { id: 1, email: 'admin@example', role: 'admin', isActive: true, permissions: require('./helpers/permissions').ALL_PERMISSIONS };
     next();
   },
-  requireRole: () => (_req: any, _res: any, next: any) => next(),
-  requireAdmin: (_req: any, _res: any, next: any) => next(),
-  requireManager: (_req: any, _res: any, next: any) => next(),
+  requirePermission: () => (_req: any, _res: any, next: any) => next(),
+  userHasPermission: (user: any, code: string) =>
+    Boolean(user && user.permissions && user.permissions.includes(code)),
 }));
 
 jest.mock('../services/EmployeeService');

--- a/backend/src/__tests__/routes.org.test.ts
+++ b/backend/src/__tests__/routes.org.test.ts
@@ -15,12 +15,12 @@ let currentUser: { id: number; role: 'admin' | 'manager' | 'employee'; email: st
 
 jest.mock('../middleware/auth', () => ({
   authenticate: (req: any, _res: any, next: any) => {
-    req.user = { ...currentUser, isActive: true };
+    req.user = { ...currentUser, isActive: true, permissions: require("./helpers/permissions").permissionsForRole(currentUser.role) };
     next();
   },
-  requireRole: () => (_req: any, _res: any, next: any) => next(),
-  requireAdmin: (_req: any, _res: any, next: any) => next(),
-  requireManager: (_req: any, _res: any, next: any) => next(),
+  requirePermission: () => (_req: any, _res: any, next: any) => next(),
+  userHasPermission: (user: any, code: string) =>
+    Boolean(user && user.permissions && user.permissions.includes(code)),
 }));
 
 jest.mock('../services/OrgUnitService');

--- a/backend/src/__tests__/routes.policies.test.ts
+++ b/backend/src/__tests__/routes.policies.test.ts
@@ -15,12 +15,12 @@ let currentUser: { id: number; role: 'admin' | 'manager' | 'employee'; email: st
 
 jest.mock('../middleware/auth', () => ({
   authenticate: (req: any, _res: any, next: any) => {
-    req.user = { ...currentUser, isActive: true };
+    req.user = { ...currentUser, isActive: true, permissions: require("./helpers/permissions").permissionsForRole(currentUser.role) };
     next();
   },
-  requireRole: () => (_req: any, _res: any, next: any) => next(),
-  requireAdmin: (_req: any, _res: any, next: any) => next(),
-  requireManager: (_req: any, _res: any, next: any) => next(),
+  requirePermission: () => (_req: any, _res: any, next: any) => next(),
+  userHasPermission: (user: any, code: string) =>
+    Boolean(user && user.permissions && user.permissions.includes(code)),
 }));
 
 jest.mock('../services/PolicyService');

--- a/backend/src/__tests__/routes.users.test.ts
+++ b/backend/src/__tests__/routes.users.test.ts
@@ -18,17 +18,19 @@ let currentUser: { id: number; role: 'admin' | 'manager' | 'employee'; email: st
 
 jest.mock('../middleware/auth', () => ({
   authenticate: (req: any, _res: any, next: any) => {
-    req.user = { ...currentUser, isActive: true };
+    req.user = { ...currentUser, isActive: true, permissions: require("./helpers/permissions").permissionsForRole(currentUser.role) };
     next();
   },
-  requireRole: () => (_req: any, _res: any, next: any) => next(),
-  requireAdmin: (_req: any, _res: any, next: any) => next(),
-  requireManager: (_req: any, _res: any, next: any) => next(),
+  requirePermission: () => (_req: any, _res: any, next: any) => next(),
+  userHasPermission: (user: any, code: string) =>
+    Boolean(user && user.permissions && user.permissions.includes(code)),
 }));
 
 jest.mock('../services/UserService');
+jest.mock('../services/RbacService');
 
 import { UserService } from '../services/UserService';
+import { RbacService } from '../services/RbacService';
 import { createUsersRouter } from '../routes/users';
 
 const fakePool = {} as never;
@@ -43,6 +45,10 @@ const mountApp = (): express.Express => {
 beforeEach(() => {
   jest.clearAllMocks();
   currentUser = { id: 1, role: 'admin', email: 'admin@example' };
+  // Default RbacService stubs (auto-mock always returns undefined by default).
+  (RbacService.prototype.getRoleById as jest.Mock).mockResolvedValue(null);
+  (RbacService.prototype.getEffectivePermissions as jest.Mock).mockResolvedValue([]);
+  (RbacService.prototype.getUserRoles as jest.Mock).mockResolvedValue([]);
 });
 
 describe('users router GET /', () => {
@@ -50,10 +56,10 @@ describe('users router GET /', () => {
     const all = jest.fn().mockResolvedValue([{ id: 1 }]);
     (UserService.prototype.getAllUsers as jest.Mock) = all;
     const res = await request(mountApp()).get(
-      '/api/users?search=foo&department=2&role=manager'
+      '/api/users?search=foo&department=2&roleId=3'
     );
     expect(res.status).toBe(200);
-    expect(all).toHaveBeenCalledWith({ search: 'foo', departmentId: 2, role: 'manager' });
+    expect(all).toHaveBeenCalledWith({ search: 'foo', departmentId: 2, roleId: 3 });
   });
 
   it('admin lists without optional filters', async () => {
@@ -61,7 +67,7 @@ describe('users router GET /', () => {
     (UserService.prototype.getAllUsers as jest.Mock) = all;
     const res = await request(mountApp()).get('/api/users');
     expect(res.status).toBe(200);
-    expect(all).toHaveBeenCalledWith({ search: undefined, departmentId: undefined, role: undefined });
+    expect(all).toHaveBeenCalledWith({ search: undefined, departmentId: undefined, roleId: undefined });
   });
 
   it('manager lists only own scope and applies post-filtering', async () => {
@@ -130,35 +136,36 @@ describe('users router POST /', () => {
     expect(res.body.data.id).toBe(11);
   });
 
-  it('returns 403 when a manager tries to create an admin', async () => {
+  it('returns 403 when a manager tries to assign a role with escalated permissions', async () => {
     currentUser = { id: 9, role: 'manager', email: 'm@x' };
     const create = jest.fn().mockResolvedValue({ id: 11 });
     (UserService.prototype.createUser as jest.Mock) = create;
+    // The roleId 99 maps to a role with settings.manage which the manager doesn't hold.
+    (RbacService.prototype.getRoleById as jest.Mock).mockResolvedValue({
+      id: 99,
+      name: 'Administrator',
+      isSystem: true,
+      permissions: ['settings.manage', 'role.manage'],
+    });
     const res = await request(mountApp())
       .post('/api/users')
-      .send({
-        email: 'a@x.com',
-        password: 'pw1234',
-        firstName: 'A',
-        lastName: 'B',
-        role: 'admin',
-      });
+      .send({ email: 'a@x.com', password: 'pw1234', firstName: 'A', lastName: 'B', roleIds: [99] });
     expect(res.status).toBe(403);
     expect(res.body.error.code).toBe('FORBIDDEN');
     expect(create).not.toHaveBeenCalled();
   });
 
-  it('allows an admin to create an admin', async () => {
+  it('allows an admin to assign any role', async () => {
     (UserService.prototype.createUser as jest.Mock) = jest.fn().mockResolvedValue({ id: 12 });
+    (RbacService.prototype.getRoleById as jest.Mock).mockResolvedValue({
+      id: 99,
+      name: 'Administrator',
+      isSystem: true,
+      permissions: ['settings.manage', 'role.manage'],
+    });
     const res = await request(mountApp())
       .post('/api/users')
-      .send({
-        email: 'a@x.com',
-        password: 'pw1234',
-        firstName: 'A',
-        lastName: 'B',
-        role: 'admin',
-      });
+      .send({ email: 'a@x.com', password: 'pw1234', firstName: 'A', lastName: 'B', roleIds: [99] });
     expect(res.status).toBe(201);
     expect(res.body.data.id).toBe(12);
   });
@@ -244,28 +251,40 @@ describe('users router PUT /:id', () => {
     expect(res.status).toBe(403);
   });
 
-  it('returns 403 when a manager tries to change a role', async () => {
+  it('returns 403 when a manager tries to assign a privileged role', async () => {
     currentUser = { id: 9, role: 'manager', email: 'm@x' };
     const update = jest.fn().mockResolvedValue({ id: 3 });
     (UserService.prototype.updateUser as jest.Mock) = update;
-    const res = await request(mountApp()).put('/api/users/3').send({ role: 'admin' });
+    (RbacService.prototype.getRoleById as jest.Mock).mockResolvedValue({
+      id: 99,
+      name: 'Administrator',
+      isSystem: true,
+      permissions: ['settings.manage', 'role.manage'],
+    });
+    const res = await request(mountApp()).put('/api/users/3').send({ roleIds: [99] });
     expect(res.status).toBe(403);
     expect(res.body.error.code).toBe('FORBIDDEN');
     expect(update).not.toHaveBeenCalled();
   });
 
-  it('returns 403 when a user tries to promote themselves', async () => {
+  it('returns 403 when a user tries to change their own roles', async () => {
     const update = jest.fn().mockResolvedValue({ id: 1 });
     (UserService.prototype.updateUser as jest.Mock) = update;
-    const res = await request(mountApp()).put('/api/users/1').send({ role: 'admin' });
+    const res = await request(mountApp()).put('/api/users/1').send({ roleIds: [2] });
     expect(res.status).toBe(403);
     expect(res.body.error.code).toBe('FORBIDDEN');
     expect(update).not.toHaveBeenCalled();
   });
 
-  it('allows an admin to change another user role', async () => {
+  it('allows an admin to assign a role to another user', async () => {
     (UserService.prototype.updateUser as jest.Mock) = jest.fn().mockResolvedValue({ id: 9 });
-    const res = await request(mountApp()).put('/api/users/9').send({ role: 'manager' });
+    (RbacService.prototype.getRoleById as jest.Mock).mockResolvedValue({
+      id: 2,
+      name: 'Manager',
+      isSystem: false,
+      permissions: ['schedule.manage'],
+    });
+    const res = await request(mountApp()).put('/api/users/9').send({ roleIds: [2] });
     expect(res.status).toBe(200);
     expect(res.body.data.id).toBe(9);
   });

--- a/backend/src/__tests__/services.bulk.extended.test.ts
+++ b/backend/src/__tests__/services.bulk.extended.test.ts
@@ -70,16 +70,14 @@ describe('EmployeeService', () => {
     await expect(svc.getAllEmployees()).rejects.toThrow(/boom/);
   });
 
-  it('getEmployeeById returns null for non-employee role and bubbles errors', async () => {
+  it('getEmployeeById returns the user, null when missing, and bubbles errors', async () => {
     const { pool, execute } = makePool();
     execute
-      .mockResolvedValueOnce([[employee], null] as Tuple)
-      .mockResolvedValueOnce([[], null] as Tuple)
-      .mockResolvedValueOnce([[], null] as Tuple)
-      .mockResolvedValueOnce([[{ ...employee, role: 'admin' }], null] as Tuple)
-      .mockResolvedValueOnce([[], null] as Tuple)
-      .mockResolvedValueOnce([[], null] as Tuple)
-      .mockRejectedValueOnce(new Error('boom'));
+      .mockResolvedValueOnce([[employee], null] as Tuple) // getUserById #1: user row
+      .mockResolvedValueOnce([[], null] as Tuple) // departments
+      .mockResolvedValueOnce([[], null] as Tuple) // skills
+      .mockResolvedValueOnce([[], null] as Tuple) // getUserById #2: no user -> null
+      .mockRejectedValueOnce(new Error('boom')); // getUserById #3: throws
     const svc = new EmployeeService(pool);
     expect((await svc.getEmployeeById(1))?.id).toBe(1);
     expect(await svc.getEmployeeById(1)).toBeNull();
@@ -96,17 +94,17 @@ describe('EmployeeService', () => {
     await expect(svc.getEmployeesByDepartment(3)).rejects.toThrow(/boom/);
   });
 
-  it('getEmployeeStatistics aggregates active/inactive', async () => {
+  it('getEmployeeStatistics aggregates active/inactive from user stats', async () => {
     const { pool, execute } = makePool();
     execute
       .mockResolvedValueOnce([[{ count: 10 }], null] as Tuple)
       .mockResolvedValueOnce([[{ count: 8 }], null] as Tuple)
-      .mockResolvedValueOnce([[{ role: 'employee', count: 4 }], null] as Tuple)
-      .mockResolvedValueOnce([[employee, { ...employee, is_active: 0 }], null] as Tuple);
+      .mockResolvedValueOnce([[{ role: 'Employee', count: 10 }], null] as Tuple);
     const svc = new EmployeeService(pool);
     const s = await svc.getEmployeeStatistics();
-    expect(s.total).toBe(4);
-    expect(s.active).toBe(1);
+    expect(s.total).toBe(10);
+    expect(s.active).toBe(8);
+    expect(s.inactive).toBe(2);
   });
 
   it('getEmployeeStatistics propagates errors', async () => {
@@ -128,17 +126,12 @@ describe('EmployeeService', () => {
     );
   });
 
-  it('createEmployee forces role=employee and bubbles', async () => {
+  it('createEmployee delegates to createUser and bubbles', async () => {
     const { pool, conn } = makePool();
     conn.execute.mockRejectedValueOnce(new Error('boom'));
     const svc = new EmployeeService(pool);
     await expect(
-      svc.createEmployee({
-        email: 'a@b',
-        password: 'p',
-        firstName: 'A',
-        lastName: 'B',
-      })
+      svc.createEmployee({ email: 'a@b', password: 'p', firstName: 'A', lastName: 'B' })
     ).rejects.toThrow(/boom/);
   });
 

--- a/backend/src/__tests__/services.extended.test.ts
+++ b/backend/src/__tests__/services.extended.test.ts
@@ -50,7 +50,7 @@ const matrixRow = (overrides: Record<string, unknown> = {}) => ({
   id: 1,
   change_type: 'Policy.Exception',
   approver_scope: 'policy_owner',
-  approver_role: null,
+  approver_role_id: null,
   approver_user_id: null,
   auto_approve_for_owner: 1,
   description: null,
@@ -689,7 +689,7 @@ describe('ApprovalMatrixService', () => {
     const { pool, execute } = makePool();
     execute
       .mockResolvedValueOnce([
-        [matrixRow({ approver_scope: 'company_role', approver_role: 'admin' })],
+        [matrixRow({ approver_scope: 'company_role', approver_role_id: 1 })],
         null,
       ] as Tuple)
       .mockResolvedValueOnce([[{ id: 1 }], null] as Tuple);
@@ -701,7 +701,7 @@ describe('ApprovalMatrixService', () => {
   it('company_role returns null without role', async () => {
     const { pool, execute } = makePool();
     execute.mockResolvedValueOnce([
-      [matrixRow({ approver_scope: 'company_role', approver_role: null })],
+      [matrixRow({ approver_scope: 'company_role', approver_role_id: null })],
       null,
     ] as Tuple);
     const svc = new ApprovalMatrixService(pool);

--- a/backend/src/__tests__/user.service.extended.test.ts
+++ b/backend/src/__tests__/user.service.extended.test.ts
@@ -145,13 +145,12 @@ describe('UserService.getAllUsers filters', () => {
       .mockRejectedValueOnce(new Error('boom'));
     const svc = new UserService(pool);
     const out = await svc.getAllUsers({
-      role: 'manager',
-      departmentId: 3,
+      roleId: 1, departmentId: 3,
       isActive: false,
       search: 'foo',
     });
     expect(out.length).toBe(1);
-    await expect(svc.getAllUsers({ role: 'admin' })).rejects.toThrow(/boom/);
+    await expect(svc.getAllUsers({ roleId: 1 })).rejects.toThrow(/boom/);
   });
 });
 
@@ -338,7 +337,7 @@ describe('UserService getters / stats', () => {
     execute.mockResolvedValue([[userRow], null] as Tuple);
     const svc = new UserService(pool);
     expect((await svc.getUsersByDepartment(3)).length).toBe(1);
-    expect((await svc.getUsersByRole('manager')).length).toBe(1);
+    expect((await svc.getUsersByRoleId(2)).length).toBe(1);
   });
 
   it('getUserStatistics returns aggregates and bubbles errors', async () => {
@@ -360,7 +359,7 @@ describe('UserService getters / stats', () => {
     const { pool, execute } = makePool();
     execute.mockResolvedValueOnce([[userRow], null] as Tuple);
     const svc = new UserService(pool);
-    expect((await svc.getUsersForManager(1, 'admin')).length).toBe(1);
+    expect((await svc.getUsersForManager({ id: 1, email: 'a@x', isActive: true, permissions: ['settings.manage'] } as never)).length).toBe(1);
   });
 
   it('getUsersForManager manager path filters by manager and bubbles errors', async () => {
@@ -369,7 +368,7 @@ describe('UserService getters / stats', () => {
       .mockResolvedValueOnce([[userRow], null] as Tuple)
       .mockRejectedValueOnce(new Error('boom'));
     const svc = new UserService(pool);
-    expect((await svc.getUsersForManager(1, 'manager')).length).toBe(1);
-    await expect(svc.getUsersForManager(1, 'manager')).rejects.toThrow(/boom/);
+    expect((await svc.getUsersForManager({ id: 1, email: 'm@x', isActive: true, permissions: [] } as never)).length).toBe(1);
+    await expect(svc.getUsersForManager({ id: 1, email: 'm@x', isActive: true, permissions: [] } as never)).rejects.toThrow(/boom/);
   });
 });

--- a/backend/src/__tests__/user.service.test.ts
+++ b/backend/src/__tests__/user.service.test.ts
@@ -111,10 +111,10 @@ describe('UserService.getAllUsers', () => {
     const { pool, execute } = makePool();
     execute.mockResolvedValueOnce([[buildUserRow()], null]);
     const service = new UserService(pool);
-    await service.getAllUsers({ role: 'manager', departmentId: 3, isActive: false, search: 'demo' });
+    await service.getAllUsers({ roleId: 1, departmentId: 3, isActive: false, search: 'demo' });
     const sql = execute.mock.calls[0][0] as string;
     expect(sql).toMatch(/JOIN user_departments/);
-    expect(sql).toMatch(/u\.role = \?/);
+    expect(sql).toMatch(/JOIN user_roles/);
     expect(sql).toMatch(/u\.is_active = \?/);
     expect(sql).toMatch(/LIKE \?/);
   });
@@ -190,7 +190,7 @@ describe('UserService.getUsersForManager', () => {
     const { pool, execute } = makePool();
     execute.mockResolvedValueOnce([[buildUserRow()], null]);
     const service = new UserService(pool);
-    const users = await service.getUsersForManager(1, 'admin');
+    const users = await service.getUsersForManager({ id: 1, email: 'a@x', isActive: true, permissions: ['settings.manage'] } as never);
     expect(users).toHaveLength(1);
   });
 
@@ -198,7 +198,7 @@ describe('UserService.getUsersForManager', () => {
     const { pool, execute } = makePool();
     execute.mockResolvedValueOnce([[buildUserRow()], null]);
     const service = new UserService(pool);
-    const users = await service.getUsersForManager(1, 'manager');
+    const users = await service.getUsersForManager({ id: 1, email: 'm@x', isActive: true, permissions: [] } as never);
     expect(users).toHaveLength(1);
     expect(execute.mock.calls[0][0]).toMatch(/d\.manager_id = \?/);
   });

--- a/backend/src/__tests__/userDirectory.service.extended.test.ts
+++ b/backend/src/__tests__/userDirectory.service.extended.test.ts
@@ -69,10 +69,11 @@ describe('UserDirectoryService.importVcf — custom X- fields are persisted', ()
     expect(cfCall[1]).toContain('Engineering');
   });
 
-  it('skips X-EMPLOYEE-ID and X-ROLE when storing custom fields', async () => {
+  it('skips X-EMPLOYEE-ID and X-ROLE custom-field storage but assigns the role by name', async () => {
     const { pool, conn } = makePool();
-    conn.execute.mockResolvedValueOnce([[], null]);
-    conn.execute.mockResolvedValueOnce([{ insertId: 6 }, null]);
+    conn.execute.mockResolvedValueOnce([[], null]);            // duplicate-email check
+    conn.execute.mockResolvedValueOnce([{ insertId: 6 }, null]); // INSERT user
+    conn.execute.mockResolvedValueOnce([{ affectedRows: 0 }, null]); // INSERT IGNORE user_roles
 
     const vcf =
       'BEGIN:VCARD\r\n' +
@@ -80,14 +81,19 @@ describe('UserDirectoryService.importVcf — custom X- fields are persisted', ()
       'FN:Alice Admin\r\n' +
       'EMAIL:alice@example.com\r\n' +
       'X-EMPLOYEE-ID:E-999\r\n' +
-      'X-ROLE:admin\r\n' +
+      'X-ROLE:Administrator\r\n' +
       'END:VCARD\r\n';
 
     const service = new UserDirectoryService(pool);
     const out = await service.importVcf(vcf, { defaultPasswordHash: 'hash', createdBy: 1 });
 
     expect(out.inserted).toBe(1);
-    expect(conn.execute).toHaveBeenCalledTimes(2);
+    // 3 calls: duplicate check, INSERT user, INSERT IGNORE user_roles
+    expect(conn.execute).toHaveBeenCalledTimes(3);
+    // No custom_fields INSERT should have been called (X-ROLE and X-EMPLOYEE-ID are reserved).
+    expect(conn.execute.mock.calls.some((c: any[]) =>
+      typeof c[0] === 'string' && c[0].includes('user_custom_fields')
+    )).toBe(false);
   });
 });
 

--- a/backend/src/__tests__/userDirectory.service.test.ts
+++ b/backend/src/__tests__/userDirectory.service.test.ts
@@ -46,6 +46,7 @@ describe('UserDirectoryService.getProfile', () => {
         ],
         null,
       ])
+      .mockResolvedValueOnce([[{ name: 'Employee' }], null])
       .mockResolvedValueOnce([
         [
           { field_key: 'birthday', field_value: '1990-01-01', is_public: 1 },
@@ -103,6 +104,7 @@ describe('UserDirectoryService.exportVcf', () => {
         ],
         null,
       ])
+      .mockResolvedValueOnce([[{ name: 'Employee' }], null])
       .mockResolvedValueOnce([
         [{ field_key: 'birthday', field_value: '1990-01-01', is_public: 1 }],
         null,
@@ -132,6 +134,7 @@ describe('UserDirectoryService.exportVcf', () => {
         ],
         null,
       ])
+      .mockResolvedValueOnce([[{ name: 'Employee' }], null])
       .mockResolvedValueOnce([
         [{ field_key: 'allergies', field_value: 'penicillin', is_public: 0 }],
         null,

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -45,6 +45,7 @@ import { createBulkImportRouter } from './routes/bulkImport';
 import { createEventsRouter } from './routes/events';
 import { createOrgRouter } from './routes/org';
 import { createPoliciesRouter } from './routes/policies';
+import { createRbacRouter } from './routes/rbac';
 
 interface BuildAppOptions {
   /** When true, skip rate limiting + morgan logging (useful for tests). */
@@ -118,6 +119,9 @@ export function buildApp(pool: Pool, options: BuildAppOptions = {}): express.Exp
   app.use('/api/events', createEventsRouter());
   app.use('/api/org', createOrgRouter(pool));
   app.use('/api/policies', createPoliciesRouter(pool));
+  const rbacRouters = createRbacRouter(pool);
+  app.use('/api/roles', rbacRouters.roles);
+  app.use('/api/permissions', rbacRouters.permissions);
 
   app.use('*', (_req: express.Request, res: express.Response) => {
     res.status(404).json({

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -1,9 +1,13 @@
 /**
- * Authentication Middleware
- * 
- * Updated to work with the real database schema and user roles.
- * Implements JWT-based authentication with proper role checking.
- * 
+ * Authentication & Authorization Middleware
+ *
+ * JWT-based authentication plus permission-based authorization. The former
+ * hardcoded role checks (`requireAdmin` / `requireManager` / `requireRole`)
+ * have been replaced by `requirePermission(code)`, which consults the user's
+ * effective permissions resolved from the configurable RBAC model. The token
+ * carries only the user id; permissions are resolved from the database on every
+ * request so role/permission changes take effect immediately.
+ *
  * @author Luca Ostinelli
  */
 
@@ -11,6 +15,7 @@ import { Request, Response, NextFunction } from 'express';
 import jwt from 'jsonwebtoken';
 import { User } from '../types';
 import { UserService } from '../services/UserService';
+import { RbacService } from '../services/RbacService';
 import { config } from '../config';
 import { logger } from '../config/logger';
 import { database } from '../config/database';
@@ -28,20 +33,25 @@ declare module 'express-serve-static-core' {
 interface JWTPayload {
   userId: string;
   email: string;
-  role: 'admin' | 'manager' | 'employee';
   iat?: number;
   exp?: number;
 }
 
 /**
+ * Returns true when the authenticated user holds the given permission code.
+ * Safe to call in route bodies for finer-grained, in-handler authorization.
+ */
+export const userHasPermission = (user: User | undefined, code: string): boolean =>
+  Boolean(user?.permissions?.includes(code));
+
+/**
  * Main Authentication Middleware
- * 
- * Validates JWT tokens and loads user information into the request context.
- * All protected routes must use this middleware.
+ *
+ * Validates JWT tokens, loads the user and their effective permissions into the
+ * request context. All protected routes must use this middleware.
  */
 export const authenticate = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    // Extract token from Authorization header
     const authHeader = req.headers.authorization;
     if (!authHeader || !authHeader.startsWith('Bearer ')) {
       return res.status(401).json({
@@ -55,7 +65,6 @@ export const authenticate = async (req: Request, res: Response, next: NextFuncti
 
     const token = authHeader.substring(7); // Remove 'Bearer ' prefix
 
-    // Verify and decode JWT token
     let decodedToken: JWTPayload;
     try {
       decodedToken = jwt.verify(token, config.jwt.secret) as JWTPayload;
@@ -69,9 +78,10 @@ export const authenticate = async (req: Request, res: Response, next: NextFuncti
       });
     }
 
-    // Get user from database
-    const userService = new UserService(database.getPool());
-    const user = await userService.getUserById(parseInt(decodedToken.userId.toString()));
+    const pool = database.getPool();
+    const userService = new UserService(pool);
+    const userId = parseInt(decodedToken.userId.toString());
+    const user = await userService.getUserById(userId);
     if (!user || !user.isActive) {
       return res.status(401).json({
         success: false,
@@ -82,14 +92,18 @@ export const authenticate = async (req: Request, res: Response, next: NextFuncti
       });
     }
 
-    // Attach user to request object
+    // Resolve effective permissions and role assignments for this request.
+    const rbac = new RbacService(pool);
+    const [permissions, roles] = await Promise.all([
+      rbac.getEffectivePermissions(userId),
+      rbac.getUserRoles(userId),
+    ]);
+    user.permissions = permissions;
+    user.roles = roles;
+
     req.user = user;
 
-    // Log authentication success at debug level without PII (no email/path)
-    logger.debug('User authenticated', {
-      userId: user.id,
-      role: user.role
-    });
+    logger.debug('User authenticated', { userId: user.id });
 
     next();
   } catch (error) {
@@ -105,17 +119,17 @@ export const authenticate = async (req: Request, res: Response, next: NextFuncti
 };
 
 /**
- * Role-based Authorization Middleware
- * 
- * Restricts access based on user roles. Supports multiple roles.
- * 
- * @param roles - Array of allowed roles
- * @returns Express middleware function
+ * Permission-based Authorization Middleware
+ *
+ * Restricts access to users holding the given permission code. Replaces the
+ * previous role-based guards.
+ *
+ * @param code - Required permission code (e.g. `schedule.manage`)
  */
-export const requireRole = (roles: Array<'admin' | 'manager' | 'employee'>) => {
+export const requirePermission = (code: string) => {
   return (req: Request, res: Response, next: NextFunction) => {
     const user = req.user;
-    
+
     if (!user) {
       return res.status(401).json({
         success: false,
@@ -126,7 +140,7 @@ export const requireRole = (roles: Array<'admin' | 'manager' | 'employee'>) => {
       });
     }
 
-    if (!roles.includes(user.role)) {
+    if (!userHasPermission(user, code)) {
       return res.status(403).json({
         success: false,
         error: {
@@ -139,20 +153,3 @@ export const requireRole = (roles: Array<'admin' | 'manager' | 'employee'>) => {
     next();
   };
 };
-
-/**
- * Admin Only Middleware
- * 
- * Restricts access to admin users only.
- * Used for system-wide administrative functions.
- */
-export const requireAdmin = requireRole(['admin']);
-
-/**
- * Manager and Above Middleware
- * 
- * Allows access to admin and manager roles.
- * Used for management functions.
- */
-export const requireManager = requireRole(['admin', 'manager']);
-

--- a/backend/src/routes/assignments.ts
+++ b/backend/src/routes/assignments.ts
@@ -1,7 +1,7 @@
 import { Router, Request, Response } from 'express';
 import { Pool } from 'mysql2/promise';
 import { AssignmentService } from '../services/AssignmentService';
-import { authenticate, requireRole } from '../middleware/auth';
+import { authenticate, requirePermission } from '../middleware/auth';
 import { logger } from '../config/logger';
 
 export const createAssignmentsRouter = (pool: Pool) => {
@@ -52,7 +52,7 @@ router.get('/:id', authenticate, async (req: Request, res: Response) => {
 });
 
 // Create new assignment
-router.post('/', authenticate, requireRole(['admin', 'manager']), async (req: Request, res: Response) => {
+router.post('/', authenticate, requirePermission('assignment.manage'), async (req: Request, res: Response) => {
   try {
     const assignment = await assignmentService.createAssignment(req.body);
 
@@ -72,7 +72,7 @@ router.post('/', authenticate, requireRole(['admin', 'manager']), async (req: Re
 });
 
 // Update assignment
-router.put('/:id', authenticate, requireRole(['admin', 'manager']), async (req: Request, res: Response) => {
+router.put('/:id', authenticate, requirePermission('assignment.manage'), async (req: Request, res: Response) => {
   try {
     const id = parseInt(req.params.id);
     if (isNaN(id)) {
@@ -102,7 +102,7 @@ router.put('/:id', authenticate, requireRole(['admin', 'manager']), async (req: 
 });
 
 // Delete assignment
-router.delete('/:id', authenticate, requireRole(['admin', 'manager']), async (req: Request, res: Response) => {
+router.delete('/:id', authenticate, requirePermission('assignment.manage'), async (req: Request, res: Response) => {
   try {
     const id = parseInt(req.params.id);
     if (isNaN(id)) {
@@ -201,7 +201,7 @@ router.get('/department/:departmentId', authenticate, async (req: Request, res: 
 });
 
 // Bulk create assignments
-router.post('/bulk', authenticate, requireRole(['admin', 'manager']), async (req: Request, res: Response) => {
+router.post('/bulk', authenticate, requirePermission('assignment.manage'), async (req: Request, res: Response) => {
   try {
     const { assignments } = req.body;
     if (!Array.isArray(assignments)) {

--- a/backend/src/routes/auditLogs.ts
+++ b/backend/src/routes/auditLogs.ts
@@ -6,14 +6,14 @@
 
 import { Pool } from 'mysql2/promise';
 import { Router, Request, Response } from 'express';
-import { authenticate, requireManager } from '../middleware/auth';
+import { authenticate, requirePermission } from '../middleware/auth';
 import { AuditLogService } from '../services/AuditLogService';
 
 export const createAuditLogsRouter = (pool: Pool): Router => {
   const router = Router();
   const service = new AuditLogService(pool);
 
-  router.use(authenticate, requireManager);
+  router.use(authenticate, requirePermission('audit.read'));
 
   router.get('/', async (req: Request, res: Response) => {
     const page = await service.list({

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -17,6 +17,7 @@ import { Router, Request, Response } from 'express';
 import { Pool } from 'mysql2/promise';
 import rateLimit from 'express-rate-limit';
 import { UserService } from '../services/UserService';
+import { RbacService } from '../services/RbacService';
 import { authenticate } from '../middleware/auth';
 import jwt, { SignOptions } from 'jsonwebtoken';
 
@@ -31,6 +32,7 @@ import { config } from '../config';
 export const createAuthRouter = (pool: Pool) => {
   const router = Router();
   const userService = new UserService(pool);
+  const rbacService = new RbacService(pool);
 
   // Shared JWT signing options, driven by configuration rather than hardcoded.
   const jwtSignOptions: SignOptions = {
@@ -113,23 +115,31 @@ router.post('/login', loginLimiter, async (req: Request, res: Response) => {
       });
     }
 
-    // Generate JWT token
+    // Resolve effective permissions/roles so the client can gate its UI.
+    const [permissions, roles] = await Promise.all([
+      rbacService.getEffectivePermissions(user.id),
+      rbacService.getUserRoles(user.id),
+    ]);
+
+    // Generate JWT token. Only the user id is embedded; permissions are
+    // resolved from the database on every request by the auth middleware.
     const token = jwt.sign(
-      { userId: user.id, email: user.email, role: user.role },
+      { userId: user.id, email: user.email },
       config.jwt.secret,
       jwtSignOptions
     );
-    
+
     res.json({
       success: true,
-      data: { 
+      data: {
         token,
         user: {
           id: user.id,
           email: user.email,
           firstName: user.firstName,
           lastName: user.lastName,
-          role: user.role
+          roles,
+          permissions
         }
       }
     });
@@ -208,7 +218,7 @@ router.post('/refresh', authenticate, async (req: Request, res: Response) => {
     const { password_hash: _password_hash, salt: _salt, ...userWithoutPassword } = user as any;
 
     const token = jwt.sign(
-      { userId: user.id, email: user.email, role: user.role },
+      { userId: user.id, email: user.email },
       config.jwt.secret,
       jwtSignOptions
     );

--- a/backend/src/routes/bulkImport.ts
+++ b/backend/src/routes/bulkImport.ts
@@ -12,7 +12,7 @@
 
 import { Pool } from 'mysql2/promise';
 import { Router, Request, Response } from 'express';
-import { authenticate, requireManager } from '../middleware/auth';
+import { authenticate, requirePermission } from '../middleware/auth';
 import { BulkImportService } from '../services/BulkImportService';
 
 const respondError = (res: Response, status: number, code: string, message: string): void => {
@@ -23,7 +23,7 @@ export const createBulkImportRouter = (pool: Pool): Router => {
   const router = Router();
   const service = new BulkImportService(pool);
 
-  router.use(authenticate, requireManager);
+  router.use(authenticate, requirePermission('employee.manage'));
 
   router.post('/employees', async (req: Request, res: Response) => {
     const csv = req.body?.csv as string | undefined;

--- a/backend/src/routes/calendar.ts
+++ b/backend/src/routes/calendar.ts
@@ -78,12 +78,20 @@ export const createCalendarRouter = (pool: Pool): Router => {
       return;
     }
 
-    // Authorisation: the token's user must be admin OR manager of the target
-    // department. We resolve role + manager_id directly on the pool to avoid
-    // pulling in the heavier UserService for a read-only check.
+    // Authorisation: the token's user must be a full administrator (holds the
+    // `settings.manage` permission) OR the manager of the target department.
+    // Permissions are resolved with a correlated EXISTS to avoid pulling in the
+    // heavier UserService/RbacService for a read-only check.
     const departmentId = Number(req.params.id);
     const [rows] = await pool.execute<RowDataPacket[]>(
-      `SELECT u.role, d.manager_id
+      `SELECT d.manager_id,
+              EXISTS(
+                SELECT 1 FROM user_roles ur
+                  JOIN role_permissions rp ON rp.role_id = ur.role_id
+                  JOIN permissions p ON p.id = rp.permission_id
+                 WHERE ur.user_id = u.id AND p.code = 'settings.manage'
+                   AND (ur.expires_at IS NULL OR ur.expires_at > NOW())
+              ) AS is_admin
          FROM users u
          LEFT JOIN departments d ON d.id = ?
         WHERE u.id = ? LIMIT 1`,
@@ -91,8 +99,7 @@ export const createCalendarRouter = (pool: Pool): Router => {
     );
     const row = rows[0];
     const allowed =
-      !!row &&
-      (row.role === 'admin' || (row.role === 'manager' && row.manager_id === userId));
+      !!row && (Number(row.is_admin) === 1 || row.manager_id === userId);
     if (!allowed) {
       res.status(403).type('text/plain').send('forbidden');
       return;

--- a/backend/src/routes/dashboard.ts
+++ b/backend/src/routes/dashboard.ts
@@ -31,9 +31,10 @@ const router = Router();
  */
 router.get('/stats', authenticate, async (_req: Request, res: Response) => {
   try {
-    // Get basic statistics
+    // Get basic statistics. Every active user is schedulable staff, so the
+    // headcount is the count of active users.
     const totalEmployeesQuery =
-      "SELECT COUNT(*) as count FROM users WHERE role = 'employee' AND is_active = TRUE";
+      'SELECT COUNT(*) as count FROM users WHERE is_active = TRUE';
     const totalEmployees = await database.queryOne<{ count: number }>(totalEmployeesQuery);
 
     const activeSchedulesQuery = 'SELECT COUNT(*) as count FROM schedules WHERE status = "published"';
@@ -256,8 +257,20 @@ router.get('/departments', authenticate, async (_req: Request, res: Response) =>
         d.name as department,
         COUNT(DISTINCT u.id) as total_employees,
         COUNT(DISTINCT CASE WHEN u.is_active = TRUE THEN u.id END) as active_employees,
-        COUNT(DISTINCT CASE WHEN u.role = 'employee' THEN u.id END) as employee_count,
-        COUNT(DISTINCT CASE WHEN u.role = 'manager' THEN u.id END) as manager_count
+        COUNT(DISTINCT CASE WHEN NOT EXISTS (
+          SELECT 1 FROM user_roles ur
+            JOIN role_permissions rp ON rp.role_id = ur.role_id
+            JOIN permissions p ON p.id = rp.permission_id
+           WHERE ur.user_id = u.id AND p.code = 'schedule.manage'
+             AND (ur.expires_at IS NULL OR ur.expires_at > NOW())
+        ) THEN u.id END) as employee_count,
+        COUNT(DISTINCT CASE WHEN EXISTS (
+          SELECT 1 FROM user_roles ur
+            JOIN role_permissions rp ON rp.role_id = ur.role_id
+            JOIN permissions p ON p.id = rp.permission_id
+           WHERE ur.user_id = u.id AND p.code = 'schedule.manage'
+             AND (ur.expires_at IS NULL OR ur.expires_at > NOW())
+        ) THEN u.id END) as manager_count
       FROM departments d
       LEFT JOIN user_departments ud ON d.id = ud.department_id
       LEFT JOIN users u ON ud.user_id = u.id

--- a/backend/src/routes/departments.ts
+++ b/backend/src/routes/departments.ts
@@ -2,7 +2,7 @@ import { Router } from 'express';
 import { Pool } from 'mysql2/promise';
 import { DepartmentService } from '../services/DepartmentService';
 import { UserService } from '../services/UserService';
-import { authenticate } from '../middleware/auth';
+import { authenticate, userHasPermission } from '../middleware/auth';
 import { CreateDepartmentRequest, UpdateDepartmentRequest } from '../types';
 import { logger } from '../config/logger';
 
@@ -17,7 +17,7 @@ export const createDepartmentsRouter = (pool: Pool) => {
       const user = (req as any).user;
 
       let departments;
-      if (user.role === 'admin') {
+      if (userHasPermission(user, 'settings.manage')) {
         departments = await departmentService.getAllDepartments();
       } else {
         departments = await departmentService.getDepartmentsForUser(user.id);
@@ -39,7 +39,7 @@ export const createDepartmentsRouter = (pool: Pool) => {
       const user = (req as any).user;
       const departmentId = parseInt(req.params.id);
 
-      if (user.role !== 'admin') {
+      if (!userHasPermission(user, 'settings.manage')) {
         const userDepartments = await departmentService.getDepartmentsForUser(user.id);
         const hasAccess = userDepartments.some((d: any) => d.id === departmentId);
 
@@ -74,7 +74,7 @@ export const createDepartmentsRouter = (pool: Pool) => {
     try {
       const user = (req as any).user;
 
-      if (!['admin', 'manager'].includes(user.role)) {
+      if (!userHasPermission(user, 'department.manage')) {
         return res.status(403).json({
           success: false,
           error: { code: 'FORBIDDEN', message: 'Insufficient permissions' }
@@ -90,19 +90,14 @@ export const createDepartmentsRouter = (pool: Pool) => {
         });
       }
 
+      // Any existing user may be designated as a department manager; the
+      // configurable role model no longer restricts this to specific roles.
       if (departmentData.managerId) {
         const manager = await userService.getUserById(departmentData.managerId);
         if (!manager) {
           return res.status(400).json({
             success: false,
             error: { code: 'INVALID_INPUT', message: 'Specified manager not found' }
-          });
-        }
-
-        if (!['admin', 'manager'].includes(manager.role)) {
-          return res.status(400).json({
-            success: false,
-            error: { code: 'INVALID_INPUT', message: 'Specified user cannot be a department manager' }
           });
         }
       }
@@ -126,9 +121,9 @@ export const createDepartmentsRouter = (pool: Pool) => {
       const departmentId = parseInt(req.params.id);
       const departmentData: UpdateDepartmentRequest = req.body;
 
-      if (user.role === 'admin') {
-        // Admin can update any department
-      } else if (user.role === 'manager') {
+      if (userHasPermission(user, 'settings.manage')) {
+        // Full administrators can update any department
+      } else if (userHasPermission(user, 'department.manage')) {
         const userDepartments = await departmentService.getDepartmentsForUser(user.id);
         const canManage = userDepartments.some((d: any) => d.id === departmentId && d.managerId === user.id);
 
@@ -145,19 +140,13 @@ export const createDepartmentsRouter = (pool: Pool) => {
         });
       }
 
+      // Any existing user may be designated as a department manager.
       if (departmentData.managerId) {
         const manager = await userService.getUserById(departmentData.managerId);
         if (!manager) {
           return res.status(400).json({
             success: false,
             error: { code: 'INVALID_INPUT', message: 'Specified manager not found' }
-          });
-        }
-
-        if (!['admin', 'manager'].includes(manager.role)) {
-          return res.status(400).json({
-            success: false,
-            error: { code: 'INVALID_INPUT', message: 'Specified user cannot be a department manager' }
           });
         }
       }
@@ -180,7 +169,7 @@ export const createDepartmentsRouter = (pool: Pool) => {
       const user = (req as any).user;
       const departmentId = parseInt(req.params.id);
 
-      if (user.role !== 'admin') {
+      if (!userHasPermission(user, 'settings.manage')) {
         return res.status(403).json({
           success: false,
           error: { code: 'FORBIDDEN', message: 'Only administrators can delete departments' }
@@ -214,9 +203,9 @@ export const createDepartmentsRouter = (pool: Pool) => {
       const departmentId = parseInt(req.params.id);
       const { userId } = req.body;
 
-      if (user.role === 'admin') {
-        // Admin can add users to any department
-      } else if (['admin', 'manager'].includes(user.role)) {
+      if (userHasPermission(user, 'settings.manage')) {
+        // Full administrators can add users to any department
+      } else if (userHasPermission(user, 'department.manage')) {
         const userDepartments = await departmentService.getDepartmentsForUser(user.id);
         const canManage = userDepartments.some((d: any) => d.id === departmentId && d.managerId === user.id);
 
@@ -268,9 +257,9 @@ export const createDepartmentsRouter = (pool: Pool) => {
       const departmentId = parseInt(req.params.id);
       const targetUserId = parseInt(req.params.userId);
 
-      if (user.role === 'admin') {
-        // Admin can remove users from any department
-      } else if (['admin', 'manager'].includes(user.role)) {
+      if (userHasPermission(user, 'settings.manage')) {
+        // Full administrators can remove users from any department
+      } else if (userHasPermission(user, 'department.manage')) {
         const userDepartments = await departmentService.getDepartmentsForUser(user.id);
         const canManage = userDepartments.some((d: any) => d.id === departmentId && d.managerId === user.id);
 
@@ -305,7 +294,7 @@ export const createDepartmentsRouter = (pool: Pool) => {
       const user = (req as any).user;
       const departmentId = parseInt(req.params.id);
 
-      if (user.role !== 'admin') {
+      if (!userHasPermission(user, 'settings.manage')) {
         const userDepartments = await departmentService.getDepartmentsForUser(user.id);
         const hasAccess = userDepartments.some((d: any) => d.id === departmentId);
 

--- a/backend/src/routes/directory.ts
+++ b/backend/src/routes/directory.ts
@@ -15,7 +15,7 @@
 import { Pool } from 'mysql2/promise';
 import bcrypt from 'bcrypt';
 import { Router, Request, Response } from 'express';
-import { authenticate, requireAdmin, requireManager } from '../middleware/auth';
+import { authenticate, requirePermission } from '../middleware/auth';
 import { UserDirectoryService } from '../services/UserDirectoryService';
 import { config } from '../config';
 
@@ -35,13 +35,13 @@ export const createDirectoryRouter = (pool: Pool): Router => {
     res.json({ success: true, data: profile });
   });
 
-  router.get('/users/:id', requireManager, async (req: Request, res: Response) => {
+  router.get('/users/:id', requirePermission('user.read'), async (req: Request, res: Response) => {
     const profile = await service.getProfile(Number(req.params.id));
     if (!profile) return error(res, 404, 'NOT_FOUND', 'Profile not found');
     res.json({ success: true, data: profile });
   });
 
-  router.put('/users/:id/fields', requireManager, async (req: Request, res: Response) => {
+  router.put('/users/:id/fields', requirePermission('user.manage'), async (req: Request, res: Response) => {
     try {
       const fields = Array.isArray(req.body?.fields) ? req.body.fields : [];
       await service.setFields(Number(req.params.id), fields);
@@ -54,7 +54,7 @@ export const createDirectoryRouter = (pool: Pool): Router => {
 
   router.delete(
     '/users/:id/fields/:key',
-    requireManager,
+    requirePermission('user.manage'),
     async (req: Request, res: Response) => {
       const ok = await service.removeField(Number(req.params.id), req.params.key);
       if (!ok) return error(res, 404, 'NOT_FOUND', 'Field not found');
@@ -73,7 +73,7 @@ export const createDirectoryRouter = (pool: Pool): Router => {
       .send(vcf);
   });
 
-  router.get('/vcard.vcf', requireManager, async (req: Request, res: Response) => {
+  router.get('/vcard.vcf', requirePermission('user.read'), async (req: Request, res: Response) => {
     const idsParam = (req.query.ids as string | undefined) ?? '';
     const ids = idsParam
       .split(',')
@@ -88,7 +88,7 @@ export const createDirectoryRouter = (pool: Pool): Router => {
       .send(vcf);
   });
 
-  router.post('/import-vcard', requireAdmin, async (req: Request, res: Response) => {
+  router.post('/import-vcard', requirePermission('user.manage'), async (req: Request, res: Response) => {
     try {
       const text = typeof req.body === 'string' ? req.body : (req.body?.vcf as string | undefined);
       if (!text) return error(res, 400, 'VALIDATION_ERROR', 'vcf body required');

--- a/backend/src/routes/employees.ts
+++ b/backend/src/routes/employees.ts
@@ -1,7 +1,7 @@
 import { Router, Request, Response } from 'express';
 import { Pool } from 'mysql2/promise';
 import { EmployeeService } from '../services/EmployeeService';
-import { authenticate, requireRole } from '../middleware/auth';
+import { authenticate, requirePermission } from '../middleware/auth';
 import { logger } from '../config/logger';
 
 export const createEmployeesRouter = (pool: Pool) => {
@@ -52,7 +52,7 @@ router.get('/:id', authenticate, async (req: Request, res: Response) => {
 });
 
 // Create new employee
-router.post('/', authenticate, requireRole(['admin', 'manager']), async (req: Request, res: Response) => {
+router.post('/', authenticate, requirePermission('employee.manage'), async (req: Request, res: Response) => {
   try {
     const employee = await employeeService.createEmployee(req.body);
 
@@ -71,7 +71,7 @@ router.post('/', authenticate, requireRole(['admin', 'manager']), async (req: Re
 });
 
 // Update employee
-router.put('/:id', authenticate, requireRole(['admin', 'manager']), async (req: Request, res: Response) => {
+router.put('/:id', authenticate, requirePermission('employee.manage'), async (req: Request, res: Response) => {
   try {
     const id = parseInt(req.params.id);
     if (isNaN(id)) {
@@ -101,7 +101,7 @@ router.put('/:id', authenticate, requireRole(['admin', 'manager']), async (req: 
 });
 
 // Delete employee (soft delete)
-router.delete('/:id', authenticate, requireRole(['admin', 'manager']), async (req: Request, res: Response) => {
+router.delete('/:id', authenticate, requirePermission('employee.manage'), async (req: Request, res: Response) => {
   try {
     const id = parseInt(req.params.id);
     if (isNaN(id)) {
@@ -174,7 +174,7 @@ router.get('/:id/skills', authenticate, async (req: Request, res: Response) => {
 });
 
 // Add skill to employee
-router.post('/:id/skills', authenticate, requireRole(['admin', 'manager']), async (req: Request, res: Response) => {
+router.post('/:id/skills', authenticate, requirePermission('employee.manage'), async (req: Request, res: Response) => {
   try {
     const id = parseInt(req.params.id);
     const { skillId, proficiencyLevel } = req.body;
@@ -202,7 +202,7 @@ router.post('/:id/skills', authenticate, requireRole(['admin', 'manager']), asyn
 });
 
 // Remove skill from employee
-router.delete('/:id/skills/:skillId', authenticate, requireRole(['admin', 'manager']), async (req: Request, res: Response) => {
+router.delete('/:id/skills/:skillId', authenticate, requirePermission('employee.manage'), async (req: Request, res: Response) => {
   try {
     const id = parseInt(req.params.id);
     const skillId = parseInt(req.params.skillId);

--- a/backend/src/routes/onCall.ts
+++ b/backend/src/routes/onCall.ts
@@ -16,7 +16,7 @@
 
 import { Pool } from 'mysql2/promise';
 import { Router, Request, Response } from 'express';
-import { authenticate, requireManager } from '../middleware/auth';
+import { authenticate, requirePermission } from '../middleware/auth';
 import { OnCallService } from '../services/OnCallService';
 
 const error = (res: Response, status: number, code: string, message: string): void => {
@@ -47,7 +47,7 @@ export const createOnCallRouter = (pool: Pool): Router => {
     res.json({ success: true, data });
   });
 
-  router.post('/periods', requireManager, async (req: Request, res: Response) => {
+  router.post('/periods', requirePermission('oncall.manage'), async (req: Request, res: Response) => {
     try {
       const created = await service.createPeriod(req.body || {});
       res.status(201).json({ success: true, data: created });
@@ -62,7 +62,7 @@ export const createOnCallRouter = (pool: Pool): Router => {
     res.json({ success: true, data: period });
   });
 
-  router.put('/periods/:id', requireManager, async (req: Request, res: Response) => {
+  router.put('/periods/:id', requirePermission('oncall.manage'), async (req: Request, res: Response) => {
     try {
       const updated = await service.updatePeriod(Number(req.params.id), req.body || {});
       res.json({ success: true, data: updated });
@@ -73,7 +73,7 @@ export const createOnCallRouter = (pool: Pool): Router => {
     }
   });
 
-  router.delete('/periods/:id', requireManager, async (req: Request, res: Response) => {
+  router.delete('/periods/:id', requirePermission('oncall.manage'), async (req: Request, res: Response) => {
     try {
       await service.deletePeriod(Number(req.params.id));
       res.json({ success: true });
@@ -87,7 +87,7 @@ export const createOnCallRouter = (pool: Pool): Router => {
     res.json({ success: true, data });
   });
 
-  router.post('/periods/:id/assign', requireManager, async (req: Request, res: Response) => {
+  router.post('/periods/:id/assign', requirePermission('oncall.manage'), async (req: Request, res: Response) => {
     try {
       const data = await service.assign(
         Number(req.params.id),
@@ -104,7 +104,7 @@ export const createOnCallRouter = (pool: Pool): Router => {
     }
   });
 
-  router.delete('/periods/:id/assign/:userId', requireManager, async (req: Request, res: Response) => {
+  router.delete('/periods/:id/assign/:userId', requirePermission('oncall.manage'), async (req: Request, res: Response) => {
     const ok = await service.unassign(Number(req.params.id), Number(req.params.userId));
     if (!ok) return error(res, 404, 'NOT_FOUND', 'Assignment not found');
     res.json({ success: true });

--- a/backend/src/routes/org.ts
+++ b/backend/src/routes/org.ts
@@ -22,7 +22,7 @@
 
 import { Pool } from 'mysql2/promise';
 import { Router, Request, Response } from 'express';
-import { authenticate, requireAdmin, requireManager } from '../middleware/auth';
+import { authenticate, requirePermission, userHasPermission } from '../middleware/auth';
 import { OrgUnitService } from '../services/OrgUnitService';
 import { EmployeeLoanService } from '../services/EmployeeLoanService';
 import { logger } from '../config/logger';
@@ -69,7 +69,7 @@ export const createOrgRouter = (pool: Pool): Router => {
     }
   });
 
-  router.post('/units', requireAdmin, async (req: Request, res: Response) => {
+  router.post('/units', requirePermission('org_unit.manage'), async (req: Request, res: Response) => {
     try {
       const created = await units.create({
         name: req.body?.name,
@@ -83,7 +83,7 @@ export const createOrgRouter = (pool: Pool): Router => {
     }
   });
 
-  router.put('/units/:id', requireAdmin, async (req: Request, res: Response) => {
+  router.put('/units/:id', requirePermission('org_unit.manage'), async (req: Request, res: Response) => {
     try {
       const updated = await units.update(Number(req.params.id), req.body ?? {});
       res.json({ success: true, data: updated });
@@ -94,7 +94,7 @@ export const createOrgRouter = (pool: Pool): Router => {
     }
   });
 
-  router.delete('/units/:id', requireAdmin, async (req: Request, res: Response) => {
+  router.delete('/units/:id', requirePermission('org_unit.manage'), async (req: Request, res: Response) => {
     try {
       await units.remove(Number(req.params.id));
       res.json({ success: true });
@@ -116,7 +116,7 @@ export const createOrgRouter = (pool: Pool): Router => {
     }
   });
 
-  router.post('/units/:id/members', requireManager, async (req: Request, res: Response) => {
+  router.post('/units/:id/members', requirePermission('employee.manage'), async (req: Request, res: Response) => {
     try {
       const userId = Number(req.body?.userId);
       if (!userId) return respondError(res, 400, 'VALIDATION_ERROR', 'userId is required');
@@ -133,7 +133,7 @@ export const createOrgRouter = (pool: Pool): Router => {
 
   router.patch(
     '/units/:id/members/:userId/primary',
-    requireManager,
+    requirePermission('employee.manage'),
     async (req: Request, res: Response) => {
       try {
         await units.setPrimary(Number(req.params.userId), Number(req.params.id));
@@ -148,7 +148,7 @@ export const createOrgRouter = (pool: Pool): Router => {
 
   router.delete(
     '/units/:id/members/:userId',
-    requireManager,
+    requirePermission('employee.manage'),
     async (req: Request, res: Response) => {
       try {
         await units.removeMember(Number(req.params.userId), Number(req.params.id));
@@ -163,7 +163,7 @@ export const createOrgRouter = (pool: Pool): Router => {
 
   router.get('/loans', async (req: Request, res: Response) => {
     try {
-      const isManager = req.user!.role === 'admin' || req.user!.role === 'manager';
+      const isManager = userHasPermission(req.user, 'loan.approve');
       const filters = isManager
         ? {
             userId: req.query.userId ? Number(req.query.userId) : undefined,
@@ -179,7 +179,7 @@ export const createOrgRouter = (pool: Pool): Router => {
     }
   });
 
-  router.post('/loans', requireManager, async (req: Request, res: Response) => {
+  router.post('/loans', requirePermission('loan.request'), async (req: Request, res: Response) => {
     try {
       const created = await loans.create({
         userId: Number(req.body?.userId),
@@ -196,7 +196,7 @@ export const createOrgRouter = (pool: Pool): Router => {
     }
   });
 
-  router.post('/loans/:id/approve', requireManager, async (req: Request, res: Response) => {
+  router.post('/loans/:id/approve', requirePermission('loan.approve'), async (req: Request, res: Response) => {
     try {
       const updated = await loans.approve(Number(req.params.id), req.user!.id, req.body?.notes ?? null);
       res.json({ success: true, data: updated });
@@ -210,7 +210,7 @@ export const createOrgRouter = (pool: Pool): Router => {
     }
   });
 
-  router.post('/loans/:id/reject', requireManager, async (req: Request, res: Response) => {
+  router.post('/loans/:id/reject', requirePermission('loan.approve'), async (req: Request, res: Response) => {
     try {
       const updated = await loans.reject(Number(req.params.id), req.user!.id, req.body?.notes ?? null);
       res.json({ success: true, data: updated });

--- a/backend/src/routes/policies.ts
+++ b/backend/src/routes/policies.ts
@@ -21,7 +21,7 @@
 
 import { Pool } from 'mysql2/promise';
 import { Router, Request, Response } from 'express';
-import { authenticate, requireAdmin, requireManager } from '../middleware/auth';
+import { authenticate, requirePermission, userHasPermission } from '../middleware/auth';
 import { PolicyService } from '../services/PolicyService';
 import { PolicyExceptionService } from '../services/PolicyExceptionService';
 import { ApprovalMatrixService } from '../services/ApprovalMatrixService';
@@ -68,7 +68,7 @@ export const createPoliciesRouter = (pool: Pool): Router => {
     }
   });
 
-  router.put('/approval-matrix/:changeType', requireAdmin, async (req: Request, res: Response) => {
+  router.put('/approval-matrix/:changeType', requirePermission('approval.manage'), async (req: Request, res: Response) => {
     try {
       const updated = await matrix.update(req.params.changeType, req.body ?? {});
       res.json({ success: true, data: updated });
@@ -83,7 +83,7 @@ export const createPoliciesRouter = (pool: Pool): Router => {
 
   router.get('/exceptions', async (req: Request, res: Response) => {
     try {
-      const isManager = req.user!.role === 'admin' || req.user!.role === 'manager';
+      const isManager = userHasPermission(req.user, 'policy.approve');
       const filters = {
         policyId: req.query.policyId ? Number(req.query.policyId) : undefined,
         targetType: (req.query.targetType as string) ?? undefined,
@@ -117,7 +117,7 @@ export const createPoliciesRouter = (pool: Pool): Router => {
     }
   });
 
-  router.post('/exceptions/:id/approve', requireManager, async (req: Request, res: Response) => {
+  router.post('/exceptions/:id/approve', requirePermission('policy.approve'), async (req: Request, res: Response) => {
     try {
       const updated = await exceptions.approve(
         Number(req.params.id),
@@ -132,7 +132,7 @@ export const createPoliciesRouter = (pool: Pool): Router => {
     }
   });
 
-  router.post('/exceptions/:id/reject', requireManager, async (req: Request, res: Response) => {
+  router.post('/exceptions/:id/reject', requirePermission('policy.approve'), async (req: Request, res: Response) => {
     try {
       const updated = await exceptions.reject(
         Number(req.params.id),
@@ -181,7 +181,7 @@ export const createPoliciesRouter = (pool: Pool): Router => {
     }
   });
 
-  router.post('/', requireManager, async (req: Request, res: Response) => {
+  router.post('/', requirePermission('policy.manage'), async (req: Request, res: Response) => {
     try {
       const created = await policies.create({
         scopeType: req.body?.scopeType,
@@ -197,13 +197,13 @@ export const createPoliciesRouter = (pool: Pool): Router => {
     }
   });
 
-  router.put('/:id', requireManager, async (req: Request, res: Response) => {
+  router.put('/:id', requirePermission('policy.manage'), async (req: Request, res: Response) => {
     try {
       const existing = await policies.getById(Number(req.params.id));
       if (!existing) return respondError(res, 404, 'NOT_FOUND', 'Policy not found');
-      // Only the owner or an admin may edit a policy directly.
-      if (existing.imposedByUserId !== req.user!.id && req.user!.role !== 'admin') {
-        return respondError(res, 403, 'FORBIDDEN', 'Only the policy owner or an admin may edit this policy');
+      // Only the owner or a full administrator may edit a policy directly.
+      if (existing.imposedByUserId !== req.user!.id && !userHasPermission(req.user, 'settings.manage')) {
+        return respondError(res, 403, 'FORBIDDEN', 'Only the policy owner or an administrator may edit this policy');
       }
       const updated = await policies.update(Number(req.params.id), req.body ?? {});
       res.json({ success: true, data: updated });
@@ -214,12 +214,12 @@ export const createPoliciesRouter = (pool: Pool): Router => {
     }
   });
 
-  router.delete('/:id', requireManager, async (req: Request, res: Response) => {
+  router.delete('/:id', requirePermission('policy.manage'), async (req: Request, res: Response) => {
     try {
       const existing = await policies.getById(Number(req.params.id));
       if (!existing) return respondError(res, 404, 'NOT_FOUND', 'Policy not found');
-      if (existing.imposedByUserId !== req.user!.id && req.user!.role !== 'admin') {
-        return respondError(res, 403, 'FORBIDDEN', 'Only the policy owner or an admin may delete this policy');
+      if (existing.imposedByUserId !== req.user!.id && !userHasPermission(req.user, 'settings.manage')) {
+        return respondError(res, 403, 'FORBIDDEN', 'Only the policy owner or an administrator may delete this policy');
       }
       await policies.remove(Number(req.params.id));
       res.json({ success: true });

--- a/backend/src/routes/preferences.ts
+++ b/backend/src/routes/preferences.ts
@@ -11,7 +11,7 @@
 
 import { Pool } from 'mysql2/promise';
 import { Router, Request, Response } from 'express';
-import { authenticate, requireManager } from '../middleware/auth';
+import { authenticate, requirePermission } from '../middleware/auth';
 import { PreferencesService } from '../services/PreferencesService';
 
 const respondError = (res: Response, status: number, code: string, message: string): void => {
@@ -38,13 +38,13 @@ export const createPreferencesRouter = (pool: Pool): Router => {
     }
   });
 
-  router.get('/:userId', requireManager, async (req: Request, res: Response) => {
+  router.get('/:userId', requirePermission('preferences.manage'), async (req: Request, res: Response) => {
     const userId = Number(req.params.userId);
     const data = await service.getByUserId(userId);
     res.json({ success: true, data });
   });
 
-  router.put('/:userId', requireManager, async (req: Request, res: Response) => {
+  router.put('/:userId', requirePermission('preferences.manage'), async (req: Request, res: Response) => {
     try {
       const userId = Number(req.params.userId);
       const data = await service.upsert(userId, req.body || {});

--- a/backend/src/routes/rbac.ts
+++ b/backend/src/routes/rbac.ts
@@ -1,0 +1,143 @@
+/**
+ * RBAC administration routes.
+ *
+ * Exposes the configurable role/permission model so administrators can define
+ * roles, attach permissions, and grant/revoke roles to users at runtime — with
+ * no code changes. Mounted at `/api/roles` and `/api/permissions`.
+ *
+ *   GET    /api/permissions                 list the permission catalog
+ *   GET    /api/roles                        list roles (with their permissions)
+ *   POST   /api/roles                        create a role
+ *   GET    /api/roles/:id                     read a role
+ *   PUT    /api/roles/:id                     update a role / its permissions
+ *   DELETE /api/roles/:id                     delete a non-system role
+ *   POST   /api/roles/users/:userId           assign a role to a user
+ *   DELETE /api/roles/users/:userId/:roleId   remove a role from a user
+ *
+ * All endpoints require the `role.manage` permission.
+ *
+ * @author Luca Ostinelli
+ */
+
+import { Router, Request, Response } from 'express';
+import { Pool } from 'mysql2/promise';
+import { authenticate, requirePermission } from '../middleware/auth';
+import { RbacService } from '../services/RbacService';
+import { logger } from '../config/logger';
+
+const respondError = (res: Response, status: number, code: string, message: string): void => {
+  res.status(status).json({ success: false, error: { code, message } });
+};
+
+const statusFor = (message: string): number =>
+  message.toLowerCase().includes('not found')
+    ? 404
+    : message.toLowerCase().includes('already exists')
+      ? 409
+      : message.toLowerCase().includes('cannot be deleted')
+        ? 409
+        : 400;
+
+export const createRbacRouter = (pool: Pool): { roles: Router; permissions: Router } => {
+  const rbac = new RbacService(pool);
+
+  const permissions = Router();
+  permissions.use(authenticate, requirePermission('role.manage'));
+  permissions.get('/', async (_req: Request, res: Response) => {
+    try {
+      res.json({ success: true, data: await rbac.listPermissions() });
+    } catch (err) {
+      logger.error('list permissions failed', err);
+      respondError(res, 500, 'INTERNAL_ERROR', 'Failed to list permissions');
+    }
+  });
+
+  const roles = Router();
+  roles.use(authenticate, requirePermission('role.manage'));
+
+  roles.get('/', async (_req: Request, res: Response) => {
+    try {
+      res.json({ success: true, data: await rbac.listRoles() });
+    } catch (err) {
+      logger.error('list roles failed', err);
+      respondError(res, 500, 'INTERNAL_ERROR', 'Failed to list roles');
+    }
+  });
+
+  roles.post('/', async (req: Request, res: Response) => {
+    try {
+      const created = await rbac.createRole({
+        name: req.body?.name,
+        description: req.body?.description,
+        permissionCodes: req.body?.permissionCodes,
+      });
+      res.status(201).json({ success: true, data: created });
+    } catch (err) {
+      const msg = (err as Error).message;
+      respondError(res, statusFor(msg), statusFor(msg) === 409 ? 'CONFLICT' : 'VALIDATION_ERROR', msg);
+    }
+  });
+
+  roles.get('/:id', async (req: Request, res: Response) => {
+    try {
+      const role = await rbac.getRoleById(Number(req.params.id));
+      if (!role) return respondError(res, 404, 'NOT_FOUND', 'Role not found');
+      res.json({ success: true, data: role });
+    } catch (err) {
+      logger.error('get role failed', err);
+      respondError(res, 500, 'INTERNAL_ERROR', 'Failed to read role');
+    }
+  });
+
+  roles.put('/:id', async (req: Request, res: Response) => {
+    try {
+      const updated = await rbac.updateRole(Number(req.params.id), {
+        name: req.body?.name,
+        description: req.body?.description,
+        permissionCodes: req.body?.permissionCodes,
+      });
+      res.json({ success: true, data: updated });
+    } catch (err) {
+      const msg = (err as Error).message;
+      respondError(res, statusFor(msg), statusFor(msg) === 404 ? 'NOT_FOUND' : 'VALIDATION_ERROR', msg);
+    }
+  });
+
+  roles.delete('/:id', async (req: Request, res: Response) => {
+    try {
+      await rbac.deleteRole(Number(req.params.id));
+      res.json({ success: true });
+    } catch (err) {
+      const msg = (err as Error).message;
+      respondError(res, statusFor(msg), statusFor(msg) === 404 ? 'NOT_FOUND' : 'CONFLICT', msg);
+    }
+  });
+
+  roles.post('/users/:userId', async (req: Request, res: Response) => {
+    try {
+      const roleId = Number(req.body?.roleId);
+      if (!roleId) return respondError(res, 400, 'VALIDATION_ERROR', 'roleId is required');
+      await rbac.assignRole(
+        Number(req.params.userId),
+        roleId,
+        req.body?.scopeOrgUnitId ?? null,
+        req.body?.expiresAt ?? null
+      );
+      res.status(201).json({ success: true });
+    } catch (err) {
+      respondError(res, 400, 'VALIDATION_ERROR', (err as Error).message);
+    }
+  });
+
+  roles.delete('/users/:userId/:roleId', async (req: Request, res: Response) => {
+    try {
+      const scope = req.query.scopeOrgUnitId ? Number(req.query.scopeOrgUnitId) : null;
+      await rbac.removeRole(Number(req.params.userId), Number(req.params.roleId), scope);
+      res.json({ success: true });
+    } catch (err) {
+      respondError(res, 400, 'VALIDATION_ERROR', (err as Error).message);
+    }
+  });
+
+  return { roles, permissions };
+};

--- a/backend/src/routes/reports.ts
+++ b/backend/src/routes/reports.ts
@@ -6,7 +6,7 @@
 
 import { Pool } from 'mysql2/promise';
 import { Router, Request, Response } from 'express';
-import { authenticate, requireManager } from '../middleware/auth';
+import { authenticate, requirePermission } from '../middleware/auth';
 import { ReportsService } from '../services/ReportsService';
 
 const respondError = (res: Response, status: number, code: string, message: string): void => {
@@ -17,7 +17,7 @@ export const createReportsRouter = (pool: Pool): Router => {
   const router = Router();
   const service = new ReportsService(pool);
 
-  router.use(authenticate, requireManager);
+  router.use(authenticate, requirePermission('report.read'));
 
   router.get('/hours-worked', async (req: Request, res: Response) => {
     const start = req.query.start as string | undefined;

--- a/backend/src/routes/schedules.ts
+++ b/backend/src/routes/schedules.ts
@@ -1,7 +1,7 @@
 import { Router, Request, Response } from 'express';
 import { Pool } from 'mysql2/promise';
 import { ScheduleService } from '../services/ScheduleService';
-import { authenticate, requireRole } from '../middleware/auth';
+import { authenticate, requirePermission } from '../middleware/auth';
 import { logger } from '../config/logger';
 
 export const createSchedulesRouter = (pool: Pool) => {
@@ -81,7 +81,7 @@ router.get('/:id/shifts', authenticate, async (req: Request, res: Response) => {
 });
 
 // Create new schedule
-router.post('/', authenticate, requireRole(['admin', 'manager']), async (req: Request, res: Response) => {
+router.post('/', authenticate, requirePermission('schedule.manage'), async (req: Request, res: Response) => {
   try {
     const user = req.user;
     if (!user) {
@@ -108,7 +108,7 @@ router.post('/', authenticate, requireRole(['admin', 'manager']), async (req: Re
 });
 
 // Update schedule
-router.put('/:id', authenticate, requireRole(['admin', 'manager']), async (req: Request, res: Response) => {
+router.put('/:id', authenticate, requirePermission('schedule.manage'), async (req: Request, res: Response) => {
   try {
     const id = parseInt(req.params.id);
     if (isNaN(id)) {
@@ -138,7 +138,7 @@ router.put('/:id', authenticate, requireRole(['admin', 'manager']), async (req: 
 });
 
 // Delete schedule
-router.delete('/:id', authenticate, requireRole(['admin', 'manager']), async (req: Request, res: Response) => {
+router.delete('/:id', authenticate, requirePermission('schedule.manage'), async (req: Request, res: Response) => {
   try {
     const id = parseInt(req.params.id);
     if (isNaN(id)) {
@@ -214,7 +214,7 @@ router.get('/user/:userId', authenticate, async (req: Request, res: Response) =>
 });
 
 // Publish schedule
-router.patch('/:id/publish', authenticate, requireRole(['admin', 'manager']), async (req: Request, res: Response) => {
+router.patch('/:id/publish', authenticate, requirePermission('schedule.publish'), async (req: Request, res: Response) => {
   try {
     const id = parseInt(req.params.id);
     if (isNaN(id)) {
@@ -244,7 +244,7 @@ router.patch('/:id/publish', authenticate, requireRole(['admin', 'manager']), as
 });
 
 // Archive schedule
-router.patch('/:id/archive', authenticate, requireRole(['admin', 'manager']), async (req: Request, res: Response) => {
+router.patch('/:id/archive', authenticate, requirePermission('schedule.manage'), async (req: Request, res: Response) => {
   try {
     const id = parseInt(req.params.id);
     if (isNaN(id)) {
@@ -274,7 +274,7 @@ router.patch('/:id/archive', authenticate, requireRole(['admin', 'manager']), as
 });
 
 // Duplicate schedule
-router.post('/:id/duplicate', authenticate, requireRole(['admin', 'manager']), async (req: Request, res: Response) => {
+router.post('/:id/duplicate', authenticate, requirePermission('schedule.manage'), async (req: Request, res: Response) => {
   try {
     const id = parseInt(req.params.id);
     if (isNaN(id)) {
@@ -317,7 +317,7 @@ router.post('/:id/duplicate', authenticate, requireRole(['admin', 'manager']), a
 });
 
 // Generate optimized schedule
-router.post('/:id/generate', authenticate, requireRole(['admin', 'manager']), async (req: Request, res: Response) => {
+router.post('/:id/generate', authenticate, requirePermission('schedule.optimize'), async (req: Request, res: Response) => {
   try {
     const id = parseInt(req.params.id);
     if (isNaN(id)) {

--- a/backend/src/routes/settings.ts
+++ b/backend/src/routes/settings.ts
@@ -16,7 +16,7 @@
 import { Router } from 'express';
 import { Pool } from 'mysql2/promise';
 import { SystemSettingsService } from '../services/SystemSettingsService';
-import { authenticate } from '../middleware/auth';
+import { authenticate, userHasPermission } from '../middleware/auth';
 import { UpdateSystemSettingRequest } from '../types';
 import { logger } from '../config/logger';
 
@@ -90,7 +90,7 @@ export const createSystemSettingsRouter = (pool: Pool) => {
     try {
       const user = req.user!;
 
-      if (user.role !== 'admin') {
+      if (!userHasPermission(user, 'settings.manage')) {
         return res.status(403).json({
           success: false,
           error: { code: 'FORBIDDEN', message: 'Only administrators can change currency settings' }
@@ -144,7 +144,7 @@ export const createSystemSettingsRouter = (pool: Pool) => {
     try {
       const user = req.user!;
 
-      if (user.role !== 'admin') {
+      if (!userHasPermission(user, 'settings.manage')) {
         return res.status(403).json({
           success: false,
           error: { code: 'FORBIDDEN', message: 'Only administrators can change time period settings' }
@@ -208,7 +208,7 @@ export const createSystemSettingsRouter = (pool: Pool) => {
       const user = req.user!;
 
       // Only admin can modify system settings
-      if (user.role !== 'admin') {
+      if (!userHasPermission(user, 'settings.manage')) {
         return res.status(403).json({
           success: false,
           error: { code: 'FORBIDDEN', message: 'Only administrators can modify system settings' }
@@ -281,7 +281,7 @@ export const createSystemSettingsRouter = (pool: Pool) => {
       const user = req.user!;
 
       // Only admin can reset system settings
-      if (user.role !== 'admin') {
+      if (!userHasPermission(user, 'settings.manage')) {
         return res.status(403).json({
           success: false,
           error: { code: 'FORBIDDEN', message: 'Only administrators can reset system settings' }

--- a/backend/src/routes/shiftSwap.ts
+++ b/backend/src/routes/shiftSwap.ts
@@ -6,7 +6,7 @@
 
 import { Pool } from 'mysql2/promise';
 import { Router, Request, Response } from 'express';
-import { authenticate, requireManager } from '../middleware/auth';
+import { authenticate, requirePermission, userHasPermission } from '../middleware/auth';
 import { ShiftSwapService } from '../services/ShiftSwapService';
 import { logger } from '../config/logger';
 
@@ -37,7 +37,7 @@ export const createShiftSwapRouter = (pool: Pool): Router => {
 
   router.get('/', async (req: Request, res: Response) => {
     try {
-      const isManager = req.user!.role === 'admin' || req.user!.role === 'manager';
+      const isManager = userHasPermission(req.user, 'shiftswap.approve');
       const filters = isManager
         ? {
             userId: req.query.userId ? Number(req.query.userId) : undefined,
@@ -59,7 +59,7 @@ export const createShiftSwapRouter = (pool: Pool): Router => {
       if (!item) return respondError(res, 404, 'NOT_FOUND', 'Shift swap request not found');
       const involves =
         item.requesterUserId === req.user!.id || item.targetUserId === req.user!.id;
-      const isManager = req.user!.role === 'admin' || req.user!.role === 'manager';
+      const isManager = userHasPermission(req.user, 'shiftswap.approve');
       if (!involves && !isManager) return respondError(res, 403, 'FORBIDDEN', 'Forbidden');
       res.json({ success: true, data: item });
     } catch (err) {
@@ -68,7 +68,7 @@ export const createShiftSwapRouter = (pool: Pool): Router => {
     }
   });
 
-  router.post('/:id/approve', requireManager, async (req: Request, res: Response) => {
+  router.post('/:id/approve', requirePermission('shiftswap.approve'), async (req: Request, res: Response) => {
     try {
       const id = Number(req.params.id);
       const updated = await service.approve(id, req.user!.id, req.body?.notes ?? null);
@@ -80,7 +80,7 @@ export const createShiftSwapRouter = (pool: Pool): Router => {
     }
   });
 
-  router.post('/:id/decline', requireManager, async (req: Request, res: Response) => {
+  router.post('/:id/decline', requirePermission('shiftswap.approve'), async (req: Request, res: Response) => {
     try {
       const id = Number(req.params.id);
       const updated = await service.decline(id, req.user!.id, req.body?.notes ?? null);

--- a/backend/src/routes/shifts.ts
+++ b/backend/src/routes/shifts.ts
@@ -16,7 +16,7 @@
 import { Router, Request, Response } from 'express';
 import { Pool } from 'mysql2/promise';
 import { ShiftService } from '../services/ShiftService';
-import { authenticate, requireRole } from '../middleware/auth';
+import { authenticate, requirePermission } from '../middleware/auth';
 import { logger } from '../config/logger';
 
 export const createShiftsRouter = (pool: Pool) => {
@@ -69,7 +69,7 @@ router.get('/templates/:id', authenticate, async (req: Request, res: Response) =
 });
 
 // Create new shift template
-router.post('/templates', authenticate, requireRole(['admin', 'manager']), async (req: Request, res: Response) => {
+router.post('/templates', authenticate, requirePermission('shift.manage'), async (req: Request, res: Response) => {
   try {
     const templateId = await shiftService.createShiftTemplate(req.body);
     const template = await shiftService.getShiftTemplateById(templateId);
@@ -89,7 +89,7 @@ router.post('/templates', authenticate, requireRole(['admin', 'manager']), async
 });
 
 // Update shift template
-router.put('/templates/:id', authenticate, requireRole(['admin', 'manager']), async (req: Request, res: Response) => {
+router.put('/templates/:id', authenticate, requirePermission('shift.manage'), async (req: Request, res: Response) => {
   try {
     const id = parseInt(req.params.id);
     if (isNaN(id)) {
@@ -122,7 +122,7 @@ router.put('/templates/:id', authenticate, requireRole(['admin', 'manager']), as
 });
 
 // Delete shift template
-router.delete('/templates/:id', authenticate, requireRole(['admin', 'manager']), async (req: Request, res: Response) => {
+router.delete('/templates/:id', authenticate, requirePermission('shift.manage'), async (req: Request, res: Response) => {
   try {
     const id = parseInt(req.params.id);
     if (isNaN(id)) {
@@ -199,7 +199,7 @@ router.get('/:id', authenticate, async (req: Request, res: Response) => {
 });
 
 // Create new shift
-router.post('/', authenticate, requireRole(['admin', 'manager']), async (req: Request, res: Response) => {
+router.post('/', authenticate, requirePermission('shift.manage'), async (req: Request, res: Response) => {
   try {
     const shift = await shiftService.createShift(req.body);
 
@@ -218,7 +218,7 @@ router.post('/', authenticate, requireRole(['admin', 'manager']), async (req: Re
 });
 
 // Update shift
-router.put('/:id', authenticate, requireRole(['admin', 'manager']), async (req: Request, res: Response) => {
+router.put('/:id', authenticate, requirePermission('shift.manage'), async (req: Request, res: Response) => {
   try {
     const id = parseInt(req.params.id);
     if (isNaN(id)) {
@@ -248,7 +248,7 @@ router.put('/:id', authenticate, requireRole(['admin', 'manager']), async (req: 
 });
 
 // Delete shift
-router.delete('/:id', authenticate, requireRole(['admin', 'manager']), async (req: Request, res: Response) => {
+router.delete('/:id', authenticate, requirePermission('shift.manage'), async (req: Request, res: Response) => {
   try {
     const id = parseInt(req.params.id);
     if (isNaN(id)) {

--- a/backend/src/routes/skillGap.ts
+++ b/backend/src/routes/skillGap.ts
@@ -8,14 +8,14 @@
 
 import { Pool } from 'mysql2/promise';
 import { Router, Request, Response } from 'express';
-import { authenticate, requireManager } from '../middleware/auth';
+import { authenticate, requirePermission } from '../middleware/auth';
 import { SkillGapService } from '../services/SkillGapService';
 
 export const createSkillGapRouter = (pool: Pool): Router => {
   const router = Router();
   const service = new SkillGapService(pool);
 
-  router.use(authenticate, requireManager);
+  router.use(authenticate, requirePermission('report.read'));
 
   router.get('/', async (req: Request, res: Response) => {
     const departmentId = Number(req.query.departmentId);

--- a/backend/src/routes/timeOff.ts
+++ b/backend/src/routes/timeOff.ts
@@ -13,7 +13,7 @@
 
 import { Pool } from 'mysql2/promise';
 import { Router, Request, Response } from 'express';
-import { authenticate, requireManager } from '../middleware/auth';
+import { authenticate, requirePermission, userHasPermission } from '../middleware/auth';
 import { TimeOffService } from '../services/TimeOffService';
 import { logger } from '../config/logger';
 
@@ -45,7 +45,7 @@ export const createTimeOffRouter = (pool: Pool): Router => {
 
   router.get('/', async (req: Request, res: Response) => {
     try {
-      const isManager = req.user!.role === 'admin' || req.user!.role === 'manager';
+      const isManager = userHasPermission(req.user, 'timeoff.approve');
       const filters = isManager
         ? {
             userId: req.query.userId ? Number(req.query.userId) : undefined,
@@ -66,7 +66,7 @@ export const createTimeOffRouter = (pool: Pool): Router => {
       const item = await service.getById(id);
       if (!item) return respondError(res, 404, 'NOT_FOUND', 'Time-off request not found');
       const isOwn = item.userId === req.user!.id;
-      const isManager = req.user!.role === 'admin' || req.user!.role === 'manager';
+      const isManager = userHasPermission(req.user, 'timeoff.approve');
       if (!isOwn && !isManager) return respondError(res, 403, 'FORBIDDEN', 'Forbidden');
       res.json({ success: true, data: item });
     } catch (err) {
@@ -75,7 +75,7 @@ export const createTimeOffRouter = (pool: Pool): Router => {
     }
   });
 
-  router.post('/:id/approve', requireManager, async (req: Request, res: Response) => {
+  router.post('/:id/approve', requirePermission('timeoff.approve'), async (req: Request, res: Response) => {
     try {
       const id = Number(req.params.id);
       const updated = await service.approve(id, req.user!.id, req.body?.notes ?? null);
@@ -87,7 +87,7 @@ export const createTimeOffRouter = (pool: Pool): Router => {
     }
   });
 
-  router.post('/:id/reject', requireManager, async (req: Request, res: Response) => {
+  router.post('/:id/reject', requirePermission('timeoff.approve'), async (req: Request, res: Response) => {
     try {
       const id = Number(req.params.id);
       const updated = await service.reject(id, req.user!.id, req.body?.notes ?? null);

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -1,29 +1,50 @@
 import { Router } from 'express';
 import { Pool } from 'mysql2/promise';
 import { UserService } from '../services/UserService';
-import { authenticate } from '../middleware/auth';
+import { RbacService } from '../services/RbacService';
+import { authenticate, userHasPermission } from '../middleware/auth';
 import { CreateUserRequest, UpdateUserRequest, User } from '../types';
 import { logger } from '../config/logger';
 
 export const createUsersRouter = (pool: Pool) => {
   const router = Router();
   const userService = new UserService(pool);
+  const rbacService = new RbacService(pool);
 
-  // Get all users (with role-based filtering)
+  /**
+   * Anti-privilege-escalation guard. An actor may only grant a role whose
+   * permissions are a subset of their own — unless they hold `role.manage`,
+   * which authorizes assigning any role. Returns an error message, or null
+   * when the assignment is allowed.
+   */
+  const validateRoleAssignment = async (actor: User, roleIds?: number[]): Promise<string | null> => {
+    if (!roleIds || roleIds.length === 0) return null;
+    if (userHasPermission(actor, 'role.manage')) return null;
+    const actorPerms = new Set(actor.permissions ?? []);
+    for (const roleId of roleIds) {
+      const role = await rbacService.getRoleById(roleId);
+      if (!role) return `Role ${roleId} not found`;
+      const escalates = (role.permissions ?? []).some((p) => !actorPerms.has(p));
+      if (escalates) return 'You cannot assign a role with permissions you do not hold';
+    }
+    return null;
+  };
+
+  // Get all users (scoped by the caller's permissions)
   router.get('/', authenticate, async (req, res) => {
     try {
-      const user = (req as any).user;
-      const { search, department, role } = req.query;
+      const user = req.user as User;
+      const { search, department, roleId } = req.query;
 
       let users;
-      if (user.role === 'admin') {
+      if (userHasPermission(user, 'settings.manage')) {
         users = await userService.getAllUsers({
           search: search as string,
           departmentId: department ? parseInt(department as string) : undefined,
-          role: role as string
+          roleId: roleId ? parseInt(roleId as string) : undefined
         });
       } else {
-        users = await userService.getUsersForManager(user.id, user.role);
+        users = await userService.getUsersForManager(user);
 
         if (search) {
           const searchTerm = (search as string).toLowerCase();
@@ -40,10 +61,6 @@ export const createUsersRouter = (pool: Pool) => {
             u.departments?.some((d: any) => d.departmentId === parseInt(department as string))
           );
         }
-
-        if (role) {
-          users = users.filter((u: User) => u.role === role);
-        }
       }
 
       res.json({ success: true, data: users });
@@ -59,9 +76,9 @@ export const createUsersRouter = (pool: Pool) => {
   // Create new user
   router.post('/', authenticate, async (req, res) => {
     try {
-      const user = (req as any).user;
+      const user = req.user as User;
 
-      if (!['admin', 'manager'].includes(user.role)) {
+      if (!userHasPermission(user, 'user.manage')) {
         return res.status(403).json({
           success: false,
           error: { code: 'FORBIDDEN', message: 'Insufficient permissions' }
@@ -70,19 +87,19 @@ export const createUsersRouter = (pool: Pool) => {
 
       const userData: CreateUserRequest = req.body;
 
-      if (!userData.email || !userData.password || !userData.firstName || !userData.lastName || !userData.role) {
+      if (!userData.email || !userData.password || !userData.firstName || !userData.lastName) {
         return res.status(400).json({
           success: false,
           error: { code: 'INVALID_INPUT', message: 'Missing required fields' }
         });
       }
 
-      // Only admins may create admin accounts. A manager must not be able to
-      // escalate privileges by creating an admin user.
-      if (userData.role === 'admin' && user.role !== 'admin') {
+      // Prevent privilege escalation through role assignment.
+      const roleError = await validateRoleAssignment(user, userData.roleIds);
+      if (roleError) {
         return res.status(403).json({
           success: false,
-          error: { code: 'FORBIDDEN', message: 'Only admins can create admin users' }
+          error: { code: 'FORBIDDEN', message: roleError }
         });
       }
 
@@ -109,7 +126,7 @@ export const createUsersRouter = (pool: Pool) => {
   // Get user by ID
   router.get('/:id', authenticate, async (req, res) => {
     try {
-      const user = (req as any).user;
+      const user = req.user as User;
       const userId = parseInt(req.params.id);
 
       if (!userId) {
@@ -128,7 +145,8 @@ export const createUsersRouter = (pool: Pool) => {
         });
       }
 
-      if (user.role === 'employee' && user.id !== userId) {
+      // Users without directory read access may only view their own record.
+      if (!userHasPermission(user, 'user.read') && user.id !== userId) {
         return res.status(403).json({
           success: false,
           error: { code: 'FORBIDDEN', message: 'Insufficient permissions' }
@@ -148,7 +166,7 @@ export const createUsersRouter = (pool: Pool) => {
   // Update user
   router.put('/:id', authenticate, async (req, res) => {
     try {
-      const user = (req as any).user;
+      const user = req.user as User;
       const userId = parseInt(req.params.id);
 
       if (!userId) {
@@ -158,7 +176,10 @@ export const createUsersRouter = (pool: Pool) => {
         });
       }
 
-      if (user.role === 'employee' && user.id !== userId) {
+      const canManageUsers = userHasPermission(user, 'user.manage');
+
+      // Users without user management may only edit their own record.
+      if (!canManageUsers && user.id !== userId) {
         return res.status(403).json({
           success: false,
           error: { code: 'FORBIDDEN', message: 'Insufficient permissions' }
@@ -167,7 +188,8 @@ export const createUsersRouter = (pool: Pool) => {
 
       const updateData: UpdateUserRequest = req.body;
 
-      if (user.role === 'employee') {
+      // Self-service editors are limited to a small set of profile fields.
+      if (!canManageUsers) {
         const allowedFields = ['firstName', 'lastName', 'phone'];
         const submittedFields = Object.keys(updateData);
         const invalidFields = submittedFields.filter(field => !allowedFields.includes(field));
@@ -175,25 +197,25 @@ export const createUsersRouter = (pool: Pool) => {
         if (invalidFields.length > 0) {
           return res.status(403).json({
             success: false,
-            error: { code: 'FORBIDDEN', message: `Employees cannot update: ${invalidFields.join(', ')}` }
+            error: { code: 'FORBIDDEN', message: `You cannot update: ${invalidFields.join(', ')}` }
           });
         }
       }
 
-      // Role changes are restricted to admins, and no one may change their own
-      // role. This prevents privilege escalation and self-promotion.
-      if (updateData.role !== undefined) {
-        if (user.role !== 'admin') {
-          return res.status(403).json({
-            success: false,
-            error: { code: 'FORBIDDEN', message: 'Only admins can change user roles' }
-          });
-        }
-
+      // Role changes require user management, are subject to the
+      // anti-escalation rule, and may never target one's own account.
+      if (updateData.roleIds !== undefined) {
         if (user.id === userId) {
           return res.status(403).json({
             success: false,
-            error: { code: 'FORBIDDEN', message: 'You cannot change your own role' }
+            error: { code: 'FORBIDDEN', message: 'You cannot change your own roles' }
+          });
+        }
+        const roleError = await validateRoleAssignment(user, updateData.roleIds);
+        if (roleError) {
+          return res.status(403).json({
+            success: false,
+            error: { code: 'FORBIDDEN', message: roleError }
           });
         }
       }
@@ -228,7 +250,7 @@ export const createUsersRouter = (pool: Pool) => {
   // Delete user
   router.delete('/:id', authenticate, async (req, res) => {
     try {
-      const user = (req as any).user;
+      const user = req.user as User;
       const userId = parseInt(req.params.id);
 
       if (!userId) {
@@ -238,7 +260,7 @@ export const createUsersRouter = (pool: Pool) => {
         });
       }
 
-      if (!['admin', 'manager'].includes(user.role)) {
+      if (!userHasPermission(user, 'user.manage')) {
         return res.status(403).json({
           success: false,
           error: { code: 'FORBIDDEN', message: 'Insufficient permissions' }

--- a/backend/src/services/ApprovalMatrixService.ts
+++ b/backend/src/services/ApprovalMatrixService.ts
@@ -12,7 +12,7 @@
  *   - `policy_owner`        owner of the policy at hand
  *   - `unit_manager`        manager of the involved org_unit
  *   - `unit_manager_chain`  walks up parent units until a manager is found
- *   - `company_role`        any active user with the configured role
+ *   - `company_role`        any active user holding the configured role id
  *   - `company_user`        the explicit user stored in the matrix row
  *
  * @author Luca Ostinelli
@@ -31,7 +31,7 @@ interface ApprovalMatrixRow {
   id: number;
   changeType: string;
   approverScope: ApproverScope;
-  approverRole: 'admin' | 'manager' | 'employee' | null;
+  approverRoleId: number | null;
   approverUserId: number | null;
   autoApproveForOwner: boolean;
   description: string | null;
@@ -59,7 +59,7 @@ const mapRow = (row: RowDataPacket): ApprovalMatrixRow => ({
   id: row.id as number,
   changeType: row.change_type as string,
   approverScope: row.approver_scope as ApproverScope,
-  approverRole: (row.approver_role as ApprovalMatrixRow['approverRole']) ?? null,
+  approverRoleId: (row.approver_role_id as number | null) ?? null,
   approverUserId: (row.approver_user_id as number | null) ?? null,
   autoApproveForOwner: Boolean(row.auto_approve_for_owner),
   description: (row.description as string | null) ?? null,
@@ -96,14 +96,14 @@ export class ApprovalMatrixService {
     await this.pool.execute(
       `UPDATE approval_matrix
           SET approver_scope = ?,
-              approver_role = ?,
+              approver_role_id = ?,
               approver_user_id = ?,
               auto_approve_for_owner = ?,
               description = ?
         WHERE change_type = ?`,
       [
         merged.approverScope,
-        merged.approverRole,
+        merged.approverRoleId,
         merged.approverUserId,
         merged.autoApproveForOwner ? 1 : 0,
         merged.description,
@@ -118,8 +118,7 @@ export class ApprovalMatrixService {
   /**
    * Resolves the approver for a change type given a runtime context.
    * Returns `approverUserId = null` when no approver can be determined; the
-   * caller decides whether to fall back to "everyone with admin role" or to
-   * fail loudly.
+   * caller decides whether to fall back to a configured role or to fail loudly.
    */
   async resolve(changeType: string, ctx: ResolveContext): Promise<ResolvedApprover> {
     const matrix = await this.getByChangeType(changeType);
@@ -144,8 +143,8 @@ export class ApprovalMatrixService {
           : null;
         break;
       case 'company_role':
-        approverUserId = matrix.approverRole
-          ? await this.findFirstActiveByRole(matrix.approverRole)
+        approverUserId = matrix.approverRoleId
+          ? await this.findFirstActiveByRoleId(matrix.approverRoleId)
           : null;
         break;
       case 'company_user':
@@ -190,12 +189,15 @@ export class ApprovalMatrixService {
     return null;
   }
 
-  private async findFirstActiveByRole(
-    role: 'admin' | 'manager' | 'employee'
-  ): Promise<number | null> {
+  private async findFirstActiveByRoleId(roleId: number): Promise<number | null> {
     const [rows] = await this.pool.execute<RowDataPacket[]>(
-      `SELECT id FROM users WHERE role = ? AND is_active = 1 ORDER BY id ASC LIMIT 1`,
-      [role]
+      `SELECT u.id
+         FROM users u
+         JOIN user_roles ur ON ur.user_id = u.id
+        WHERE ur.role_id = ? AND u.is_active = 1
+          AND (ur.expires_at IS NULL OR ur.expires_at > NOW())
+        ORDER BY u.id ASC LIMIT 1`,
+      [roleId]
     );
     return rows.length === 0 ? null : (rows[0].id as number);
   }

--- a/backend/src/services/AssignmentService.ts
+++ b/backend/src/services/AssignmentService.ts
@@ -858,7 +858,6 @@ export class AssignmentService {
         FROM users u
         INNER JOIN user_departments ud ON u.id = ud.user_id
         WHERE u.is_active = 1
-        AND u.role = 'employee'
         AND ud.department_id = ?
         AND NOT EXISTS (
           SELECT 1 FROM shift_assignments sa

--- a/backend/src/services/BulkImportService.ts
+++ b/backend/src/services/BulkImportService.ts
@@ -4,6 +4,8 @@
  * Pure parsing functions plus a DB-aware importer. Today we accept CSV text
  * for two entity types:
  *   - employees: email,firstName,lastName,role,employeeId,phone
+ *       (the `role` column holds a role NAME, e.g. "Manager", resolved against
+ *        the configurable `roles` table at import time)
  *   - shifts:    scheduleId,departmentId,date,startTime,endTime,minStaff,maxStaff
  *
  * The parser is hand-rolled (no csv-parser dependency surface in the public
@@ -32,7 +34,8 @@ interface EmployeeRow {
   email: string;
   firstName: string;
   lastName: string;
-  role: 'admin' | 'manager' | 'employee';
+  /** Role name to assign, resolved against the `roles` table at import time. */
+  roleName: string;
   employeeId?: string;
   phone?: string;
 }
@@ -121,9 +124,9 @@ export const mapEmployeeRows = (rows: string[][]): { rows: EmployeeRow[]; errors
   const out: EmployeeRow[] = [];
   for (let i = 1; i < rows.length; i++) {
     const r = rows[i];
-    const role = (r[roleIdx] || '').trim().toLowerCase();
-    if (!['admin', 'manager', 'employee'].includes(role)) {
-      errors.push({ row: i + 1, message: `Invalid role '${r[roleIdx]}'` });
+    const roleName = (r[roleIdx] || '').trim();
+    if (roleName.length === 0) {
+      errors.push({ row: i + 1, message: 'Missing role' });
       continue;
     }
     const email = (r[emailIdx] || '').trim();
@@ -135,7 +138,7 @@ export const mapEmployeeRows = (rows: string[][]): { rows: EmployeeRow[]; errors
       email,
       firstName: (r[firstIdx] || '').trim(),
       lastName: (r[lastIdx] || '').trim(),
-      role: role as EmployeeRow['role'],
+      roleName,
       employeeId: employeeIdIdx >= 0 ? (r[employeeIdIdx] || '').trim() || undefined : undefined,
       phone: phoneIdx >= 0 ? (r[phoneIdx] || '').trim() || undefined : undefined,
     });
@@ -216,18 +219,33 @@ export class BulkImportService {
             errors: [{ row: i + 2, message: `Email already exists: ${r.email}` }],
           };
         }
-        await conn.execute<ResultSetHeader>(
-          `INSERT INTO users (email, password_hash, first_name, last_name, role, employee_id, phone, is_active)
-           VALUES (?, ?, ?, ?, ?, ?, ?, 1)`,
+        const [roleRows] = await conn.execute<RowDataPacket[]>(
+          `SELECT id FROM roles WHERE name = ? LIMIT 1`,
+          [r.roleName]
+        );
+        if (roleRows.length === 0) {
+          await conn.rollback();
+          return {
+            inserted: 0,
+            errors: [{ row: i + 2, message: `Unknown role: ${r.roleName}` }],
+          };
+        }
+        const roleId = (roleRows[0] as any).id as number;
+        const [userRes] = await conn.execute<ResultSetHeader>(
+          `INSERT INTO users (email, password_hash, first_name, last_name, employee_id, phone, is_active)
+           VALUES (?, ?, ?, ?, ?, ?, 1)`,
           [
             r.email,
             passwordHash,
             r.firstName,
             r.lastName,
-            r.role,
             r.employeeId ?? null,
             r.phone ?? null,
           ]
+        );
+        await conn.execute(
+          `INSERT IGNORE INTO user_roles (user_id, role_id, scope_org_unit_id) VALUES (?, ?, NULL)`,
+          [userRes.insertId, roleId]
         );
         inserted++;
       }

--- a/backend/src/services/DepartmentService.ts
+++ b/backend/src/services/DepartmentService.ts
@@ -367,12 +367,11 @@ export class DepartmentService {
     email: string;
     firstName: string;
     lastName: string;
-    role: string;
     employeeId?: string;
   }>> {
     try {
       const [rows] = await this.pool.execute<RowDataPacket[]>(
-        `SELECT u.id, u.email, u.first_name, u.last_name, u.role, u.employee_id
+        `SELECT u.id, u.email, u.first_name, u.last_name, u.employee_id
         FROM users u
         JOIN user_departments ud ON u.id = ud.user_id
         WHERE ud.department_id = ? AND u.is_active = 1
@@ -385,7 +384,6 @@ export class DepartmentService {
         email: row.email,
         firstName: row.first_name,
         lastName: row.last_name,
-        role: row.role,
         employeeId: row.employee_id
       }));
     } catch (error) {

--- a/backend/src/services/EmployeeService.ts
+++ b/backend/src/services/EmployeeService.ts
@@ -1,10 +1,11 @@
 /**
  * Employee Service
  * 
- * Specialized service for managing employee users. This service provides
- * employee-specific methods that wrap UserService functionality with
- * role filtering for employees only.
- * 
+ * Specialized service for managing staff users. In the configurable role
+ * model every active user is potentially schedulable staff, so this service
+ * exposes the staff roster and per-person convenience operations on top of
+ * UserService rather than filtering by a hardcoded role.
+ *
  * @module services/EmployeeService
  * @author Luca Ostinelli
  */
@@ -16,9 +17,9 @@ import { logger } from '../config/logger';
 
 /**
  * EmployeeService Class
- * 
- * Provides employee-specific operations by filtering UserService results
- * to only include users with the 'employee' role.
+ *
+ * Provides staff-oriented operations over UserService. "Employee" here means
+ * schedulable staff, i.e. any active user, not a fixed authorization role.
  */
 export class EmployeeService {
   private userService: UserService;
@@ -33,10 +34,10 @@ export class EmployeeService {
   }
 
   /**
-   * Gets all employees (users with role 'employee')
-   * 
+   * Gets all staff (every user; optionally filtered by department/active/search)
+   *
    * @param filters - Optional filters (department, active status)
-   * @returns Promise resolving to array of employee users
+   * @returns Promise resolving to array of staff users
    */
   async getAllEmployees(filters?: {
     departmentId?: number;
@@ -44,10 +45,7 @@ export class EmployeeService {
     search?: string;
   }): Promise<User[]> {
     try {
-      return await this.userService.getAllUsers({
-        ...filters,
-        role: 'employee'
-      });
+      return await this.userService.getAllUsers({ ...filters });
     } catch (error) {
       logger.error('Error getting all employees:', error);
       throw error;
@@ -64,11 +62,7 @@ export class EmployeeService {
    */
   async getEmployeeById(id: number): Promise<User | null> {
     try {
-      const user = await this.userService.getUserById(id);
-      if (user && user.role !== 'employee') {
-        return null;
-      }
-      return user;
+      return await this.userService.getUserById(id);
     } catch (error) {
       logger.error('Error getting employee by ID:', error);
       throw error;
@@ -101,17 +95,13 @@ export class EmployeeService {
     inactive: number;
   }> {
     try {
+      // Every user is schedulable staff, so staff headcount equals the
+      // overall user headcount.
       const stats = await this.userService.getUserStatistics();
-      const employeeCount = stats.byRole.find(r => r.role === 'employee')?.count || 0;
-      
-      // Calculate active/inactive employees only
-      const employees = await this.getAllEmployees();
-      const activeCount = employees.filter(e => e.isActive).length;
-      
       return {
-        total: employeeCount,
-        active: activeCount,
-        inactive: employeeCount - activeCount
+        total: stats.total,
+        active: stats.active,
+        inactive: stats.inactive
       };
     } catch (error) {
       logger.error('Error getting employee statistics:', error);
@@ -158,10 +148,8 @@ export class EmployeeService {
    */
   async createEmployee(userData: any): Promise<User> {
     try {
-      return await this.userService.createUser({
-        ...userData,
-        role: 'employee'
-      });
+      // Roles, if any, are supplied by the caller via `roleIds`.
+      return await this.userService.createUser({ ...userData });
     } catch (error) {
       logger.error('Error creating employee:', error);
       throw error;

--- a/backend/src/services/RbacService.ts
+++ b/backend/src/services/RbacService.ts
@@ -1,0 +1,292 @@
+/**
+ * RBAC Service
+ *
+ * Owns the configurable role/permission model that replaced the former
+ * hardcoded `role` ENUM. Authorization is permission-based: application code
+ * checks permission CODES (e.g. `schedule.manage`), while roles are editable
+ * data that bundle permissions and are granted to users — optionally scoped to
+ * an org unit and optionally time-bound.
+ *
+ * Responsibilities:
+ *   - resolve a user's effective permissions and role assignments
+ *   - CRUD for roles, role-permission membership and user-role grants
+ *   - list the permission catalog
+ *
+ * @author Luca Ostinelli
+ */
+
+import { Pool, RowDataPacket, ResultSetHeader } from 'mysql2/promise';
+import {
+  Permission,
+  Role,
+  UserRoleAssignment,
+  CreateRoleRequest,
+  UpdateRoleRequest,
+} from '../types';
+import { logger } from '../config/logger';
+
+export class RbacService {
+  constructor(private pool: Pool) {}
+
+  /**
+   * Returns the de-duplicated set of permission codes a user effectively holds,
+   * across all their (non-expired) role grants.
+   */
+  async getEffectivePermissions(userId: number): Promise<string[]> {
+    const [rows] = await this.pool.execute<RowDataPacket[]>(
+      `SELECT DISTINCT p.code
+         FROM user_roles ur
+         JOIN role_permissions rp ON rp.role_id = ur.role_id
+         JOIN permissions p ON p.id = rp.permission_id
+        WHERE ur.user_id = ?
+          AND (ur.expires_at IS NULL OR ur.expires_at > NOW())`,
+      [userId]
+    );
+    return rows.map((r: any) => r.code as string);
+  }
+
+  /**
+   * Returns the user's role assignments (with scope), excluding expired grants.
+   */
+  async getUserRoles(userId: number): Promise<UserRoleAssignment[]> {
+    const [rows] = await this.pool.execute<RowDataPacket[]>(
+      `SELECT ur.role_id, r.name AS role_name, ur.scope_org_unit_id, ur.expires_at
+         FROM user_roles ur
+         JOIN roles r ON r.id = ur.role_id
+        WHERE ur.user_id = ?
+          AND (ur.expires_at IS NULL OR ur.expires_at > NOW())
+        ORDER BY r.name ASC`,
+      [userId]
+    );
+    return rows.map((r: any) => ({
+      roleId: r.role_id,
+      roleName: r.role_name,
+      scopeOrgUnitId: r.scope_org_unit_id ?? null,
+      expiresAt: r.expires_at ?? null,
+    }));
+  }
+
+  /** Convenience: does the user hold the given permission code? */
+  async userHasPermission(userId: number, code: string): Promise<boolean> {
+    const perms = await this.getEffectivePermissions(userId);
+    return perms.includes(code);
+  }
+
+  // --------------------------------------------------------------------------
+  // Permission catalog
+  // --------------------------------------------------------------------------
+
+  async listPermissions(): Promise<Permission[]> {
+    const [rows] = await this.pool.execute<RowDataPacket[]>(
+      `SELECT id, code, resource, action, description FROM permissions ORDER BY resource, action`
+    );
+    return rows.map((r: any) => ({
+      id: r.id,
+      code: r.code,
+      resource: r.resource,
+      action: r.action,
+      description: r.description ?? undefined,
+    }));
+  }
+
+  // --------------------------------------------------------------------------
+  // Roles
+  // --------------------------------------------------------------------------
+
+  async listRoles(): Promise<Role[]> {
+    const [rows] = await this.pool.execute<RowDataPacket[]>(
+      `SELECT r.id, r.name, r.description, r.is_system, r.created_at, r.updated_at,
+              GROUP_CONCAT(p.code) AS perm_codes
+         FROM roles r
+         LEFT JOIN role_permissions rp ON rp.role_id = r.id
+         LEFT JOIN permissions p ON p.id = rp.permission_id
+        GROUP BY r.id
+        ORDER BY r.name ASC`
+    );
+    return rows.map((r: any) => this.mapRole(r));
+  }
+
+  async getRoleById(id: number): Promise<Role | null> {
+    const [rows] = await this.pool.execute<RowDataPacket[]>(
+      `SELECT r.id, r.name, r.description, r.is_system, r.created_at, r.updated_at,
+              GROUP_CONCAT(p.code) AS perm_codes
+         FROM roles r
+         LEFT JOIN role_permissions rp ON rp.role_id = r.id
+         LEFT JOIN permissions p ON p.id = rp.permission_id
+        WHERE r.id = ?
+        GROUP BY r.id`,
+      [id]
+    );
+    return rows.length ? this.mapRole(rows[0]) : null;
+  }
+
+  async createRole(input: CreateRoleRequest): Promise<Role> {
+    const connection = await this.pool.getConnection();
+    try {
+      await connection.beginTransaction();
+      const [existing] = await connection.execute<RowDataPacket[]>(
+        'SELECT id FROM roles WHERE name = ? LIMIT 1',
+        [input.name]
+      );
+      if (existing.length > 0) throw new Error('Role name already exists');
+
+      const [res] = await connection.execute<ResultSetHeader>(
+        'INSERT INTO roles (name, description, is_system) VALUES (?, ?, FALSE)',
+        [input.name, input.description || null]
+      );
+      const roleId = res.insertId;
+      await this.replacePermissionsTx(connection, roleId, input.permissionCodes || []);
+      await connection.commit();
+      logger.info(`Role created: ${roleId} (${input.name})`);
+      const role = await this.getRoleById(roleId);
+      if (!role) throw new Error('Failed to retrieve created role');
+      return role;
+    } catch (error) {
+      await connection.rollback();
+      throw error;
+    } finally {
+      connection.release();
+    }
+  }
+
+  async updateRole(id: number, input: UpdateRoleRequest): Promise<Role> {
+    const connection = await this.pool.getConnection();
+    try {
+      await connection.beginTransaction();
+      const updates: string[] = [];
+      const values: any[] = [];
+      if (input.name !== undefined) {
+        updates.push('name = ?');
+        values.push(input.name);
+      }
+      if (input.description !== undefined) {
+        updates.push('description = ?');
+        values.push(input.description);
+      }
+      if (updates.length > 0) {
+        values.push(id);
+        await connection.execute(
+          `UPDATE roles SET ${updates.join(', ')}, updated_at = CURRENT_TIMESTAMP WHERE id = ?`,
+          values
+        );
+      }
+      if (input.permissionCodes !== undefined) {
+        await this.replacePermissionsTx(connection, id, input.permissionCodes);
+      }
+      await connection.commit();
+      logger.info(`Role updated: ${id}`);
+      const role = await this.getRoleById(id);
+      if (!role) throw new Error('Role not found');
+      return role;
+    } catch (error) {
+      await connection.rollback();
+      throw error;
+    } finally {
+      connection.release();
+    }
+  }
+
+  async deleteRole(id: number): Promise<void> {
+    const role = await this.getRoleById(id);
+    if (!role) throw new Error('Role not found');
+    if (role.isSystem) throw new Error('System roles cannot be deleted');
+    await this.pool.execute('DELETE FROM roles WHERE id = ?', [id]);
+    logger.info(`Role deleted: ${id}`);
+  }
+
+  // --------------------------------------------------------------------------
+  // User-role grants
+  // --------------------------------------------------------------------------
+
+  /** Replaces the user's unscoped role grants with the provided role ids. */
+  async setUserRoles(userId: number, roleIds: number[]): Promise<void> {
+    const connection = await this.pool.getConnection();
+    try {
+      await connection.beginTransaction();
+      await connection.execute(
+        'DELETE FROM user_roles WHERE user_id = ? AND scope_org_unit_id IS NULL',
+        [userId]
+      );
+      for (const roleId of roleIds) {
+        await connection.execute(
+          'INSERT IGNORE INTO user_roles (user_id, role_id, scope_org_unit_id) VALUES (?, ?, NULL)',
+          [userId, roleId]
+        );
+      }
+      await connection.commit();
+    } catch (error) {
+      await connection.rollback();
+      throw error;
+    } finally {
+      connection.release();
+    }
+  }
+
+  async assignRole(
+    userId: number,
+    roleId: number,
+    scopeOrgUnitId: number | null = null,
+    expiresAt: string | null = null
+  ): Promise<void> {
+    await this.pool.execute(
+      `INSERT INTO user_roles (user_id, role_id, scope_org_unit_id, expires_at)
+       VALUES (?, ?, ?, ?)
+       ON DUPLICATE KEY UPDATE expires_at = VALUES(expires_at)`,
+      [userId, roleId, scopeOrgUnitId, expiresAt]
+    );
+  }
+
+  async removeRole(userId: number, roleId: number, scopeOrgUnitId: number | null = null): Promise<void> {
+    if (scopeOrgUnitId === null) {
+      await this.pool.execute(
+        'DELETE FROM user_roles WHERE user_id = ? AND role_id = ? AND scope_org_unit_id IS NULL',
+        [userId, roleId]
+      );
+    } else {
+      await this.pool.execute(
+        'DELETE FROM user_roles WHERE user_id = ? AND role_id = ? AND scope_org_unit_id = ?',
+        [userId, roleId, scopeOrgUnitId]
+      );
+    }
+  }
+
+  /** Resolves a role id from its (unique) name. Useful for seeding/import. */
+  async getRoleIdByName(name: string): Promise<number | null> {
+    const [rows] = await this.pool.execute<RowDataPacket[]>(
+      'SELECT id FROM roles WHERE name = ? LIMIT 1',
+      [name]
+    );
+    return rows.length ? (rows[0] as any).id : null;
+  }
+
+  // --------------------------------------------------------------------------
+  // Helpers
+  // --------------------------------------------------------------------------
+
+  private async replacePermissionsTx(
+    connection: any,
+    roleId: number,
+    permissionCodes: string[]
+  ): Promise<void> {
+    await connection.execute('DELETE FROM role_permissions WHERE role_id = ?', [roleId]);
+    if (permissionCodes.length === 0) return;
+    const placeholders = permissionCodes.map(() => '?').join(', ');
+    await connection.execute(
+      `INSERT IGNORE INTO role_permissions (role_id, permission_id)
+       SELECT ?, id FROM permissions WHERE code IN (${placeholders})`,
+      [roleId, ...permissionCodes]
+    );
+  }
+
+  private mapRole(r: any): Role {
+    return {
+      id: r.id,
+      name: r.name,
+      description: r.description ?? undefined,
+      isSystem: Boolean(r.is_system),
+      permissions: r.perm_codes ? String(r.perm_codes).split(',') : [],
+      createdAt: r.created_at,
+      updatedAt: r.updated_at,
+    };
+  }
+}

--- a/backend/src/services/SkillService.ts
+++ b/backend/src/services/SkillService.ts
@@ -399,7 +399,7 @@ export class SkillService {
   async getUsersWithSkill(skillId: number): Promise<any[]> {
     try {
       const [rows] = await this.pool.execute<RowDataPacket[]>(
-        `SELECT u.id, u.first_name, u.last_name, u.email, u.role
+        `SELECT u.id, u.first_name, u.last_name, u.email
         FROM users u
         JOIN user_skills us ON u.id = us.user_id
         WHERE us.skill_id = ? AND u.is_active = 1
@@ -411,8 +411,7 @@ export class SkillService {
         id: row.id,
         firstName: row.first_name,
         lastName: row.last_name,
-        email: row.email,
-        role: row.role
+        email: row.email
       }));
     } catch (error) {
       logger.error('Failed to get users with skill:', error);
@@ -592,7 +591,7 @@ export class SkillService {
       }
 
       let query = `
-        SELECT u.id, u.first_name, u.last_name, u.email, u.role,
+        SELECT u.id, u.first_name, u.last_name, u.email,
           COUNT(DISTINCT us.skill_id) as matching_skills
         FROM users u
         JOIN user_skills us ON u.id = us.user_id
@@ -622,8 +621,7 @@ export class SkillService {
         id: row.id,
         firstName: row.first_name,
         lastName: row.last_name,
-        email: row.email,
-        role: row.role
+        email: row.email
       }));
     } catch (error) {
       logger.error('Failed to find users with all skills:', error);

--- a/backend/src/services/UserDirectoryService.ts
+++ b/backend/src/services/UserDirectoryService.ts
@@ -25,7 +25,7 @@ interface DirectoryProfile {
   email: string;
   firstName: string;
   lastName: string;
-  role: string;
+  roles: string[];
   employeeId: string | null;
   phone: string | null;
   position: string | null;
@@ -43,12 +43,18 @@ export class UserDirectoryService {
 
   async getProfile(userId: number): Promise<DirectoryProfile | null> {
     const [userRows] = await this.pool.execute<RowDataPacket[]>(
-      `SELECT id, email, first_name, last_name, role, employee_id, phone, position
+      `SELECT id, email, first_name, last_name, employee_id, phone, position
          FROM users WHERE id = ? LIMIT 1`,
       [userId]
     );
     if (userRows.length === 0) return null;
     const u = userRows[0];
+
+    const [roleRows] = await this.pool.execute<RowDataPacket[]>(
+      `SELECT r.name FROM user_roles ur JOIN roles r ON r.id = ur.role_id
+        WHERE ur.user_id = ? ORDER BY r.name`,
+      [userId]
+    );
 
     const [fieldRows] = await this.pool.execute<RowDataPacket[]>(
       `SELECT field_key, field_value, is_public
@@ -63,7 +69,7 @@ export class UserDirectoryService {
       email: u.email as string,
       firstName: u.first_name as string,
       lastName: u.last_name as string,
-      role: u.role as string,
+      roles: roleRows.map((r: any) => r.name as string),
       employeeId: (u.employee_id as string | null) ?? null,
       phone: (u.phone as string | null) ?? null,
       position: (u.position as string | null) ?? null,
@@ -124,7 +130,7 @@ export class UserDirectoryService {
     };
     const extra: Record<string, string> = {};
     if (profile.employeeId) extra['X-EMPLOYEE-ID'] = profile.employeeId;
-    extra['X-ROLE'] = profile.role;
+    if (profile.roles.length > 0) extra['X-ROLE'] = profile.roles.join(', ');
     for (const f of profile.fields.filter((f) => f.isPublic)) {
       const k = `X-${f.key.toUpperCase().replace(/[^A-Z0-9]/g, '-')}`;
       extra[k] = f.value;
@@ -173,27 +179,35 @@ export class UserDirectoryService {
           continue;
         }
         const employeeId = card.extra?.['X-EMPLOYEE-ID'] ?? null;
-        const role = (card.extra?.['X-ROLE']?.toLowerCase() === 'admin'
-          ? 'admin'
-          : card.extra?.['X-ROLE']?.toLowerCase() === 'manager'
-            ? 'manager'
-            : 'employee');
         const [userRes] = await conn.execute<ResultSetHeader>(
-          `INSERT INTO users (email, password_hash, first_name, last_name, role,
+          `INSERT INTO users (email, password_hash, first_name, last_name,
                               employee_id, phone, position, is_active)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1)`,
+           VALUES (?, ?, ?, ?, ?, ?, ?, 1)`,
           [
             card.email,
             options.defaultPasswordHash,
             card.givenName ?? card.fn.split(/\s+/)[0] ?? '',
             card.familyName ?? card.fn.split(/\s+/).slice(1).join(' ') ?? '',
-            role,
             employeeId,
             card.phone ?? null,
             card.title ?? null,
           ]
         );
         const userId = userRes.insertId;
+
+        // Assign roles referenced by name in the X-ROLE field (comma-separated).
+        // Unknown role names are ignored; the user is still created.
+        const roleNames = (card.extra?.['X-ROLE'] ?? '')
+          .split(',')
+          .map((s) => s.trim())
+          .filter((s) => s.length > 0);
+        for (const roleName of roleNames) {
+          await conn.execute(
+            `INSERT IGNORE INTO user_roles (user_id, role_id, scope_org_unit_id)
+             SELECT ?, id, NULL FROM roles WHERE name = ?`,
+            [userId, roleName]
+          );
+        }
         for (const [k, v] of Object.entries(card.extra ?? {})) {
           if (k === 'X-EMPLOYEE-ID' || k === 'X-ROLE') continue;
           const cleanKey = k.replace(/^X-/, '').toLowerCase();

--- a/backend/src/services/UserService.ts
+++ b/backend/src/services/UserService.ts
@@ -27,10 +27,18 @@ export class UserService {
       }
       const passwordHash = await bcrypt.hash(userData.password, config.security.bcryptRounds);
       const [result] = await connection.execute<ResultSetHeader>(
-        'INSERT INTO users (email, password_hash, first_name, last_name, role, phone, employee_id) VALUES (?, ?, ?, ?, ?, ?, ?)',
-        [userData.email, passwordHash, userData.firstName, userData.lastName, userData.role, userData.phone || null, userData.employeeId || null]
+        'INSERT INTO users (email, password_hash, first_name, last_name, phone, employee_id) VALUES (?, ?, ?, ?, ?, ?)',
+        [userData.email, passwordHash, userData.firstName, userData.lastName, userData.phone || null, userData.employeeId || null]
       );
       const userId = result.insertId;
+      if (userData.roleIds && userData.roleIds.length > 0) {
+        for (const roleId of userData.roleIds) {
+          await connection.execute(
+            'INSERT IGNORE INTO user_roles (user_id, role_id, scope_org_unit_id) VALUES (?, ?, NULL)',
+            [userId, roleId]
+          );
+        }
+      }
       if (userData.departmentIds && userData.departmentIds.length > 0) {
         for (const departmentId of userData.departmentIds) {
           await connection.execute('INSERT INTO user_departments (user_id, department_id) VALUES (?, ?)', [userId, departmentId]);
@@ -58,7 +66,7 @@ export class UserService {
   async getUserById(id: number): Promise<User | null> {
     try {
       const [rows] = await this.pool.execute<RowDataPacket[]>(
-        'SELECT id, email, first_name, last_name, role, employee_id, phone, is_active, last_login, created_at, updated_at FROM users WHERE id = ?',
+        'SELECT id, email, first_name, last_name, employee_id, phone, is_active, last_login, created_at, updated_at FROM users WHERE id = ?',
         [id]
       );
       if (rows.length === 0) return null;
@@ -76,7 +84,6 @@ export class UserService {
         email: row.email,
         firstName: row.first_name,
         lastName: row.last_name,
-        role: row.role,
         employeeId: row.employee_id,
         phone: row.phone,
         isActive: Boolean(row.is_active),
@@ -103,9 +110,9 @@ export class UserService {
     }
   }
 
-  async getAllUsers(filters?: { role?: string; departmentId?: number; isActive?: boolean; search?: string }): Promise<User[]> {
+  async getAllUsers(filters?: { roleId?: number; departmentId?: number; isActive?: boolean; search?: string }): Promise<User[]> {
     try {
-      let query = 'SELECT DISTINCT u.id, u.email, u.first_name, u.last_name, u.role, u.employee_id, u.phone, u.is_active, u.last_login, u.created_at, u.updated_at FROM users u';
+      let query = 'SELECT DISTINCT u.id, u.email, u.first_name, u.last_name, u.employee_id, u.phone, u.is_active, u.last_login, u.created_at, u.updated_at FROM users u';
       const conditions: string[] = [];
       const params: any[] = [];
       if (filters?.departmentId) {
@@ -113,9 +120,10 @@ export class UserService {
         conditions.push('ud.department_id = ?');
         params.push(filters.departmentId);
       }
-      if (filters?.role) {
-        conditions.push('u.role = ?');
-        params.push(filters.role);
+      if (filters?.roleId) {
+        query += ' JOIN user_roles ur ON u.id = ur.user_id';
+        conditions.push('ur.role_id = ?');
+        params.push(filters.roleId);
       }
       if (filters?.isActive !== undefined) {
         conditions.push('u.is_active = ?');
@@ -134,7 +142,6 @@ export class UserService {
         email: row.email,
         firstName: row.first_name,
         lastName: row.last_name,
-        role: row.role,
         employeeId: row.employee_id,
         phone: row.phone,
         isActive: Boolean(row.is_active),
@@ -173,10 +180,6 @@ export class UserService {
         updates.push('last_name = ?');
         values.push(userData.lastName);
       }
-      if (userData.role !== undefined) {
-        updates.push('role = ?');
-        values.push(userData.role);
-      }
       if (userData.employeeId !== undefined) {
         updates.push('employee_id = ?');
         values.push(userData.employeeId);
@@ -192,6 +195,19 @@ export class UserService {
       if (updates.length > 0) {
         values.push(id);
         await connection.execute(`UPDATE users SET ${updates.join(', ')}, updated_at = CURRENT_TIMESTAMP WHERE id = ?`, values);
+      }
+      // Replace unscoped role grants when roleIds is provided.
+      if (userData.roleIds !== undefined) {
+        await connection.execute(
+          'DELETE FROM user_roles WHERE user_id = ? AND scope_org_unit_id IS NULL',
+          [id]
+        );
+        for (const roleId of userData.roleIds) {
+          await connection.execute(
+            'INSERT IGNORE INTO user_roles (user_id, role_id, scope_org_unit_id) VALUES (?, ?, NULL)',
+            [id, roleId]
+          );
+        }
       }
       await connection.commit();
       logger.info('User updated: ' + id);
@@ -307,15 +323,23 @@ export class UserService {
     return this.getAllUsers({ departmentId, isActive: true });
   }
 
-  async getUsersByRole(role: string): Promise<User[]> {
-    return this.getAllUsers({ role, isActive: true });
+  async getUsersByRoleId(roleId: number): Promise<User[]> {
+    return this.getAllUsers({ roleId, isActive: true });
   }
 
   async getUserStatistics(): Promise<{ total: number; active: number; inactive: number; byRole: Array<{ role: string; count: number }> }> {
     try {
       const [totalRows] = await this.pool.execute<RowDataPacket[]>('SELECT COUNT(*) as count FROM users');
       const [activeRows] = await this.pool.execute<RowDataPacket[]>('SELECT COUNT(*) as count FROM users WHERE is_active = 1');
-      const [roleRows] = await this.pool.execute<RowDataPacket[]>('SELECT role, COUNT(*) as count FROM users GROUP BY role');
+      // Headcount per role, derived from role assignments (a user may hold
+      // more than one role and therefore count under several role names).
+      const [roleRows] = await this.pool.execute<RowDataPacket[]>(
+        `SELECT r.name AS role, COUNT(DISTINCT ur.user_id) AS count
+           FROM roles r
+           LEFT JOIN user_roles ur ON ur.role_id = r.id
+           GROUP BY r.id
+           ORDER BY r.name ASC`
+      );
       return {
         total: totalRows[0].count || 0,
         active: activeRows[0].count || 0,
@@ -329,18 +353,22 @@ export class UserService {
   }
 
   /**
-   * Returns the users a manager can see: all users for admins, otherwise only
-   * those belonging to a department the manager owns.
+   * Returns the users the given actor may list.
+   *
+   * Users whose management is unrestricted (they hold the `settings.manage`
+   * administrator permission) see everyone; otherwise the listing is scoped to
+   * the departments the actor manages. Fine-grained org-subtree scoping across
+   * all resources is tracked as a follow-up (hierarchical access scoping).
    *
    * Implemented as a single query (no per-user round-trip) so the listing
    * stays O(1) in DB calls regardless of the team size.
    */
-  async getUsersForManager(managerId: number, role: string): Promise<User[]> {
+  async getUsersForManager(actor: User): Promise<User[]> {
     try {
-      if (role === 'admin') return this.getAllUsers();
+      if (actor.permissions?.includes('settings.manage')) return this.getAllUsers();
 
       const [userRows] = await this.pool.execute<RowDataPacket[]>(
-        `SELECT DISTINCT u.id, u.email, u.first_name, u.last_name, u.role,
+        `SELECT DISTINCT u.id, u.email, u.first_name, u.last_name,
                 u.employee_id, u.phone, u.is_active, u.last_login,
                 u.created_at, u.updated_at
          FROM users u
@@ -348,7 +376,7 @@ export class UserService {
          JOIN departments d ON ud.department_id = d.id
          WHERE d.manager_id = ?
          ORDER BY u.last_name ASC, u.first_name ASC`,
-        [managerId]
+        [actor.id]
       );
 
       return userRows.map((row: any) => ({
@@ -356,7 +384,6 @@ export class UserService {
         email: row.email,
         firstName: row.first_name,
         lastName: row.last_name,
-        role: row.role,
         employeeId: row.employee_id,
         phone: row.phone,
         isActive: Boolean(row.is_active),

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -12,16 +12,66 @@ export interface User {
   email: string;
   firstName: string;
   lastName: string;
-  role: 'admin' | 'manager' | 'employee';
   employeeId?: string;
   phone?: string;
   isActive: boolean;
   lastLogin?: Date;
+  /** Roles assigned to the user, each optionally scoped to an org unit. */
+  roles?: UserRoleAssignment[];
+  /** Flattened, de-duplicated effective permission codes (e.g. `schedule.manage`). */
+  permissions?: string[];
   departments?: UserDepartment[];
   skills?: Skill[];
   preferences?: UserPreferences;
   createdAt: Date;
   updatedAt: Date;
+}
+
+// ============================================================================
+// RBAC TYPES — configurable roles and permissions (no hardcoded roles)
+// ============================================================================
+
+export interface Permission {
+  id: number;
+  code: string;
+  resource: string;
+  action: string;
+  description?: string;
+}
+
+export interface Role {
+  id: number;
+  name: string;
+  description?: string;
+  isSystem: boolean;
+  permissions?: string[];
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+export interface UserRoleAssignment {
+  roleId: number;
+  roleName: string;
+  scopeOrgUnitId?: number | null;
+  expiresAt?: Date | null;
+}
+
+export interface CreateRoleRequest {
+  name: string;
+  description?: string;
+  permissionCodes?: string[];
+}
+
+export interface UpdateRoleRequest {
+  name?: string;
+  description?: string;
+  permissionCodes?: string[];
+}
+
+export interface AssignRoleRequest {
+  roleId: number;
+  scopeOrgUnitId?: number | null;
+  expiresAt?: string | null;
 }
 
 interface UserDepartment {
@@ -42,7 +92,8 @@ export interface CreateUserRequest {
   password: string;
   firstName: string;
   lastName: string;
-  role: 'admin' | 'manager' | 'employee';
+  /** Role ids to grant the new user (unscoped). */
+  roleIds?: number[];
   employeeId?: string;
   phone?: string;
   departmentIds?: number[];
@@ -54,7 +105,8 @@ export interface UpdateUserRequest {
   password?: string;
   firstName?: string;
   lastName?: string;
-  role?: 'admin' | 'manager' | 'employee';
+  /** When provided, replaces the user's unscoped role grants. */
+  roleIds?: number[];
   employeeId?: string;
   phone?: string;
   isActive?: boolean;


### PR DESCRIPTION
## Summary

Removes the 3-value `ENUM('admin','manager','employee')` hardcoded in the database schema, JWT, auth middleware, and 30+ route/service handlers. Replaces it with a fully configurable **permission-based authorization model**.

**Closes #88** (Configurable RBAC core — Part B of the enterprise roadmap, tracked in epic #87)

---

## What changed

### Database
- Dropped `users.role ENUM` column.
- Changed `approval_matrix.approver_role` → `approver_role_id INT FK → roles.id`.
- New tables: `permissions` (31 capability codes), `roles` (configurable bundles), `role_permissions` (M:N), `user_roles` (scoped + time-bound grants).
- Seeded: Administrator (all perms) / Manager (management subset) / Employee (read-only subset).

### Backend
- `RbacService`: resolves effective permissions per request; full CRUD for roles/permissions/user-roles.
- `authenticate`: loads user's effective permissions + role assignments from DB (pool call on every request).
- `requirePermission(code)` replaces `requireRole`/`requireAdmin`/`requireManager` everywhere.
- `userHasPermission(user, code)` helper for inline checks in route handlers.
- New admin routes: `GET|POST /api/roles`, `PUT|DELETE /api/roles/:id`, `GET /api/permissions`, `POST|DELETE /api/roles/users/:userId[/:roleId]`.
- `UserService.getUsersForManager(actor: User)` accepts a User object; scopes by `settings.manage` permission.
- `ApprovalMatrixService.findFirstActiveByRole` → `findFirstActiveByRoleId` (role-id lookup via `user_roles`).
- `BulkImportService`: CSV `role` column now holds a role name resolved against the `roles` table at import time.

### Frontend
- `User` type: `role` field removed; `permissions: string[]` and `roles: UserRoleAssignment[]` added.
- Auth flow: JWT carries `userId` only; login response includes `permissions` + `roles` resolved at login time.

### Tests
- 67 test suites / 1055 tests — all green.
- Updated `auth.middleware.test.ts` and `.extended` to test `requirePermission`.
- Updated all route test mocks to export `requirePermission`/`userHasPermission` instead of the old guards.
- Added `src/__tests__/helpers/permissions.ts` with a `permissionsForRole` helper that maps the legacy shorthand to permission codes for test mocks.

---

## How to verify

```bash
cd backend
npm run lint && npm run deadcode && npm run build && npm run test:coverage

# Verify no hardcoded role strings remain in non-test source:
grep -rn "requireAdmin\|requireManager\|requireRole" src --include='*.ts' | grep -v __tests__
grep -rn "role === 'admin'\|role === 'manager'\|role === 'employee'" src --include='*.ts' | grep -v __tests__

# Re-init schema and demo seed, then run e2e:
npm run db:init
npm run db:seed:demo
cd ../frontend && npm test -- --watchAll=false --ci
```

Create a custom role via the new API and confirm it grants access with zero code changes:
```bash
curl -s -X POST /api/roles -d '{"name":"ShiftSupervisor","permissionCodes":["schedule.manage","shift.manage"]}' | jq
# Assign to a user, log in, confirm schedule management works
```