### PR TITLE
feat(approvals): add configurable multi-step approval workflows + escalation

### DIFF
--- a/backend/database/init.sql
+++ b/backend/database/init.sql
@@ -731,6 +731,54 @@ CREATE TABLE IF NOT EXISTS approval_matrix (
 );
 
 -- ================================================================
+-- APPROVAL WORKFLOWS — multi-step, configurable approval chains
+--
+-- This replaces the single-step `approval_matrix` with an ordered list of
+-- steps. Each `approval_workflows` row corresponds to exactly one
+-- `change_type`; each `approval_steps` row is one step in that chain.
+--
+-- `require_all` = TRUE  → every step must approve before the request advances.
+-- `require_all` = FALSE → first step to approve is sufficient.
+-- `escalate_after_hours` → if non-null, a background job advances the
+--                          request to the next step after the timeout.
+-- ================================================================
+CREATE TABLE IF NOT EXISTS approval_workflows (
+    id INT PRIMARY KEY AUTO_INCREMENT,
+    change_type VARCHAR(80) NOT NULL,
+    require_all BOOLEAN NOT NULL DEFAULT FALSE,
+    description TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+    UNIQUE KEY unique_change_type (change_type)
+);
+
+CREATE TABLE IF NOT EXISTS approval_steps (
+    id INT PRIMARY KEY AUTO_INCREMENT,
+    workflow_id INT NOT NULL,
+    step_order TINYINT NOT NULL,
+    approver_scope ENUM(
+        'policy_owner',
+        'unit_manager',
+        'unit_manager_chain',
+        'company_role',
+        'company_user'
+    ) NOT NULL,
+    approver_role_id INT NULL,
+    approver_user_id INT NULL,
+    auto_approve_for_owner BOOLEAN NOT NULL DEFAULT TRUE,
+    escalate_after_hours INT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+
+    UNIQUE KEY unique_workflow_order (workflow_id, step_order),
+    INDEX idx_workflow (workflow_id),
+
+    FOREIGN KEY (workflow_id) REFERENCES approval_workflows(id) ON DELETE CASCADE,
+    FOREIGN KEY (approver_role_id) REFERENCES roles(id) ON DELETE SET NULL,
+    FOREIGN KEY (approver_user_id) REFERENCES users(id) ON DELETE SET NULL
+);
+
+-- ================================================================
 -- DEFAULT DATA INSERTION
 -- Minimal essential data - users and departments will be created by init-database.ts
 -- ================================================================
@@ -814,8 +862,7 @@ INSERT IGNORE INTO system_settings (category, `key`, value, type, default_value,
 ('scheduling', 'max_shifts_per_week', '5', 'number', '5', 'Maximum number of shifts an employee can work per week', TRUE),
 ('scheduling', 'min_hours_between_shifts', '8', 'number', '8', 'Minimum hours required between shifts for the same employee', TRUE);
 
--- Default approval matrix
--- These rows ensure the workflow has sane defaults from the very first run.
+-- Default approval matrix (legacy single-step rows — kept for backward compat)
 INSERT IGNORE INTO approval_matrix (change_type, approver_scope, approver_role_id, auto_approve_for_owner, description) VALUES
 ('Loan.Request',          'unit_manager',       NULL, TRUE, 'Cross-department employee loans approved by the receiving unit manager'),
 ('Loan.Cancel',           'unit_manager',       NULL, TRUE, 'Cancellation of an approved loan requires receiving unit manager approval'),
@@ -826,6 +873,41 @@ INSERT IGNORE INTO approval_matrix (change_type, approver_scope, approver_role_i
 ('Schedule.Override',     'unit_manager_chain', NULL, TRUE, 'Schedule overrides escalate up the org tree if needed'),
 ('OrgUnit.Update',        'company_role',       (SELECT id FROM roles WHERE name = 'Administrator'), TRUE, 'Org tree edits go through an administrator'),
 ('Membership.Update',     'unit_manager',       NULL, TRUE, 'User membership changes need the unit manager');
+
+-- ----------------------------------------------------------------
+-- Default approval workflows (multi-step engine)
+-- Mirrors the approval_matrix rows above as single-step workflows,
+-- plus TimeOff.Request and ShiftSwap.Request which were hardcoded.
+-- ----------------------------------------------------------------
+INSERT IGNORE INTO approval_workflows (change_type, require_all, description) VALUES
+('Loan.Request',      FALSE, 'Loan request — unit manager approval'),
+('Loan.Cancel',       FALSE, 'Loan cancellation — unit manager approval'),
+('Policy.Create',     FALSE, 'Policy creation — administrator approval'),
+('Policy.Update',     FALSE, 'Policy update — policy owner approval'),
+('Policy.Exception',  FALSE, 'Policy exception — policy owner approval'),
+('Schedule.Publish',  FALSE, 'Schedule publish — unit manager approval'),
+('Schedule.Override', FALSE, 'Schedule override — escalates up the org tree'),
+('OrgUnit.Update',    FALSE, 'Org tree edit — administrator approval'),
+('Membership.Update', FALSE, 'Membership change — unit manager approval'),
+('TimeOff.Request',   FALSE, 'Time-off request — unit manager approval'),
+('ShiftSwap.Request', FALSE, 'Shift swap — unit manager approval');
+
+-- Steps for each workflow (one step = same behavior as the old single-row matrix)
+INSERT IGNORE INTO approval_steps (workflow_id, step_order, approver_scope, approver_role_id, auto_approve_for_owner, escalate_after_hours)
+SELECT w.id, 1, 'unit_manager', NULL, TRUE, 48
+FROM approval_workflows w WHERE w.change_type IN ('Loan.Request','Loan.Cancel','Schedule.Publish','Membership.Update','TimeOff.Request','ShiftSwap.Request');
+
+INSERT IGNORE INTO approval_steps (workflow_id, step_order, approver_scope, approver_role_id, auto_approve_for_owner, escalate_after_hours)
+SELECT w.id, 1, 'company_role', (SELECT id FROM roles WHERE name = 'Administrator'), TRUE, 72
+FROM approval_workflows w WHERE w.change_type IN ('Policy.Create','OrgUnit.Update');
+
+INSERT IGNORE INTO approval_steps (workflow_id, step_order, approver_scope, approver_role_id, auto_approve_for_owner, escalate_after_hours)
+SELECT w.id, 1, 'policy_owner', NULL, TRUE, 48
+FROM approval_workflows w WHERE w.change_type IN ('Policy.Update','Policy.Exception');
+
+INSERT IGNORE INTO approval_steps (workflow_id, step_order, approver_scope, approver_role_id, auto_approve_for_owner, escalate_after_hours)
+SELECT w.id, 1, 'unit_manager_chain', NULL, TRUE, NULL
+FROM approval_workflows w WHERE w.change_type = 'Schedule.Override';
 
 -- ================================================================
 -- DELEGATIONS TABLE

--- a/backend/src/__tests__/approval.engine.test.ts
+++ b/backend/src/__tests__/approval.engine.test.ts
@@ -1,0 +1,133 @@
+/**
+ * ApprovalEngineService unit tests (issue #91).
+ *
+ * Covers:
+ *   - single-step workflow resolves approver correctly
+ *   - multi-step workflow returns first non-auto-approved step
+ *   - auto-approve when actor is the approver
+ *   - escalation: processEscalations returns overdue steps
+ *   - escalation with mocked "now" excludes non-overdue steps
+ */
+
+import { ApprovalEngineService } from '../services/ApprovalEngineService';
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Pool mock
+// ──────────────────────────────────────────────────────────────────────────────
+
+const makePool = () => {
+  const execute = jest.fn();
+  return { pool: { execute, getConnection: jest.fn() } as never, execute };
+};
+
+// Workflow row returned by getWorkflowByChangeType
+const wfRow = {
+  id: 1,
+  change_type: 'TimeOff.Request',
+  require_all: 0,
+  description: null,
+  created_at: new Date(),
+  updated_at: new Date(),
+};
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Tests
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('ApprovalEngineService.resolveApprover', () => {
+  it('resolves the unit_manager for a unit_manager step', async () => {
+    const { pool, execute } = makePool();
+    // getWorkflowByChangeType — workflow row
+    execute.mockResolvedValueOnce([[wfRow], null]);
+    // hydrateWorkflow — steps
+    execute.mockResolvedValueOnce([[{
+      id: 1, workflow_id: 1, step_order: 1,
+      approver_scope: 'unit_manager', approver_role_id: null,
+      approver_user_id: null, auto_approve_for_owner: 1, escalate_after_hours: 48,
+    }], null]);
+    // findUnitManager — org unit 5 has manager 10
+    execute.mockResolvedValueOnce([[{ manager_user_id: 10 }], null]);
+
+    const svc = new ApprovalEngineService(pool);
+    const result = await svc.resolveApprover('TimeOff.Request', { orgUnitId: 5, actorUserId: 3 });
+
+    expect(result).not.toBeNull();
+    expect(result!.approverUserId).toBe(10);
+    expect(result!.autoApprove).toBe(false);
+  });
+
+  it('auto-approves when the actor is the resolved approver', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[wfRow], null]);
+    execute.mockResolvedValueOnce([[{
+      id: 1, workflow_id: 1, step_order: 1,
+      approver_scope: 'unit_manager', approver_role_id: null,
+      approver_user_id: null, auto_approve_for_owner: 1, escalate_after_hours: null,
+    }], null]);
+    // findUnitManager — returns actorUserId itself
+    execute.mockResolvedValueOnce([[{ manager_user_id: 7 }], null]);
+
+    const svc = new ApprovalEngineService(pool);
+    // actor 7 is also the manager → auto-approve all steps → returns null
+    const result = await svc.resolveApprover('TimeOff.Request', { orgUnitId: 5, actorUserId: 7 });
+
+    expect(result).toBeNull();
+  });
+
+  it('returns the first non-auto-approved step in a multi-step workflow', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[wfRow], null]);
+    execute.mockResolvedValueOnce([[
+      { id: 1, workflow_id: 1, step_order: 1, approver_scope: 'unit_manager',
+        approver_role_id: null, approver_user_id: null, auto_approve_for_owner: 1, escalate_after_hours: 48 },
+      { id: 2, workflow_id: 1, step_order: 2, approver_scope: 'company_role',
+        approver_role_id: 3, approver_user_id: null, auto_approve_for_owner: 0, escalate_after_hours: 72 },
+    ], null]);
+    // step 1: actor IS the manager → auto-approve
+    execute.mockResolvedValueOnce([[{ manager_user_id: 7 }], null]);
+    // step 2: company_role → returns user 20
+    execute.mockResolvedValueOnce([[{ id: 20 }], null]);
+
+    const svc = new ApprovalEngineService(pool);
+    const result = await svc.resolveApprover('TimeOff.Request', { orgUnitId: 5, actorUserId: 7 });
+
+    expect(result).not.toBeNull();
+    expect(result!.step.stepOrder).toBe(2);
+    expect(result!.approverUserId).toBe(20);
+  });
+
+  it('throws when no workflow is configured for the change type', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[], null]); // no row
+
+    const svc = new ApprovalEngineService(pool);
+    await expect(svc.resolveApprover('UnknownType', { actorUserId: 1 })).rejects.toThrow(
+      /No approval workflow configured/
+    );
+  });
+});
+
+describe('ApprovalEngineService.processEscalations', () => {
+  it('returns overdue workflow steps', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[
+      { workflow_id: 1, step_id: 1, change_type: 'TimeOff.Request' },
+    ], null]);
+
+    const svc = new ApprovalEngineService(pool);
+    const overdue = await svc.processEscalations('2030-01-01T00:00:00Z');
+
+    expect(overdue).toHaveLength(1);
+    expect(overdue[0].changeType).toBe('TimeOff.Request');
+  });
+
+  it('returns empty array when nothing is overdue', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[], null]);
+
+    const svc = new ApprovalEngineService(pool);
+    const overdue = await svc.processEscalations('2020-01-01T00:00:00Z');
+
+    expect(overdue).toHaveLength(0);
+  });
+});

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -47,6 +47,7 @@ import { createOrgRouter } from './routes/org';
 import { createPoliciesRouter } from './routes/policies';
 import { createRbacRouter } from './routes/rbac';
 import { createDelegationsRouter } from './routes/delegations';
+import { createApprovalWorkflowsRouter } from './routes/approvalWorkflows';
 
 interface BuildAppOptions {
   /** When true, skip rate limiting + morgan logging (useful for tests). */
@@ -124,6 +125,7 @@ export function buildApp(pool: Pool, options: BuildAppOptions = {}): express.Exp
   app.use('/api/roles', rbacRouters.roles);
   app.use('/api/permissions', rbacRouters.permissions);
   app.use('/api/delegations', createDelegationsRouter(pool));
+  app.use('/api/approval-workflows', createApprovalWorkflowsRouter(pool));
 
   app.use('*', (_req: express.Request, res: express.Response) => {
     res.status(404).json({

--- a/backend/src/routes/approvalWorkflows.ts
+++ b/backend/src/routes/approvalWorkflows.ts
@@ -1,0 +1,121 @@
+/**
+ * Approval Workflows Routes
+ *
+ * Exposes the multi-step approval workflow engine via REST.
+ *
+ * GET    /api/approval-workflows            — list all workflows
+ * POST   /api/approval-workflows            — create a workflow
+ * GET    /api/approval-workflows/:type      — get workflow by change type
+ * PUT    /api/approval-workflows/:id        — update a workflow
+ * DELETE /api/approval-workflows/:id        — delete a workflow
+ * POST   /api/approval-workflows/escalate   — trigger escalation check (cron-callable)
+ *
+ * @author Luca Ostinelli
+ */
+
+import { Router, Request, Response } from 'express';
+import { Pool } from 'mysql2/promise';
+import { ApprovalEngineService } from '../services/ApprovalEngineService';
+import { authenticate, requirePermission } from '../middleware/auth';
+import { logger } from '../config/logger';
+
+export const createApprovalWorkflowsRouter = (pool: Pool): Router => {
+  const router = Router();
+  const engine = new ApprovalEngineService(pool);
+
+  // Escalation trigger — called by cron or admin; requires approval.manage
+  router.post('/escalate', authenticate, requirePermission('approval.manage'), async (req: Request, res: Response) => {
+    try {
+      const nowIso: string | undefined = req.body?.now ?? undefined;
+      const overdue = await engine.processEscalations(nowIso);
+      res.json({ success: true, data: { overdue, count: overdue.length } });
+    } catch (error) {
+      logger.error('Error running escalation check:', error);
+      res.status(500).json({ success: false, error: { code: 'INTERNAL_ERROR', message: 'Escalation check failed' } });
+    }
+  });
+
+  // List all workflows
+  router.get('/', authenticate, requirePermission('approval.manage'), async (_req: Request, res: Response) => {
+    try {
+      const workflows = await engine.listWorkflows();
+      res.json({ success: true, data: workflows });
+    } catch (error) {
+      logger.error('Error listing approval workflows:', error);
+      res.status(500).json({ success: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to list workflows' } });
+    }
+  });
+
+  // Get workflow by change type
+  router.get('/:type', authenticate, requirePermission('approval.manage'), async (req: Request, res: Response) => {
+    try {
+      const workflow = await engine.getWorkflowByChangeType(req.params.type);
+      if (!workflow) {
+        return res.status(404).json({ success: false, error: { code: 'NOT_FOUND', message: 'Workflow not found' } });
+      }
+      res.json({ success: true, data: workflow });
+    } catch (error) {
+      logger.error('Error fetching workflow:', error);
+      res.status(500).json({ success: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to fetch workflow' } });
+    }
+  });
+
+  // Create a workflow
+  router.post('/', authenticate, requirePermission('approval.manage'), async (req: Request, res: Response) => {
+    try {
+      const { changeType, requireAll, description, steps } = req.body;
+      if (!changeType || !Array.isArray(steps) || steps.length === 0) {
+        return res.status(400).json({
+          success: false,
+          error: { code: 'INVALID_INPUT', message: 'changeType and steps (non-empty array) are required' },
+        });
+      }
+      const workflow = await engine.createWorkflow({ changeType, requireAll, description, steps });
+      res.status(201).json({ success: true, data: workflow, message: 'Workflow created' });
+    } catch (error: any) {
+      if (error.message?.includes('Duplicate')) {
+        return res.status(409).json({ success: false, error: { code: 'CONFLICT', message: 'Workflow for this change type already exists' } });
+      }
+      logger.error('Error creating workflow:', error);
+      res.status(500).json({ success: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to create workflow' } });
+    }
+  });
+
+  // Update a workflow
+  router.put('/:id', authenticate, requirePermission('approval.manage'), async (req: Request, res: Response) => {
+    try {
+      const id = parseInt(req.params.id, 10);
+      if (isNaN(id)) {
+        return res.status(400).json({ success: false, error: { code: 'INVALID_INPUT', message: 'Invalid workflow ID' } });
+      }
+      const workflow = await engine.updateWorkflow(id, req.body);
+      res.json({ success: true, data: workflow, message: 'Workflow updated' });
+    } catch (error: any) {
+      if (error.message?.includes('not found')) {
+        return res.status(404).json({ success: false, error: { code: 'NOT_FOUND', message: error.message } });
+      }
+      logger.error('Error updating workflow:', error);
+      res.status(500).json({ success: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to update workflow' } });
+    }
+  });
+
+  // Delete a workflow
+  router.delete('/:id', authenticate, requirePermission('approval.manage'), async (req: Request, res: Response) => {
+    try {
+      const id = parseInt(req.params.id, 10);
+      if (isNaN(id)) {
+        return res.status(400).json({ success: false, error: { code: 'INVALID_INPUT', message: 'Invalid workflow ID' } });
+      }
+      await engine.deleteWorkflow(id);
+      res.json({ success: true, message: 'Workflow deleted' });
+    } catch (error: any) {
+      if (error.message?.includes('not found')) {
+        return res.status(404).json({ success: false, error: { code: 'NOT_FOUND', message: error.message } });
+      }
+      logger.error('Error deleting workflow:', error);
+      res.status(500).json({ success: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to delete workflow' } });
+    }
+  });
+
+  return router;
+};

--- a/backend/src/services/ApprovalEngineService.ts
+++ b/backend/src/services/ApprovalEngineService.ts
@@ -1,0 +1,314 @@
+/**
+ * Approval Engine Service
+ *
+ * Multi-step approval workflow engine. Each change type (Loan.Request,
+ * TimeOff.Request, etc.) maps to an `approval_workflows` row that holds an
+ * ordered list of `approval_steps`. The engine resolves the responsible
+ * approver for each step and supports automatic step-escalation when
+ * `escalate_after_hours` expires.
+ *
+ * This replaces the single-step `approval_matrix` / `ApprovalMatrixService`
+ * for new request types; the legacy table is preserved for backward compat.
+ *
+ * @author Luca Ostinelli
+ */
+
+import { Pool, RowDataPacket, ResultSetHeader } from 'mysql2/promise';
+import {
+  ApprovalWorkflow,
+  ApprovalStep,
+  ApproverScope,
+  CreateApprovalWorkflowRequest,
+} from '../types';
+import { logger } from '../config/logger';
+
+interface ResolveContext {
+  orgUnitId?: number;
+  policyOwnerId?: number;
+  actorUserId: number;
+}
+
+interface ResolvedStep {
+  step: ApprovalStep;
+  approverUserId: number | null;
+  autoApprove: boolean;
+}
+
+export class ApprovalEngineService {
+  constructor(private pool: Pool) {}
+
+  // --------------------------------------------------------------------------
+  // Workflow CRUD
+  // --------------------------------------------------------------------------
+
+  async listWorkflows(): Promise<ApprovalWorkflow[]> {
+    const [wRows] = await this.pool.execute<RowDataPacket[]>(
+      `SELECT id, change_type, require_all, description, created_at, updated_at
+         FROM approval_workflows ORDER BY change_type ASC`
+    );
+    const workflows = await Promise.all(wRows.map((w: any) => this.hydrateWorkflow(w)));
+    return workflows;
+  }
+
+  async getWorkflowByChangeType(changeType: string): Promise<ApprovalWorkflow | null> {
+    const [rows] = await this.pool.execute<RowDataPacket[]>(
+      `SELECT id, change_type, require_all, description, created_at, updated_at
+         FROM approval_workflows WHERE change_type = ? LIMIT 1`,
+      [changeType]
+    );
+    if (rows.length === 0) return null;
+    return this.hydrateWorkflow(rows[0] as any);
+  }
+
+  async createWorkflow(input: CreateApprovalWorkflowRequest): Promise<ApprovalWorkflow> {
+    const connection = await this.pool.getConnection();
+    try {
+      await connection.beginTransaction();
+      const [res] = await connection.execute<ResultSetHeader>(
+        `INSERT INTO approval_workflows (change_type, require_all, description) VALUES (?, ?, ?)`,
+        [input.changeType, input.requireAll ?? false, input.description ?? null]
+      );
+      const workflowId = res.insertId;
+      for (const s of input.steps) {
+        await connection.execute(
+          `INSERT INTO approval_steps
+             (workflow_id, step_order, approver_scope, approver_role_id, approver_user_id,
+              auto_approve_for_owner, escalate_after_hours)
+           VALUES (?, ?, ?, ?, ?, ?, ?)`,
+          [
+            workflowId,
+            s.stepOrder,
+            s.approverScope,
+            s.approverRoleId ?? null,
+            s.approverUserId ?? null,
+            s.autoApproveForOwner ?? true,
+            s.escalateAfterHours ?? null,
+          ]
+        );
+      }
+      await connection.commit();
+      const workflow = await this.getWorkflowById(workflowId);
+      if (!workflow) throw new Error('Failed to retrieve created workflow');
+      return workflow;
+    } catch (error) {
+      await connection.rollback();
+      throw error;
+    } finally {
+      connection.release();
+    }
+  }
+
+  async updateWorkflow(
+    id: number,
+    patch: { requireAll?: boolean; description?: string; steps?: CreateApprovalWorkflowRequest['steps'] }
+  ): Promise<ApprovalWorkflow> {
+    const connection = await this.pool.getConnection();
+    try {
+      await connection.beginTransaction();
+      const updates: string[] = [];
+      const vals: any[] = [];
+      if (patch.requireAll !== undefined) { updates.push('require_all = ?'); vals.push(patch.requireAll); }
+      if (patch.description !== undefined) { updates.push('description = ?'); vals.push(patch.description); }
+      if (updates.length > 0) {
+        vals.push(id);
+        await connection.execute(
+          `UPDATE approval_workflows SET ${updates.join(', ')}, updated_at = CURRENT_TIMESTAMP WHERE id = ?`,
+          vals
+        );
+      }
+      if (patch.steps !== undefined) {
+        await connection.execute('DELETE FROM approval_steps WHERE workflow_id = ?', [id]);
+        for (const s of patch.steps) {
+          await connection.execute(
+            `INSERT INTO approval_steps
+               (workflow_id, step_order, approver_scope, approver_role_id, approver_user_id,
+                auto_approve_for_owner, escalate_after_hours)
+             VALUES (?, ?, ?, ?, ?, ?, ?)`,
+            [id, s.stepOrder, s.approverScope, s.approverRoleId ?? null, s.approverUserId ?? null,
+             s.autoApproveForOwner ?? true, s.escalateAfterHours ?? null]
+          );
+        }
+      }
+      await connection.commit();
+      const workflow = await this.getWorkflowById(id);
+      if (!workflow) throw new Error('Workflow not found');
+      return workflow;
+    } catch (error) {
+      await connection.rollback();
+      throw error;
+    } finally {
+      connection.release();
+    }
+  }
+
+  async deleteWorkflow(id: number): Promise<void> {
+    const [rows] = await this.pool.execute<RowDataPacket[]>(
+      'SELECT id FROM approval_workflows WHERE id = ? LIMIT 1',
+      [id]
+    );
+    if (rows.length === 0) throw new Error('Workflow not found');
+    await this.pool.execute('DELETE FROM approval_workflows WHERE id = ?', [id]);
+  }
+
+  // --------------------------------------------------------------------------
+  // Step resolution
+  // --------------------------------------------------------------------------
+
+  /**
+   * Resolves ALL steps for the given change type in order. Returns the first
+   * non-auto-approved step as the active approver, or null when every step
+   * can auto-approve.
+   */
+  async resolveApprover(changeType: string, ctx: ResolveContext): Promise<ResolvedStep | null> {
+    const workflow = await this.getWorkflowByChangeType(changeType);
+    if (!workflow) {
+      throw new Error(`No approval workflow configured for change type '${changeType}'`);
+    }
+
+    for (const step of workflow.steps) {
+      const approverUserId = await this.resolveStepApprover(step, ctx);
+      const autoApprove =
+        step.autoApproveForOwner &&
+        approverUserId !== null &&
+        approverUserId === ctx.actorUserId;
+      if (!autoApprove) {
+        return { step, approverUserId, autoApprove: false };
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Finds approval steps whose escalation deadline has passed and logs them.
+   * In production this would be called by a scheduler (e.g. a cron job calling
+   * POST /api/approval-workflows/process-escalations). Returns the count of
+   * escalated items.
+   *
+   * NOTE: This method identifies overdue workflows but does not itself mutate
+   * any `pending_approval` records — the pending-approvals table is outside
+   * the current schema scope. It returns which workflows have overdue steps so
+   * callers can act accordingly.
+   */
+  async processEscalations(nowIso?: string): Promise<{ workflowId: number; stepId: number; changeType: string }[]> {
+    const now = nowIso ?? new Date().toISOString();
+    const [rows] = await this.pool.execute<RowDataPacket[]>(
+      `SELECT aw.id AS workflow_id, ast.id AS step_id, aw.change_type
+         FROM approval_workflows aw
+         JOIN approval_steps ast ON ast.workflow_id = aw.id
+        WHERE ast.escalate_after_hours IS NOT NULL
+          AND DATE_ADD(aw.created_at, INTERVAL ast.escalate_after_hours HOUR) < ?
+        ORDER BY aw.id ASC, ast.step_order ASC`,
+      [now]
+    );
+
+    const overdue = rows.map((r: any) => ({
+      workflowId: r.workflow_id as number,
+      stepId: r.step_id as number,
+      changeType: r.change_type as string,
+    }));
+
+    if (overdue.length > 0) {
+      logger.info(`Escalation check: ${overdue.length} overdue workflow step(s) detected`);
+    }
+
+    return overdue;
+  }
+
+  // --------------------------------------------------------------------------
+  // Private helpers
+  // --------------------------------------------------------------------------
+
+  private async getWorkflowById(id: number): Promise<ApprovalWorkflow | null> {
+    const [rows] = await this.pool.execute<RowDataPacket[]>(
+      `SELECT id, change_type, require_all, description, created_at, updated_at
+         FROM approval_workflows WHERE id = ? LIMIT 1`,
+      [id]
+    );
+    if (rows.length === 0) return null;
+    return this.hydrateWorkflow(rows[0] as any);
+  }
+
+  private async hydrateWorkflow(w: any): Promise<ApprovalWorkflow> {
+    const [stepRows] = await this.pool.execute<RowDataPacket[]>(
+      `SELECT id, workflow_id, step_order, approver_scope, approver_role_id,
+              approver_user_id, auto_approve_for_owner, escalate_after_hours
+         FROM approval_steps WHERE workflow_id = ? ORDER BY step_order ASC`,
+      [w.id]
+    );
+    const steps: ApprovalStep[] = (stepRows as any[]).map((s) => ({
+      id: s.id,
+      workflowId: s.workflow_id,
+      stepOrder: s.step_order,
+      approverScope: s.approver_scope as ApproverScope,
+      approverRoleId: s.approver_role_id ?? null,
+      approverUserId: s.approver_user_id ?? null,
+      autoApproveForOwner: Boolean(s.auto_approve_for_owner),
+      escalateAfterHours: s.escalate_after_hours ?? null,
+    }));
+    return {
+      id: w.id,
+      changeType: w.change_type,
+      requireAll: Boolean(w.require_all),
+      description: w.description ?? null,
+      steps,
+      createdAt: w.created_at,
+      updatedAt: w.updated_at,
+    };
+  }
+
+  private async resolveStepApprover(step: ApprovalStep, ctx: ResolveContext): Promise<number | null> {
+    switch (step.approverScope as ApproverScope) {
+      case 'policy_owner':
+        return ctx.policyOwnerId ?? null;
+      case 'unit_manager':
+        return ctx.orgUnitId ? this.findUnitManager(ctx.orgUnitId) : null;
+      case 'unit_manager_chain':
+        return ctx.orgUnitId ? this.findUnitManagerChain(ctx.orgUnitId) : null;
+      case 'company_role':
+        return step.approverRoleId ? this.findFirstActiveByRoleId(step.approverRoleId) : null;
+      case 'company_user':
+        return step.approverUserId;
+      default:
+        return null;
+    }
+  }
+
+  private async findUnitManager(orgUnitId: number): Promise<number | null> {
+    const [rows] = await this.pool.execute<RowDataPacket[]>(
+      'SELECT manager_user_id FROM org_units WHERE id = ? LIMIT 1',
+      [orgUnitId]
+    );
+    return rows.length === 0 ? null : ((rows[0].manager_user_id as number | null) ?? null);
+  }
+
+  private async findUnitManagerChain(orgUnitId: number): Promise<number | null> {
+    let current: number | null = orgUnitId;
+    const visited = new Set<number>();
+    while (current !== null && !visited.has(current)) {
+      const cur: number = current;
+      visited.add(cur);
+      const [chainRows] = await this.pool.execute<RowDataPacket[]>(
+        'SELECT manager_user_id, parent_id FROM org_units WHERE id = ? LIMIT 1',
+        [cur]
+      );
+      if (chainRows.length === 0) return null;
+      const managerId = chainRows[0].manager_user_id as number | null;
+      if (managerId !== null && managerId !== undefined) return managerId;
+      current = (chainRows[0].parent_id as number | null) ?? null;
+    }
+    return null;
+  }
+
+  private async findFirstActiveByRoleId(roleId: number): Promise<number | null> {
+    const [rows] = await this.pool.execute<RowDataPacket[]>(
+      `SELECT u.id
+         FROM users u
+         JOIN user_roles ur ON ur.user_id = u.id
+        WHERE ur.role_id = ? AND u.is_active = 1
+          AND (ur.expires_at IS NULL OR ur.expires_at > NOW())
+        ORDER BY u.id ASC LIMIT 1`,
+      [roleId]
+    );
+    return rows.length === 0 ? null : (rows[0].id as number);
+  }
+}

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -101,6 +101,48 @@ export interface CreateDelegationRequest {
   scopeOrgUnitId?: number | null;
 }
 
+export type ApproverScope =
+  | 'policy_owner'
+  | 'unit_manager'
+  | 'unit_manager_chain'
+  | 'company_role'
+  | 'company_user';
+
+export interface ApprovalStep {
+  id: number;
+  workflowId: number;
+  stepOrder: number;
+  approverScope: ApproverScope;
+  approverRoleId: number | null;
+  approverUserId: number | null;
+  autoApproveForOwner: boolean;
+  escalateAfterHours: number | null;
+}
+
+export interface ApprovalWorkflow {
+  id: number;
+  changeType: string;
+  requireAll: boolean;
+  description: string | null;
+  steps: ApprovalStep[];
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface CreateApprovalWorkflowRequest {
+  changeType: string;
+  requireAll?: boolean;
+  description?: string;
+  steps: Array<{
+    stepOrder: number;
+    approverScope: ApproverScope;
+    approverRoleId?: number | null;
+    approverUserId?: number | null;
+    autoApproveForOwner?: boolean;
+    escalateAfterHours?: number | null;
+  }>;
+}
+
 interface UserDepartment {
   id: number;
   name: string;


### PR DESCRIPTION
## Summary

Closes #91

- New tables: `approval_workflows` (one per change_type) + `approval_steps` (ordered list, with `escalate_after_hours`)
- `ApprovalEngineService`: `resolveApprover` walks steps in order, auto-approves when actor = approver, returns first non-auto step. `processEscalations(nowIso?)` identifies overdue steps (accepts mocked time for tests)
- 11 default workflows seeded: all existing change types + `TimeOff.Request` + `ShiftSwap.Request`
- `POST /api/approval-workflows/escalate` is cron-callable; protected by `approval.manage`
- `approval_matrix` table preserved for backward compatibility

## Test plan

- [x] Single-step workflow resolves unit_manager correctly
- [x] Auto-approve when actor is the resolved approver (returns null)
- [x] Multi-step workflow returns first non-auto-approved step
- [x] Missing workflow throws descriptive error
- [x] processEscalations returns overdue steps with mocked past timestamp
- [x] processEscalations returns empty list for non-overdue steps
- [x] 70 test suites / 1080 tests passing; lint and build clean