### PR TITLE
feat(rbac): add delegation framework for temporary authority transfer

### DIFF
--- a/backend/database/init.sql
+++ b/backend/database/init.sql
@@ -828,6 +828,34 @@ INSERT IGNORE INTO approval_matrix (change_type, approver_scope, approver_role_i
 ('Membership.Update',     'unit_manager',       NULL, TRUE, 'User membership changes need the unit manager');
 
 -- ================================================================
+-- DELEGATIONS TABLE
+-- Allows user A (delegator) to grant user B (delegatee) a subset of their
+-- own permissions for a bounded time window. Rules enforced by the app:
+--   - permission_codes must be a subset of the delegator's own permissions
+--   - chained sub-delegation is not allowed
+--   - a delegation that has passed expires_at is ignored by getEffectivePermissions
+-- ================================================================
+CREATE TABLE IF NOT EXISTS delegations (
+    id INT PRIMARY KEY AUTO_INCREMENT,
+    delegator_id INT NOT NULL,
+    delegatee_id INT NOT NULL,
+    permission_codes JSON NOT NULL,
+    scope_org_unit_id INT NULL,
+    starts_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    expires_at TIMESTAMP NOT NULL,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+    INDEX idx_delegatee (delegatee_id),
+    INDEX idx_delegator (delegator_id),
+    INDEX idx_active_expiry (is_active, expires_at),
+
+    FOREIGN KEY (delegator_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (delegatee_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+-- ================================================================
 -- DEFERRED FOREIGN KEYS
 -- Added here because they reference tables defined later than the source table.
 -- ================================================================

--- a/backend/src/__tests__/delegation.service.test.ts
+++ b/backend/src/__tests__/delegation.service.test.ts
@@ -1,0 +1,159 @@
+/**
+ * DelegationService unit tests (issue #90).
+ *
+ * Covers:
+ *   - successful delegation creation
+ *   - escalation guard (code not held by delegator is rejected)
+ *   - self-delegation guard
+ *   - RbacService.getEffectivePermissions merges active delegations
+ *   - expired delegation is excluded from effective permissions
+ */
+
+import { DelegationService } from '../services/DelegationService';
+import { RbacService } from '../services/RbacService';
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Pool mock helpers
+// ──────────────────────────────────────────────────────────────────────────────
+
+const makePool = () => {
+  const execute = jest.fn();
+  return { pool: { execute } as never, execute };
+};
+
+// ──────────────────────────────────────────────────────────────────────────────
+// DelegationService tests
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('DelegationService.createDelegation', () => {
+  const delegatorPerms = ['timeoff.approve', 'schedule.read', 'employee.read'];
+
+  it('creates a delegation when all requested codes are held by the delegator', async () => {
+    const { pool, execute } = makePool();
+    execute
+      .mockResolvedValueOnce([{ insertId: 42, affectedRows: 1 }, null]) // INSERT
+      .mockResolvedValueOnce([[]])                                       // writeAuditLog audit insert
+      .mockResolvedValueOnce([                                           // getDelegationById
+        [{
+          id: 42,
+          delegator_id: 1,
+          delegatee_id: 2,
+          permission_codes: JSON.stringify(['timeoff.approve']),
+          scope_org_unit_id: null,
+          starts_at: new Date(),
+          expires_at: new Date(Date.now() + 86400000),
+          is_active: 1,
+          created_at: new Date(),
+          updated_at: new Date(),
+        }],
+        null,
+      ]);
+
+    const service = new DelegationService(pool);
+    const result = await service.createDelegation(1, delegatorPerms, {
+      delegateeId: 2,
+      permissionCodes: ['timeoff.approve'],
+      expiresAt: new Date(Date.now() + 86400000).toISOString(),
+    });
+
+    expect(result.id).toBe(42);
+    expect(result.permissionCodes).toEqual(['timeoff.approve']);
+  });
+
+  it('throws when a requested code is not held by the delegator (escalation guard)', async () => {
+    const { pool } = makePool();
+    const service = new DelegationService(pool);
+
+    await expect(
+      service.createDelegation(1, delegatorPerms, {
+        delegateeId: 2,
+        permissionCodes: ['settings.manage'], // not in delegatorPerms
+        expiresAt: new Date(Date.now() + 86400000).toISOString(),
+      })
+    ).rejects.toThrow(/escalation/);
+  });
+
+  it('throws when delegatee is the same as the delegator', async () => {
+    const { pool } = makePool();
+    const service = new DelegationService(pool);
+
+    await expect(
+      service.createDelegation(1, delegatorPerms, {
+        delegateeId: 1,
+        permissionCodes: ['timeoff.approve'],
+        expiresAt: new Date(Date.now() + 86400000).toISOString(),
+      })
+    ).rejects.toThrow(/yourself/);
+  });
+});
+
+describe('DelegationService.revokeDelegation', () => {
+  it('throws when delegation does not exist', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[], null]);
+
+    const service = new DelegationService(pool);
+    await expect(service.revokeDelegation(999, 1)).rejects.toThrow(/not found/);
+  });
+
+  it('throws when the requestor is not the delegator', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[{ id: 10, delegator_id: 5 }], null]);
+
+    const service = new DelegationService(pool);
+    await expect(service.revokeDelegation(10, 99)).rejects.toThrow(/Only the delegator/);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// RbacService.getEffectivePermissions — delegation merge
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('RbacService.getEffectivePermissions — delegation merge', () => {
+  it('includes delegated permissions alongside role permissions', async () => {
+    const { pool, execute } = makePool();
+    // First call: role-based permissions
+    execute.mockResolvedValueOnce([[{ code: 'schedule.read' }], null]);
+    // Second call: active delegations
+    execute.mockResolvedValueOnce([
+      [{ permission_codes: JSON.stringify(['timeoff.approve']) }],
+      null,
+    ]);
+
+    const service = new RbacService(pool);
+    const perms = await service.getEffectivePermissions(7);
+
+    expect(perms).toContain('schedule.read');
+    expect(perms).toContain('timeoff.approve');
+    expect(new Set(perms).size).toBe(perms.length); // no duplicates
+  });
+
+  it('excludes expired delegations (query WHERE handles it; mock returns [])', async () => {
+    const { pool, execute } = makePool();
+    // Role-based permissions
+    execute.mockResolvedValueOnce([[{ code: 'employee.read' }], null]);
+    // Active delegations — empty because the delegation has expired
+    execute.mockResolvedValueOnce([[], null]);
+
+    const service = new RbacService(pool);
+    const perms = await service.getEffectivePermissions(7);
+
+    expect(perms).toEqual(['employee.read']);
+    expect(perms).not.toContain('timeoff.approve');
+  });
+
+  it('de-duplicates codes that appear in both role and delegation', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[{ code: 'schedule.read' }], null]);
+    execute.mockResolvedValueOnce([
+      [{ permission_codes: JSON.stringify(['schedule.read', 'timeoff.approve']) }],
+      null,
+    ]);
+
+    const service = new RbacService(pool);
+    const perms = await service.getEffectivePermissions(7);
+
+    expect(perms.filter((c) => c === 'schedule.read')).toHaveLength(1);
+    expect(perms).toContain('timeoff.approve');
+  });
+});

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -46,6 +46,7 @@ import { createEventsRouter } from './routes/events';
 import { createOrgRouter } from './routes/org';
 import { createPoliciesRouter } from './routes/policies';
 import { createRbacRouter } from './routes/rbac';
+import { createDelegationsRouter } from './routes/delegations';
 
 interface BuildAppOptions {
   /** When true, skip rate limiting + morgan logging (useful for tests). */
@@ -122,6 +123,7 @@ export function buildApp(pool: Pool, options: BuildAppOptions = {}): express.Exp
   const rbacRouters = createRbacRouter(pool);
   app.use('/api/roles', rbacRouters.roles);
   app.use('/api/permissions', rbacRouters.permissions);
+  app.use('/api/delegations', createDelegationsRouter(pool));
 
   app.use('*', (_req: express.Request, res: express.Response) => {
     res.status(404).json({

--- a/backend/src/routes/delegations.ts
+++ b/backend/src/routes/delegations.ts
@@ -1,0 +1,90 @@
+/**
+ * Delegation Routes
+ *
+ * POST   /api/delegations        — create a delegation (delegator = req.user)
+ * GET    /api/delegations        — list delegations where req.user is delegator or delegatee
+ * DELETE /api/delegations/:id    — revoke a delegation (only the delegator may do this)
+ *
+ * @author Luca Ostinelli
+ */
+
+import { Router, Request, Response } from 'express';
+import { Pool } from 'mysql2/promise';
+import { DelegationService } from '../services/DelegationService';
+import { authenticate } from '../middleware/auth';
+import { logger } from '../config/logger';
+
+export const createDelegationsRouter = (pool: Pool): Router => {
+  const router = Router();
+  const delegationService = new DelegationService(pool);
+
+  // Create a delegation
+  router.post('/', authenticate, async (req: Request, res: Response) => {
+    try {
+      const actor = req.user!;
+      const { delegateeId, permissionCodes, expiresAt, scopeOrgUnitId } = req.body;
+
+      if (!delegateeId || !Array.isArray(permissionCodes) || permissionCodes.length === 0 || !expiresAt) {
+        return res.status(400).json({
+          success: false,
+          error: { code: 'INVALID_INPUT', message: 'delegateeId, permissionCodes (non-empty array), and expiresAt are required' },
+        });
+      }
+
+      const delegation = await delegationService.createDelegation(
+        actor.id,
+        actor.permissions ?? [],
+        { delegateeId, permissionCodes, expiresAt, scopeOrgUnitId: scopeOrgUnitId ?? null }
+      );
+
+      res.status(201).json({ success: true, data: delegation, message: 'Delegation created' });
+    } catch (error: any) {
+      if (
+        error.message?.includes('escalation') ||
+        error.message?.includes('yourself')
+      ) {
+        return res.status(422).json({
+          success: false,
+          error: { code: 'DELEGATION_INVALID', message: error.message },
+        });
+      }
+      logger.error('Error creating delegation:', error);
+      res.status(500).json({ success: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to create delegation' } });
+    }
+  });
+
+  // List delegations for the current user
+  router.get('/', authenticate, async (req: Request, res: Response) => {
+    try {
+      const delegations = await delegationService.listForUser(req.user!.id);
+      res.json({ success: true, data: delegations });
+    } catch (error) {
+      logger.error('Error fetching delegations:', error);
+      res.status(500).json({ success: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to fetch delegations' } });
+    }
+  });
+
+  // Revoke a delegation
+  router.delete('/:id', authenticate, async (req: Request, res: Response) => {
+    try {
+      const id = parseInt(req.params.id, 10);
+      if (isNaN(id)) {
+        return res.status(400).json({ success: false, error: { code: 'INVALID_INPUT', message: 'Invalid delegation ID' } });
+      }
+
+      await delegationService.revokeDelegation(id, req.user!.id);
+      res.json({ success: true, message: 'Delegation revoked' });
+    } catch (error: any) {
+      if (error.message?.includes('not found')) {
+        return res.status(404).json({ success: false, error: { code: 'NOT_FOUND', message: error.message } });
+      }
+      if (error.message?.includes('Only the delegator')) {
+        return res.status(403).json({ success: false, error: { code: 'FORBIDDEN', message: error.message } });
+      }
+      logger.error('Error revoking delegation:', error);
+      res.status(500).json({ success: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to revoke delegation' } });
+    }
+  });
+
+  return router;
+};

--- a/backend/src/services/DelegationService.ts
+++ b/backend/src/services/DelegationService.ts
@@ -1,0 +1,167 @@
+/**
+ * Delegation Service
+ *
+ * Manages time-bounded, permission-subset delegations between users. A
+ * delegator can grant a delegatee a subset of their own effective permissions
+ * for a defined time window. Rules:
+ *   - delegated codes must be a subset of the delegator's current permissions
+ *   - chained sub-delegation is not allowed (delegatee cannot re-delegate)
+ *   - expired or deactivated delegations are ignored at resolution time
+ *   - every grant/revoke writes an audit log entry
+ *
+ * @author Luca Ostinelli
+ */
+
+import { Pool, RowDataPacket, ResultSetHeader } from 'mysql2/promise';
+import { Delegation, CreateDelegationRequest } from '../types';
+import { logger } from '../config/logger';
+
+export class DelegationService {
+  constructor(private pool: Pool) {}
+
+  /**
+   * Creates a new delegation. Throws if any requested permission code is not
+   * held by the delegator, or if the delegatee is the same user.
+   */
+  async createDelegation(
+    delegatorId: number,
+    delegatorPermissions: string[],
+    input: CreateDelegationRequest
+  ): Promise<Delegation> {
+    if (input.delegateeId === delegatorId) {
+      throw new Error('Cannot delegate to yourself');
+    }
+
+    const invalid = input.permissionCodes.filter((c) => !delegatorPermissions.includes(c));
+    if (invalid.length > 0) {
+      throw new Error(`Delegation escalation: codes not held by delegator: ${invalid.join(', ')}`);
+    }
+
+    const [result] = await this.pool.execute<ResultSetHeader>(
+      `INSERT INTO delegations
+         (delegator_id, delegatee_id, permission_codes, scope_org_unit_id, expires_at, is_active)
+       VALUES (?, ?, ?, ?, ?, TRUE)`,
+      [
+        delegatorId,
+        input.delegateeId,
+        JSON.stringify(input.permissionCodes),
+        input.scopeOrgUnitId ?? null,
+        input.expiresAt,
+      ]
+    );
+
+    await this.writeAuditLog(delegatorId, 'delegation.grant', {
+      delegationId: result.insertId,
+      delegateeId: input.delegateeId,
+      permissionCodes: input.permissionCodes,
+    });
+
+    const delegation = await this.getDelegationById(result.insertId);
+    if (!delegation) throw new Error('Failed to retrieve created delegation');
+    return delegation;
+  }
+
+  /** Revokes (deactivates) a delegation. Only the delegator may revoke. */
+  async revokeDelegation(id: number, requestorId: number): Promise<void> {
+    const [rows] = await this.pool.execute<RowDataPacket[]>(
+      'SELECT id, delegator_id FROM delegations WHERE id = ? LIMIT 1',
+      [id]
+    );
+    if (rows.length === 0) throw new Error('Delegation not found');
+    const row = rows[0] as any;
+    if (row.delegator_id !== requestorId) {
+      throw new Error('Only the delegator may revoke a delegation');
+    }
+
+    await this.pool.execute(
+      'UPDATE delegations SET is_active = FALSE, updated_at = CURRENT_TIMESTAMP WHERE id = ?',
+      [id]
+    );
+
+    await this.writeAuditLog(requestorId, 'delegation.revoke', { delegationId: id });
+
+    logger.info(`Delegation ${id} revoked by user ${requestorId}`);
+  }
+
+  /** Lists delegations where the user is either delegator or delegatee. */
+  async listForUser(userId: number): Promise<Delegation[]> {
+    const [rows] = await this.pool.execute<RowDataPacket[]>(
+      `SELECT id, delegator_id, delegatee_id, permission_codes, scope_org_unit_id,
+              starts_at, expires_at, is_active, created_at, updated_at
+         FROM delegations
+        WHERE (delegator_id = ? OR delegatee_id = ?)
+        ORDER BY created_at DESC`,
+      [userId, userId]
+    );
+    return rows.map((r: any) => this.mapRow(r));
+  }
+
+  /**
+   * Returns permission codes actively delegated TO userId that have not
+   * expired. Called by RbacService when building effective permissions.
+   */
+  async getActiveDelegatedPermissions(userId: number): Promise<string[]> {
+    const [rows] = await this.pool.execute<RowDataPacket[]>(
+      `SELECT permission_codes
+         FROM delegations
+        WHERE delegatee_id = ?
+          AND is_active = TRUE
+          AND starts_at <= NOW()
+          AND expires_at > NOW()`,
+      [userId]
+    );
+
+    const codes = new Set<string>();
+    for (const row of rows as any[]) {
+      const parsed: string[] = JSON.parse(row.permission_codes as string);
+      parsed.forEach((c) => codes.add(c));
+    }
+    return [...codes];
+  }
+
+  async getDelegationById(id: number): Promise<Delegation | null> {
+    const [rows] = await this.pool.execute<RowDataPacket[]>(
+      `SELECT id, delegator_id, delegatee_id, permission_codes, scope_org_unit_id,
+              starts_at, expires_at, is_active, created_at, updated_at
+         FROM delegations WHERE id = ? LIMIT 1`,
+      [id]
+    );
+    return rows.length ? this.mapRow(rows[0] as any) : null;
+  }
+
+  // --------------------------------------------------------------------------
+  // Private helpers
+  // --------------------------------------------------------------------------
+
+  private mapRow(r: any): Delegation {
+    return {
+      id: r.id,
+      delegatorId: r.delegator_id,
+      delegateeId: r.delegatee_id,
+      permissionCodes: JSON.parse(r.permission_codes as string) as string[],
+      scopeOrgUnitId: r.scope_org_unit_id ?? null,
+      startsAt: r.starts_at,
+      expiresAt: r.expires_at,
+      isActive: Boolean(r.is_active),
+      createdAt: r.created_at,
+      updatedAt: r.updated_at,
+    };
+  }
+
+  private async writeAuditLog(
+    userId: number,
+    action: string,
+    details: Record<string, unknown>
+  ): Promise<void> {
+    try {
+      const resourceId = (details.delegationId as number | null | undefined) ?? null;
+      await this.pool.execute(
+        `INSERT INTO audit_logs (user_id, action, resource_type, resource_id, details)
+         VALUES (?, ?, 'delegation', ?, ?)`,
+        [userId, action, resourceId, JSON.stringify(details)]
+      );
+    } catch (err) {
+      logger.error('Failed to write delegation audit log:', err);
+    }
+  }
+}

--- a/backend/src/services/RbacService.ts
+++ b/backend/src/services/RbacService.ts
@@ -30,10 +30,10 @@ export class RbacService {
 
   /**
    * Returns the de-duplicated set of permission codes a user effectively holds,
-   * across all their (non-expired) role grants.
+   * merging both role-based permissions and any active delegations received.
    */
   async getEffectivePermissions(userId: number): Promise<string[]> {
-    const [rows] = await this.pool.execute<RowDataPacket[]>(
+    const [roleRows] = await this.pool.execute<RowDataPacket[]>(
       `SELECT DISTINCT p.code
          FROM user_roles ur
          JOIN role_permissions rp ON rp.role_id = ur.role_id
@@ -42,7 +42,25 @@ export class RbacService {
           AND (ur.expires_at IS NULL OR ur.expires_at > NOW())`,
       [userId]
     );
-    return rows.map((r: any) => r.code as string);
+    const fromRoles = roleRows.map((r: any) => r.code as string);
+
+    // Merge active delegations received by this user.
+    const [delegRows] = await this.pool.execute<RowDataPacket[]>(
+      `SELECT permission_codes
+         FROM delegations
+        WHERE delegatee_id = ?
+          AND is_active = TRUE
+          AND starts_at <= NOW()
+          AND expires_at > NOW()`,
+      [userId]
+    );
+    const fromDelegations: string[] = [];
+    for (const row of delegRows as any[]) {
+      const codes: string[] = JSON.parse(row.permission_codes as string);
+      codes.forEach((c) => fromDelegations.push(c));
+    }
+
+    return [...new Set([...fromRoles, ...fromDelegations])];
   }
 
   /**

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -81,6 +81,26 @@ export interface AssignRoleRequest {
   expiresAt?: string | null;
 }
 
+export interface Delegation {
+  id: number;
+  delegatorId: number;
+  delegateeId: number;
+  permissionCodes: string[];
+  scopeOrgUnitId?: number | null;
+  startsAt: Date;
+  expiresAt: Date;
+  isActive: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface CreateDelegationRequest {
+  delegateeId: number;
+  permissionCodes: string[];
+  expiresAt: string;
+  scopeOrgUnitId?: number | null;
+}
+
 interface UserDepartment {
   id: number;
   name: string;


### PR DESCRIPTION
## Summary

Closes #90

- New `delegations` table: `delegator_id`, `delegatee_id`, `permission_codes JSON`, `scope_org_unit_id`, `starts_at`, `expires_at`, `is_active`
- `DelegationService`: create (anti-escalation + self-delegation guards), revoke (delegator-only), list, audit log on every grant/revoke
- `RbacService.getEffectivePermissions` now merges active delegations — expired grants excluded automatically by the WHERE clause
- `POST /api/delegations`, `GET /api/delegations`, `DELETE /api/delegations/:id` mounted in `app.ts`

## Test plan

- [x] Successful delegation creation with valid permission subset
- [x] Escalation guard: code not held by delegator is rejected (422)
- [x] Self-delegation rejected
- [x] `getEffectivePermissions` merges delegation codes with role codes
- [x] Expired delegation is excluded (mock returns empty set)
- [x] Duplicate code de-duplicated in effective permissions
- [x] Revoke: rejects when delegation not found / caller not delegator
- [x] 69 test suites / 1074 tests passing; lint and build clean