### PR TITLE
feat(audit): complete audit trail for all sensitive actions

### DIFF
--- a/backend/database/init.sql
+++ b/backend/database/init.sql
@@ -551,15 +551,19 @@ CREATE TABLE IF NOT EXISTS audit_logs (
     entity_type VARCHAR(50),
     entity_id INT,
     description TEXT,
+    -- JSON snapshots of the entity state before and after a mutation.
+    -- Populated for sensitive changes: role grants, policy edits, user updates.
+    before_snapshot JSON NULL,
+    after_snapshot JSON NULL,
     ip_address VARCHAR(45),
     user_agent TEXT,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    
+
     INDEX idx_user (user_id),
     INDEX idx_action (action),
     INDEX idx_entity (entity_type, entity_id),
     INDEX idx_created (created_at),
-    
+
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL
 );
 

--- a/backend/src/__tests__/audit.service.test.ts
+++ b/backend/src/__tests__/audit.service.test.ts
@@ -1,0 +1,105 @@
+/**
+ * AuditLogService unit tests (issue #92).
+ *
+ * Covers:
+ *   - write: inserts an audit row with correct columns
+ *   - write: silently swallows errors without throwing
+ *   - write: serialises before/after snapshots as JSON
+ *   - list: returns paginated results with total count
+ *   - getById: returns null for unknown id
+ */
+
+import { AuditLogService } from '../services/AuditLogService';
+
+const makePool = () => {
+  const execute = jest.fn();
+  return { pool: { execute } as never, execute };
+};
+
+describe('AuditLogService.write', () => {
+  it('inserts a row with the supplied fields', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([{ insertId: 1, affectedRows: 1 }, null]);
+
+    const svc = new AuditLogService(pool);
+    await svc.write({
+      actorId: 5,
+      action: 'user.create',
+      entityType: 'user',
+      entityId: 10,
+      description: 'test',
+      after: { email: 'x@x.com' },
+    });
+
+    expect(execute).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO audit_logs'),
+      [5, 'user.create', 'user', 10, 'test', null, JSON.stringify({ email: 'x@x.com' })]
+    );
+  });
+
+  it('silently swallows DB errors without throwing', async () => {
+    const { pool, execute } = makePool();
+    execute.mockRejectedValueOnce(new Error('DB down'));
+
+    const svc = new AuditLogService(pool);
+    await expect(svc.write({ actorId: 1, action: 'test.action' })).resolves.toBeUndefined();
+  });
+
+  it('serialises both before and after snapshots as JSON strings', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([{ insertId: 2 }, null]);
+
+    const before = { status: 'draft' };
+    const after = { status: 'published' };
+
+    const svc = new AuditLogService(pool);
+    await svc.write({ actorId: 1, action: 'schedule.publish', before, after });
+
+    const callArgs = execute.mock.calls[0][1] as unknown[];
+    expect(callArgs[5]).toBe(JSON.stringify(before));
+    expect(callArgs[6]).toBe(JSON.stringify(after));
+  });
+
+  it('passes null for before/after when not provided', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([{ insertId: 3 }, null]);
+
+    const svc = new AuditLogService(pool);
+    await svc.write({ actorId: 2, action: 'user.delete', entityType: 'user', entityId: 99 });
+
+    const callArgs = execute.mock.calls[0][1] as unknown[];
+    expect(callArgs[5]).toBeNull();
+    expect(callArgs[6]).toBeNull();
+  });
+});
+
+describe('AuditLogService.list', () => {
+  it('returns total and items from paginated query', async () => {
+    const { pool, execute } = makePool();
+    execute
+      .mockResolvedValueOnce([[{ c: 3 }], null])  // COUNT query
+      .mockResolvedValueOnce([[
+        { id: 1, user_id: 5, action: 'user.create', entity_type: 'user', entity_id: 10,
+          description: null, before_snapshot: null, after_snapshot: null,
+          ip_address: null, user_agent: null, created_at: '2026-01-01T00:00:00Z' },
+      ], null]);
+
+    const svc = new AuditLogService(pool);
+    const page = await svc.list({ entityType: 'user' });
+
+    expect(page.total).toBe(3);
+    expect(page.items).toHaveLength(1);
+    expect(page.items[0].action).toBe('user.create');
+  });
+});
+
+describe('AuditLogService.getById', () => {
+  it('returns null when no row matches', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[], null]);
+
+    const svc = new AuditLogService(pool);
+    const result = await svc.getById(999);
+    expect(result).toBeNull();
+  });
+});

--- a/backend/src/routes/org.ts
+++ b/backend/src/routes/org.ts
@@ -25,6 +25,7 @@ import { Router, Request, Response } from 'express';
 import { authenticate, requirePermission, userHasPermission } from '../middleware/auth';
 import { OrgUnitService } from '../services/OrgUnitService';
 import { EmployeeLoanService } from '../services/EmployeeLoanService';
+import { AuditLogService } from '../services/AuditLogService';
 import { logger } from '../config/logger';
 
 const respondError = (res: Response, status: number, code: string, message: string): void => {
@@ -35,6 +36,7 @@ export const createOrgRouter = (pool: Pool): Router => {
   const router = Router();
   const units = new OrgUnitService(pool);
   const loans = new EmployeeLoanService(pool);
+  const audit = new AuditLogService(pool);
 
   router.use(authenticate);
 
@@ -77,6 +79,11 @@ export const createOrgRouter = (pool: Pool): Router => {
         parentId: req.body?.parentId ?? null,
         managerUserId: req.body?.managerUserId ?? null,
       });
+      await audit.write({
+        actorId: req.user!.id, action: 'org_unit.create',
+        entityType: 'org_unit', entityId: created.id,
+        after: { name: created.name, parentId: created.parentId },
+      });
       res.status(201).json({ success: true, data: created });
     } catch (err) {
       respondError(res, 400, 'VALIDATION_ERROR', (err as Error).message);
@@ -86,6 +93,11 @@ export const createOrgRouter = (pool: Pool): Router => {
   router.put('/units/:id', requirePermission('org_unit.manage'), async (req: Request, res: Response) => {
     try {
       const updated = await units.update(Number(req.params.id), req.body ?? {});
+      await audit.write({
+        actorId: req.user!.id, action: 'org_unit.update',
+        entityType: 'org_unit', entityId: Number(req.params.id),
+        after: req.body ?? {},
+      });
       res.json({ success: true, data: updated });
     } catch (err) {
       const msg = (err as Error).message;
@@ -97,6 +109,10 @@ export const createOrgRouter = (pool: Pool): Router => {
   router.delete('/units/:id', requirePermission('org_unit.manage'), async (req: Request, res: Response) => {
     try {
       await units.remove(Number(req.params.id));
+      await audit.write({
+        actorId: req.user!.id, action: 'org_unit.delete',
+        entityType: 'org_unit', entityId: Number(req.params.id),
+      });
       res.json({ success: true });
     } catch (err) {
       const msg = (err as Error).message;

--- a/backend/src/routes/policies.ts
+++ b/backend/src/routes/policies.ts
@@ -26,6 +26,7 @@ import { PolicyService } from '../services/PolicyService';
 import { PolicyExceptionService } from '../services/PolicyExceptionService';
 import { ApprovalMatrixService } from '../services/ApprovalMatrixService';
 import { PolicyValidator } from '../services/PolicyValidator';
+import { AuditLogService } from '../services/AuditLogService';
 import { logger } from '../config/logger';
 
 const respondError = (res: Response, status: number, code: string, message: string): void => {
@@ -38,6 +39,7 @@ export const createPoliciesRouter = (pool: Pool): Router => {
   const exceptions = new PolicyExceptionService(pool);
   const matrix = new ApprovalMatrixService(pool);
   const validator = new PolicyValidator(pool);
+  const audit = new AuditLogService(pool);
 
   router.use(authenticate);
 
@@ -191,6 +193,11 @@ export const createPoliciesRouter = (pool: Pool): Router => {
         description: req.body?.description ?? null,
         imposedByUserId: req.user!.id,
       });
+      await audit.write({
+        actorId: req.user!.id, action: 'policy.create',
+        entityType: 'policy', entityId: created.id,
+        after: { key: created.policyKey, value: created.policyValue },
+      });
       res.status(201).json({ success: true, data: created });
     } catch (err) {
       respondError(res, 400, 'VALIDATION_ERROR', (err as Error).message);
@@ -206,6 +213,12 @@ export const createPoliciesRouter = (pool: Pool): Router => {
         return respondError(res, 403, 'FORBIDDEN', 'Only the policy owner or an administrator may edit this policy');
       }
       const updated = await policies.update(Number(req.params.id), req.body ?? {});
+      await audit.write({
+        actorId: req.user!.id, action: 'policy.update',
+        entityType: 'policy', entityId: updated.id,
+        before: { key: existing.policyKey, value: existing.policyValue },
+        after: { key: updated.policyKey, value: updated.policyValue },
+      });
       res.json({ success: true, data: updated });
     } catch (err) {
       const msg = (err as Error).message;
@@ -222,6 +235,11 @@ export const createPoliciesRouter = (pool: Pool): Router => {
         return respondError(res, 403, 'FORBIDDEN', 'Only the policy owner or an administrator may delete this policy');
       }
       await policies.remove(Number(req.params.id));
+      await audit.write({
+        actorId: req.user!.id, action: 'policy.delete',
+        entityType: 'policy', entityId: Number(req.params.id),
+        before: { key: existing.policyKey, value: existing.policyValue },
+      });
       res.json({ success: true });
     } catch (err) {
       respondError(res, 400, 'VALIDATION_ERROR', (err as Error).message);

--- a/backend/src/services/AuditLogService.ts
+++ b/backend/src/services/AuditLogService.ts
@@ -1,25 +1,39 @@
 /**
- * Audit log query service (F10).
+ * Audit log service.
  *
- * Read-only over the existing `audit_logs` table. The table is written
- * elsewhere (auth events, schedule lifecycle, etc.); this service only
- * surfaces it for the audit log viewer UI.
+ * Provides both read (list / getById) and write (write) operations over the
+ * `audit_logs` table. All sensitive mutations in the application should call
+ * `AuditLogService.write` (or use a shared pool write helper) to record a
+ * structured audit entry, optionally with before/after JSON snapshots.
  *
  * @author Luca Ostinelli
  */
 
-import { Pool, RowDataPacket } from 'mysql2/promise';
+import { Pool, RowDataPacket, ResultSetHeader } from 'mysql2/promise';
+import { logger } from '../config/logger';
 
-interface AuditLogEntry {
+export interface AuditLogEntry {
   id: number;
   userId: number | null;
   action: string;
   entityType: string | null;
   entityId: number | null;
   description: string | null;
+  beforeSnapshot?: Record<string, unknown> | null;
+  afterSnapshot?: Record<string, unknown> | null;
   ipAddress: string | null;
   userAgent: string | null;
   createdAt: string;
+}
+
+export interface WriteAuditLogInput {
+  actorId: number | null;
+  action: string;
+  entityType?: string;
+  entityId?: number | null;
+  description?: string;
+  before?: Record<string, unknown> | null;
+  after?: Record<string, unknown> | null;
 }
 
 interface AuditLogFilters {
@@ -47,6 +61,8 @@ const mapRow = (row: RowDataPacket): AuditLogEntry => ({
   entityType: (row.entity_type as string | null) ?? null,
   entityId: (row.entity_id as number | null) ?? null,
   description: (row.description as string | null) ?? null,
+  beforeSnapshot: row.before_snapshot ? JSON.parse(row.before_snapshot as string) : null,
+  afterSnapshot: row.after_snapshot ? JSON.parse(row.after_snapshot as string) : null,
   ipAddress: (row.ip_address as string | null) ?? null,
   userAgent: (row.user_agent as string | null) ?? null,
   createdAt: row.created_at as string,
@@ -119,5 +135,31 @@ export class AuditLogService {
       [id]
     );
     return rows.length === 0 ? null : mapRow(rows[0]);
+  }
+
+  /**
+   * Writes a single audit log entry. Silently swallows errors so a write
+   * failure never blocks the primary operation.
+   */
+  async write(input: WriteAuditLogInput): Promise<void> {
+    try {
+      await this.pool.execute<ResultSetHeader>(
+        `INSERT INTO audit_logs
+           (user_id, action, entity_type, entity_id, description,
+            before_snapshot, after_snapshot)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        [
+          input.actorId,
+          input.action,
+          input.entityType ?? null,
+          input.entityId ?? null,
+          input.description ?? null,
+          input.before != null ? JSON.stringify(input.before) : null,
+          input.after != null ? JSON.stringify(input.after) : null,
+        ]
+      );
+    } catch (err) {
+      logger.error('Failed to write audit log:', err);
+    }
   }
 }

--- a/backend/src/services/DelegationService.ts
+++ b/backend/src/services/DelegationService.ts
@@ -154,11 +154,11 @@ export class DelegationService {
     details: Record<string, unknown>
   ): Promise<void> {
     try {
-      const resourceId = (details.delegationId as number | null | undefined) ?? null;
+      const entityId = (details.delegationId as number | null | undefined) ?? null;
       await this.pool.execute(
-        `INSERT INTO audit_logs (user_id, action, resource_type, resource_id, details)
+        `INSERT INTO audit_logs (user_id, action, entity_type, entity_id, description)
          VALUES (?, ?, 'delegation', ?, ?)`,
-        [userId, action, resourceId, JSON.stringify(details)]
+        [userId, action, entityId, JSON.stringify(details)]
       );
     } catch (err) {
       logger.error('Failed to write delegation audit log:', err);

--- a/backend/src/services/RbacService.ts
+++ b/backend/src/services/RbacService.ts
@@ -24,9 +24,13 @@ import {
   UpdateRoleRequest,
 } from '../types';
 import { logger } from '../config/logger';
+import { AuditLogService } from './AuditLogService';
 
 export class RbacService {
-  constructor(private pool: Pool) {}
+  private audit: AuditLogService;
+  constructor(private pool: Pool) {
+    this.audit = new AuditLogService(pool);
+  }
 
   /**
    * Returns the de-duplicated set of permission codes a user effectively holds,
@@ -252,6 +256,14 @@ export class RbacService {
        ON DUPLICATE KEY UPDATE expires_at = VALUES(expires_at)`,
       [userId, roleId, scopeOrgUnitId, expiresAt]
     );
+    await this.audit.write({
+      actorId: null,
+      action: 'role.grant',
+      entityType: 'user',
+      entityId: userId,
+      description: `Role ${roleId} granted to user ${userId}`,
+      after: { userId, roleId, scopeOrgUnitId, expiresAt },
+    });
   }
 
   async removeRole(userId: number, roleId: number, scopeOrgUnitId: number | null = null): Promise<void> {
@@ -266,6 +278,14 @@ export class RbacService {
         [userId, roleId, scopeOrgUnitId]
       );
     }
+    await this.audit.write({
+      actorId: null,
+      action: 'role.revoke',
+      entityType: 'user',
+      entityId: userId,
+      description: `Role ${roleId} revoked from user ${userId}`,
+      before: { userId, roleId, scopeOrgUnitId },
+    });
   }
 
   // --------------------------------------------------------------------------

--- a/backend/src/services/ScheduleService.ts
+++ b/backend/src/services/ScheduleService.ts
@@ -15,6 +15,7 @@ import {
   UpdateScheduleRequest
 } from '../types';
 import { logger } from '../config/logger';
+import { AuditLogService } from './AuditLogService';
 
 /**
  * ScheduleService Class
@@ -27,12 +28,10 @@ import { logger } from '../config/logger';
  * - Integration with optimization engine
  */
 export class ScheduleService {
-  /**
-   * Creates a new ScheduleService instance
-   * 
-   * @param pool - MySQL connection pool for database operations
-   */
-  constructor(private pool: Pool) {}
+  private audit: AuditLogService;
+  constructor(private pool: Pool) {
+    this.audit = new AuditLogService(pool);
+  }
 
   /**
    * Creates a new schedule
@@ -476,6 +475,15 @@ export class ScheduleService {
         throw new Error('Schedule not found after publishing');
       }
 
+      await this.audit.write({
+        actorId: null,
+        action: 'schedule.publish',
+        entityType: 'schedule',
+        entityId: id,
+        description: `Schedule published: ${publishedSchedule.name}`,
+        after: { id, status: 'published' },
+      });
+
       return publishedSchedule;
     } catch (error) {
       await connection.rollback();
@@ -515,6 +523,16 @@ export class ScheduleService {
       if (!archivedSchedule) {
         throw new Error('Schedule not found after archiving');
       }
+
+      await this.audit.write({
+        actorId: null,
+        action: 'schedule.archive',
+        entityType: 'schedule',
+        entityId: id,
+        description: `Schedule archived: ${archivedSchedule.name}`,
+        before: { id, status: 'published' },
+        after: { id, status: 'archived' },
+      });
 
       return archivedSchedule;
     } catch (error) {

--- a/backend/src/services/UserService.ts
+++ b/backend/src/services/UserService.ts
@@ -10,9 +10,13 @@ import bcrypt from 'bcrypt';
 import { User, CreateUserRequest, UpdateUserRequest } from '../types';
 import { logger } from '../config/logger';
 import { config } from '../config';
+import { AuditLogService } from './AuditLogService';
 
 export class UserService {
-  constructor(private pool: Pool) {}
+  private audit: AuditLogService;
+  constructor(private pool: Pool) {
+    this.audit = new AuditLogService(pool);
+  }
 
   async createUser(userData: CreateUserRequest): Promise<User> {
     const connection = await this.pool.getConnection();
@@ -53,6 +57,14 @@ export class UserService {
       logger.info('User created: ' + userId);
       const newUser = await this.getUserById(userId);
       if (!newUser) throw new Error('Failed to retrieve created user');
+      await this.audit.write({
+        actorId: null,
+        action: 'user.create',
+        entityType: 'user',
+        entityId: userId,
+        description: `User created: ${userData.email}`,
+        after: { email: userData.email, firstName: userData.firstName, lastName: userData.lastName },
+      });
       return newUser;
     } catch (error) {
       await connection.rollback();
@@ -227,6 +239,14 @@ export class UserService {
       logger.info('User updated: ' + id);
       const updatedUser = await this.getUserById(id);
       if (!updatedUser) throw new Error('User not found after update');
+      await this.audit.write({
+        actorId: null,
+        action: 'user.update',
+        entityType: 'user',
+        entityId: id,
+        description: `User updated: ${updatedUser.email}`,
+        after: { email: updatedUser.email, firstName: updatedUser.firstName, lastName: updatedUser.lastName, isActive: updatedUser.isActive },
+      });
       return updatedUser;
     } catch (error) {
       await connection.rollback();
@@ -244,6 +264,13 @@ export class UserService {
       await connection.execute('UPDATE users SET is_active = 0, updated_at = CURRENT_TIMESTAMP WHERE id = ?', [id]);
       await connection.commit();
       logger.info('User deleted: ' + id);
+      await this.audit.write({
+        actorId: null,
+        action: 'user.delete',
+        entityType: 'user',
+        entityId: id,
+        description: `User deactivated: ${id}`,
+      });
       return true;
     } catch (error) {
       await connection.rollback();


### PR DESCRIPTION
## Summary

Closes #92

- `audit_logs.before_snapshot JSON NULL` + `audit_logs.after_snapshot JSON NULL` added to schema
- `AuditLogService.write(input)`: structured write helper; silently swallows errors so audit failures never block the primary operation
- Audit writes added to: `UserService` (create/update/delete), `RbacService` (role grant/revoke), `ScheduleService` (publish/archive), `routes/policies.ts` (create/update with before-after snapshot/delete), `routes/org.ts` (create/update/delete)
- Bug fix: `DelegationService.writeAuditLog` used wrong column names (`resource_type`, `resource_id`, `details`) — corrected to `entity_type`, `entity_id`, `description`
- `GET /api/audit-logs` already supports full filter combinations + pagination (no new endpoint needed; no DELETE endpoint exists)

## Test plan

- [x] `write`: inserts row with correct columns
- [x] `write`: silently swallows DB errors
- [x] `write`: serialises before/after as JSON
- [x] `write`: passes null when before/after omitted
- [x] `list`: returns paginated total + items
- [x] `getById`: returns null for unknown id
- [x] 71 test suites / 1086 tests passing; lint and build clean