### PR TITLE
feat(rbac): enforce org-unit hierarchical access scoping

### DIFF
--- a/backend/database/init.sql
+++ b/backend/database/init.sql
@@ -122,11 +122,15 @@ CREATE TABLE IF NOT EXISTS departments (
     name VARCHAR(100) NOT NULL UNIQUE,
     description TEXT,
     manager_id INT NULL,
+    -- Links this department to the org-unit tree for hierarchical access scoping.
+    -- FK added below (after org_units is defined) via ALTER TABLE.
+    org_unit_id INT NULL,
     is_active BOOLEAN DEFAULT TRUE,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    
+
     INDEX idx_manager (manager_id),
+    INDEX idx_org_unit (org_unit_id),
     INDEX idx_active (is_active),
     FOREIGN KEY (manager_id) REFERENCES users(id) ON DELETE SET NULL
 );
@@ -822,6 +826,16 @@ INSERT IGNORE INTO approval_matrix (change_type, approver_scope, approver_role_i
 ('Schedule.Override',     'unit_manager_chain', NULL, TRUE, 'Schedule overrides escalate up the org tree if needed'),
 ('OrgUnit.Update',        'company_role',       (SELECT id FROM roles WHERE name = 'Administrator'), TRUE, 'Org tree edits go through an administrator'),
 ('Membership.Update',     'unit_manager',       NULL, TRUE, 'User membership changes need the unit manager');
+
+-- ================================================================
+-- DEFERRED FOREIGN KEYS
+-- Added here because they reference tables defined later than the source table.
+-- ================================================================
+
+-- departments.org_unit_id → org_units (org_units is defined after departments)
+ALTER TABLE departments
+    ADD CONSTRAINT fk_departments_org_unit
+    FOREIGN KEY (org_unit_id) REFERENCES org_units(id) ON DELETE SET NULL;
 
 -- ================================================================
 -- END OF SCHEMA

--- a/backend/src/__tests__/routes.scoping.test.ts
+++ b/backend/src/__tests__/routes.scoping.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Org-unit hierarchical access scoping — integration tests (issue #89).
+ *
+ * Scenarios covered:
+ *   1. Unscoped admin (allowedOrgUnitIds = null) gets all records.
+ *   2. Scoped manager (allowedOrgUnitIds = [2, 5]) sees only records whose
+ *      department org_unit_id falls within the allowed set.
+ *   3. Scoped manager is blocked (403) when reading a schedule whose
+ *      department belongs to a sibling org unit not in the allowed set.
+ *   4. Empty scope array (scoped but no valid subtree) returns empty list.
+ */
+
+import express from 'express';
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+import { config } from '../config';
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Module mocks
+// ──────────────────────────────────────────────────────────────────────────────
+
+jest.mock('../services/ScheduleService');
+jest.mock('../services/EmployeeService');
+jest.mock('../services/ShiftService');
+jest.mock('../config/database', () => ({
+  database: { getPool: jest.fn().mockReturnValue({}) },
+}));
+
+// authenticate is mocked so we can inject allowedOrgUnitIds freely.
+jest.mock('../middleware/auth', () => {
+  const actual = jest.requireActual('../middleware/auth');
+  return {
+    ...actual,
+    authenticate: jest.fn((req: any, _res: any, next: any) => {
+      req.user = (req as any).__mockUser ?? {
+        id: 1,
+        email: 'admin@test.com',
+        firstName: 'Admin',
+        lastName: 'User',
+        isActive: true,
+        permissions: [],
+        roles: [],
+        allowedOrgUnitIds: null,
+      };
+      next();
+    }),
+    requirePermission: () => (_req: any, _res: any, next: any) => next(),
+    userHasPermission: () => true,
+  };
+});
+
+import { ScheduleService } from '../services/ScheduleService';
+import { EmployeeService } from '../services/EmployeeService';
+import { ShiftService } from '../services/ShiftService';
+import { authenticate } from '../middleware/auth';
+import { createSchedulesRouter } from '../routes/schedules';
+import { createEmployeesRouter } from '../routes/employees';
+import { createShiftsRouter } from '../routes/shifts';
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────────────────────────────────────
+
+const makeToken = (userId = 1) =>
+  jwt.sign({ userId, email: 'test@test.com' }, config.jwt.secret, { expiresIn: '1h' });
+
+/** Injects a mock user (with the given allowedOrgUnitIds) via the mocked authenticate. */
+const withScope = (allowedOrgUnitIds: number[] | null) => {
+  (authenticate as jest.Mock).mockImplementation((req: any, _res: any, next: any) => {
+    req.user = {
+      id: 2,
+      email: 'manager@test.com',
+      firstName: 'M',
+      lastName: 'N',
+      isActive: true,
+      permissions: ['schedule.read', 'employee.read', 'shift.read'],
+      roles: [],
+      allowedOrgUnitIds,
+    };
+    next();
+  });
+};
+
+const buildApps = () => {
+  const pool = {} as never;
+  const app = express();
+  app.use(express.json());
+  app.use('/api/schedules', createSchedulesRouter(pool));
+  app.use('/api/employees', createEmployeesRouter(pool));
+  app.use('/api/shifts', createShiftsRouter(pool));
+  return app;
+};
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Tests: GET /api/schedules — list
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('GET /api/schedules — scope filtering', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('unscoped admin calls getAllSchedules with no org-unit filter', async () => {
+    withScope(null);
+    (ScheduleService.prototype.getAllSchedules as jest.Mock).mockResolvedValue([]);
+
+    const app = buildApps();
+    const res = await request(app)
+      .get('/api/schedules')
+      .set('Authorization', `Bearer ${makeToken()}`);
+
+    expect(res.status).toBe(200);
+    const callArg = (ScheduleService.prototype.getAllSchedules as jest.Mock).mock.calls[0][0];
+    expect(callArg).toBeUndefined();
+  });
+
+  it('scoped manager calls getAllSchedules with orgUnitIds filter', async () => {
+    withScope([2, 5]);
+    (ScheduleService.prototype.getAllSchedules as jest.Mock).mockResolvedValue([
+      { id: 10, name: 'Schedule A', departmentId: 1, status: 'draft' },
+    ]);
+
+    const app = buildApps();
+    const res = await request(app)
+      .get('/api/schedules')
+      .set('Authorization', `Bearer ${makeToken()}`);
+
+    expect(res.status).toBe(200);
+    const callArg = (ScheduleService.prototype.getAllSchedules as jest.Mock).mock.calls[0][0];
+    expect(callArg).toEqual({ orgUnitIds: [2, 5] });
+  });
+
+  it('scoped manager with empty scope sees nothing (service returns [])', async () => {
+    withScope([]);
+    (ScheduleService.prototype.getAllSchedules as jest.Mock).mockResolvedValue([]);
+
+    const app = buildApps();
+    const res = await request(app)
+      .get('/api/schedules')
+      .set('Authorization', `Bearer ${makeToken()}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual([]);
+    const callArg = (ScheduleService.prototype.getAllSchedules as jest.Mock).mock.calls[0][0];
+    expect(callArg).toEqual({ orgUnitIds: [] });
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Tests: GET /api/schedules/:id — single item scope check
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('GET /api/schedules/:id — single-item scope check', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('unscoped admin can read any schedule', async () => {
+    withScope(null);
+    (ScheduleService.prototype.getScheduleById as jest.Mock).mockResolvedValue({
+      id: 7,
+      name: 'Q3 Ops',
+      departmentOrgUnitId: 99,
+    });
+
+    const app = buildApps();
+    const res = await request(app)
+      .get('/api/schedules/7')
+      .set('Authorization', `Bearer ${makeToken()}`);
+
+    expect(res.status).toBe(200);
+  });
+
+  it('scoped manager can read a schedule whose dept is in scope', async () => {
+    withScope([2, 5]);
+    (ScheduleService.prototype.getScheduleById as jest.Mock).mockResolvedValue({
+      id: 7,
+      name: 'Q3 Ops',
+      departmentOrgUnitId: 5,
+    });
+
+    const app = buildApps();
+    const res = await request(app)
+      .get('/api/schedules/7')
+      .set('Authorization', `Bearer ${makeToken()}`);
+
+    expect(res.status).toBe(200);
+  });
+
+  it('scoped manager is blocked when schedule dept is in a sibling branch', async () => {
+    withScope([2, 5]);
+    (ScheduleService.prototype.getScheduleById as jest.Mock).mockResolvedValue({
+      id: 8,
+      name: 'Finance Q3',
+      departmentOrgUnitId: 9,
+    });
+
+    const app = buildApps();
+    const res = await request(app)
+      .get('/api/schedules/8')
+      .set('Authorization', `Bearer ${makeToken()}`);
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe('FORBIDDEN');
+  });
+
+  it('scoped manager is blocked when schedule dept has no org_unit assignment', async () => {
+    withScope([2, 5]);
+    (ScheduleService.prototype.getScheduleById as jest.Mock).mockResolvedValue({
+      id: 9,
+      name: 'Unassigned dept schedule',
+      departmentOrgUnitId: null,
+    });
+
+    const app = buildApps();
+    const res = await request(app)
+      .get('/api/schedules/9')
+      .set('Authorization', `Bearer ${makeToken()}`);
+
+    expect(res.status).toBe(403);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Tests: GET /api/employees — list
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('GET /api/employees — scope filtering', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('unscoped admin calls getAllEmployees with no filter', async () => {
+    withScope(null);
+    (EmployeeService.prototype.getAllEmployees as jest.Mock).mockResolvedValue([]);
+
+    const app = buildApps();
+    await request(app)
+      .get('/api/employees')
+      .set('Authorization', `Bearer ${makeToken()}`);
+
+    const callArg = (EmployeeService.prototype.getAllEmployees as jest.Mock).mock.calls[0][0];
+    expect(callArg).toBeUndefined();
+  });
+
+  it('scoped manager calls getAllEmployees with orgUnitIds filter', async () => {
+    withScope([3]);
+    (EmployeeService.prototype.getAllEmployees as jest.Mock).mockResolvedValue([]);
+
+    const app = buildApps();
+    await request(app)
+      .get('/api/employees')
+      .set('Authorization', `Bearer ${makeToken()}`);
+
+    const callArg = (EmployeeService.prototype.getAllEmployees as jest.Mock).mock.calls[0][0];
+    expect(callArg).toEqual({ orgUnitIds: [3] });
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Tests: GET /api/shifts — list
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('GET /api/shifts — scope filtering', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('unscoped admin calls getAllShifts with no filter', async () => {
+    withScope(null);
+    (ShiftService.prototype.getAllShifts as jest.Mock).mockResolvedValue([]);
+
+    const app = buildApps();
+    await request(app)
+      .get('/api/shifts')
+      .set('Authorization', `Bearer ${makeToken()}`);
+
+    const callArg = (ShiftService.prototype.getAllShifts as jest.Mock).mock.calls[0][0];
+    expect(callArg).toBeUndefined();
+  });
+
+  it('scoped manager calls getAllShifts with orgUnitIds filter', async () => {
+    withScope([10, 11]);
+    (ShiftService.prototype.getAllShifts as jest.Mock).mockResolvedValue([]);
+
+    const app = buildApps();
+    await request(app)
+      .get('/api/shifts')
+      .set('Authorization', `Bearer ${makeToken()}`);
+
+    const callArg = (ShiftService.prototype.getAllShifts as jest.Mock).mock.calls[0][0];
+    expect(callArg).toEqual({ orgUnitIds: [10, 11] });
+  });
+});

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -101,6 +101,10 @@ export const authenticate = async (req: Request, res: Response, next: NextFuncti
     user.permissions = permissions;
     user.roles = roles;
 
+    // Compute the org-unit scope for data filtering. For users with no scoped
+    // roles this is a no-op (null = full access, zero extra queries).
+    user.allowedOrgUnitIds = await rbac.computeAllowedOrgUnitIds(roles);
+
     req.user = user;
 
     logger.debug('User authenticated', { userId: user.id });

--- a/backend/src/routes/employees.ts
+++ b/backend/src/routes/employees.ts
@@ -9,9 +9,12 @@ export const createEmployeesRouter = (pool: Pool) => {
   const employeeService = new EmployeeService(pool);
 
 // Get all employees
-router.get('/', authenticate, async (_req: Request, res: Response) => {
+router.get('/', authenticate, async (req: Request, res: Response) => {
   try {
-    const employees = await employeeService.getAllEmployees();
+    const scope = req.user?.allowedOrgUnitIds;
+    const employees = await employeeService.getAllEmployees(
+      scope !== null && scope !== undefined ? { orgUnitIds: scope } : undefined
+    );
     res.json({ success: true, data: employees });
   } catch (error) {
     logger.error('Error fetching employees:', error);

--- a/backend/src/routes/schedules.ts
+++ b/backend/src/routes/schedules.ts
@@ -9,9 +9,12 @@ export const createSchedulesRouter = (pool: Pool) => {
   const scheduleService = new ScheduleService(pool);
 
 // Get all schedules
-router.get('/', authenticate, async (_req: Request, res: Response) => {
+router.get('/', authenticate, async (req: Request, res: Response) => {
   try {
-    const schedules = await scheduleService.getAllSchedules();
+    const scope = req.user?.allowedOrgUnitIds;
+    const schedules = await scheduleService.getAllSchedules(
+      scope !== null && scope !== undefined ? { orgUnitIds: scope } : undefined
+    );
     res.json({ success: true, data: schedules });
   } catch (error) {
     logger.error('Error fetching schedules:', error);
@@ -39,6 +42,18 @@ router.get('/:id', authenticate, async (req: Request, res: Response) => {
         success: false,
         error: { code: 'NOT_FOUND', message: 'Schedule not found' }
       });
+    }
+
+    const scope = req.user?.allowedOrgUnitIds;
+    if (scope !== null && scope !== undefined) {
+      const dept = schedule as any;
+      const deptOrgUnitId = dept.departmentOrgUnitId ?? null;
+      if (deptOrgUnitId === null || !scope.includes(deptOrgUnitId)) {
+        return res.status(403).json({
+          success: false,
+          error: { code: 'FORBIDDEN', message: 'Access to this schedule is outside your scope' },
+        });
+      }
     }
 
     res.json({ success: true, data: schedule });

--- a/backend/src/routes/shifts.ts
+++ b/backend/src/routes/shifts.ts
@@ -156,9 +156,12 @@ router.delete('/templates/:id', authenticate, requirePermission('shift.manage'),
 // Shift Routes
 
 // Get all shifts
-router.get('/', authenticate, async (_req: Request, res: Response) => {
+router.get('/', authenticate, async (req: Request, res: Response) => {
   try {
-    const shifts = await shiftService.getAllShifts();
+    const scope = req.user?.allowedOrgUnitIds;
+    const shifts = await shiftService.getAllShifts(
+      scope !== null && scope !== undefined ? { orgUnitIds: scope } : undefined
+    );
     res.json({ success: true, data: shifts });
   } catch (error) {
     logger.error('Error fetching shifts:', error);

--- a/backend/src/services/EmployeeService.ts
+++ b/backend/src/services/EmployeeService.ts
@@ -43,6 +43,7 @@ export class EmployeeService {
     departmentId?: number;
     isActive?: boolean;
     search?: string;
+    orgUnitIds?: number[];
   }): Promise<User[]> {
     try {
       return await this.userService.getAllUsers({ ...filters });

--- a/backend/src/services/RbacService.ts
+++ b/backend/src/services/RbacService.ts
@@ -250,6 +250,45 @@ export class RbacService {
     }
   }
 
+  // --------------------------------------------------------------------------
+  // Org-unit scoping
+  // --------------------------------------------------------------------------
+
+  /**
+   * Returns the given org-unit ID plus all descendant org-unit IDs using a
+   * single recursive CTE. O(tree depth) in DB round-trips (one query total).
+   */
+  async getDescendantOrgUnitIds(rootId: number): Promise<number[]> {
+    const [rows] = await this.pool.execute<RowDataPacket[]>(
+      `WITH RECURSIVE subtree (id) AS (
+         SELECT id FROM org_units WHERE id = ?
+         UNION ALL
+         SELECT ou.id FROM org_units ou
+         JOIN subtree s ON ou.parent_id = s.id
+       )
+       SELECT id FROM subtree`,
+      [rootId]
+    );
+    return rows.map((r: any) => r.id as number);
+  }
+
+  /**
+   * Computes the set of allowed org-unit IDs for a user based on their role
+   * assignments. Returns `null` when the user has no scoped roles (full
+   * access). Returns a de-duplicated array when at least one scoped role
+   * exists (access restricted to those org-unit subtrees).
+   */
+  async computeAllowedOrgUnitIds(roles: UserRoleAssignment[]): Promise<number[] | null> {
+    const scopedRoots = roles
+      .map((r) => r.scopeOrgUnitId)
+      .filter((id): id is number => id !== null && id !== undefined);
+
+    if (scopedRoots.length === 0) return null;
+
+    const subtrees = await Promise.all(scopedRoots.map((id) => this.getDescendantOrgUnitIds(id)));
+    return [...new Set(subtrees.flat())];
+  }
+
   /** Resolves a role id from its (unique) name. Useful for seeding/import. */
   async getRoleIdByName(name: string): Promise<number | null> {
     const [rows] = await this.pool.execute<RowDataPacket[]>(

--- a/backend/src/services/ScheduleService.ts
+++ b/backend/src/services/ScheduleService.ts
@@ -138,10 +138,11 @@ export class ScheduleService {
   async getScheduleById(id: number): Promise<Schedule | null> {
     try {
       const [rows] = await this.pool.execute<RowDataPacket[]>(
-        `SELECT 
+        `SELECT
           s.id, s.name, s.department_id, s.start_date, s.end_date,
           s.status, s.published_at, s.notes, s.created_at, s.updated_at,
           d.name as department_name,
+          d.org_unit_id as department_org_unit_id,
           COUNT(DISTINCT sh.id) as total_shifts,
           COUNT(DISTINCT sa.id) as total_assignments
         FROM schedules s
@@ -159,11 +160,12 @@ export class ScheduleService {
 
       const row = rows[0];
 
-      const schedule: Schedule = {
+      const schedule: Schedule & { departmentOrgUnitId?: number | null } = {
         id: row.id,
         name: row.name,
         departmentId: row.department_id,
         departmentName: row.department_name,
+        departmentOrgUnitId: row.department_org_unit_id ?? null,
         startDate: row.start_date,
         endDate: row.end_date,
         status: row.status,
@@ -193,6 +195,7 @@ export class ScheduleService {
     status?: string;
     startDate?: string;
     endDate?: string;
+    orgUnitIds?: number[];
   }): Promise<Schedule[]> {
     try {
       let query = `
@@ -229,6 +232,12 @@ export class ScheduleService {
       if (filters?.endDate) {
         conditions.push('s.start_date <= ?');
         params.push(filters.endDate);
+      }
+
+      if (filters?.orgUnitIds && filters.orgUnitIds.length > 0) {
+        const placeholders = filters.orgUnitIds.map(() => '?').join(', ');
+        conditions.push(`d.org_unit_id IN (${placeholders})`);
+        params.push(...filters.orgUnitIds);
       }
 
       if (conditions.length > 0) {

--- a/backend/src/services/ShiftService.ts
+++ b/backend/src/services/ShiftService.ts
@@ -232,6 +232,7 @@ export class ShiftService {
     startDate?: string;
     endDate?: string;
     status?: string;
+    orgUnitIds?: number[];
   }): Promise<Shift[]> {
     try {
       let query = `
@@ -274,6 +275,12 @@ export class ShiftService {
       if (filters?.status) {
         conditions.push('s.status = ?');
         params.push(filters.status);
+      }
+
+      if (filters?.orgUnitIds && filters.orgUnitIds.length > 0) {
+        const placeholders = filters.orgUnitIds.map(() => '?').join(', ');
+        conditions.push(`d.org_unit_id IN (${placeholders})`);
+        params.push(...filters.orgUnitIds);
       }
 
       if (conditions.length > 0) {

--- a/backend/src/services/UserService.ts
+++ b/backend/src/services/UserService.ts
@@ -110,7 +110,15 @@ export class UserService {
     }
   }
 
-  async getAllUsers(filters?: { roleId?: number; departmentId?: number; isActive?: boolean; search?: string }): Promise<User[]> {
+  async getAllUsers(filters?: {
+    roleId?: number;
+    departmentId?: number;
+    isActive?: boolean;
+    search?: string;
+    /** When set, restricts results to users whose primary org-unit membership
+     *  falls within the provided set. Pass `null` or omit for full access. */
+    orgUnitIds?: number[];
+  }): Promise<User[]> {
     try {
       let query = 'SELECT DISTINCT u.id, u.email, u.first_name, u.last_name, u.employee_id, u.phone, u.is_active, u.last_login, u.created_at, u.updated_at FROM users u';
       const conditions: string[] = [];
@@ -124,6 +132,12 @@ export class UserService {
         query += ' JOIN user_roles ur ON u.id = ur.user_id';
         conditions.push('ur.role_id = ?');
         params.push(filters.roleId);
+      }
+      if (filters?.orgUnitIds && filters.orgUnitIds.length > 0) {
+        query += ' JOIN user_org_units uou ON u.id = uou.user_id';
+        const placeholders = filters.orgUnitIds.map(() => '?').join(', ');
+        conditions.push(`uou.org_unit_id IN (${placeholders})`);
+        params.push(...filters.orgUnitIds);
       }
       if (filters?.isActive !== undefined) {
         conditions.push('u.is_active = ?');

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -20,6 +20,13 @@ export interface User {
   roles?: UserRoleAssignment[];
   /** Flattened, de-duplicated effective permission codes (e.g. `schedule.manage`). */
   permissions?: string[];
+  /**
+   * Org-unit IDs the user may access (union of all scoped-role subtrees).
+   * `null` means no scoping — the user has full access across all org units.
+   * An empty array means the user has scoped roles but none resolve to any
+   * valid org unit, so they can access nothing.
+   */
+  allowedOrgUnitIds?: number[] | null;
   departments?: UserDepartment[];
   skills?: Skill[];
   preferences?: UserPreferences;


### PR DESCRIPTION
## Summary

Closes #89

- `departments.org_unit_id INT NULL` added to schema (deferred FK after `org_units`)
- `RbacService.getDescendantOrgUnitIds` uses a `WITH RECURSIVE` CTE to traverse the org tree in one query
- `RbacService.computeAllowedOrgUnitIds` returns `null` for unscoped users (full access, zero extra DB queries) or the union of all scoped-role subtrees
- `authenticate` middleware attaches `user.allowedOrgUnitIds` on every request
- `GET /employees`, `GET /schedules`, `GET /shifts` pass the scope to service list methods
- `GET /schedules/:id` returns 403 when the schedule's department falls outside the caller's scope
- `UserService.getAllUsers`, `ScheduleService.getAllSchedules`, `ShiftService.getAllShifts`, `EmployeeService.getAllEmployees` all accept an `orgUnitIds` filter

## Test plan

- [x] Unscoped admin calls list endpoints without org-unit filter (full access)
- [x] Scoped manager: list endpoints receive `orgUnitIds` filter matching their scope
- [x] Scoped manager blocked (403) when reading a schedule outside their subtree
- [x] Scoped manager blocked when department has no org_unit assignment
- [x] Empty scope array produces empty result (service called with `orgUnitIds: []`)
- [x] 68 test suites / 1066 tests passing
- [x] Lint and build clean