### PR TITLE
feat(modules): add runtime module enable/disable system

### DIFF
--- a/backend/database/init.sql
+++ b/backend/database/init.sql
@@ -542,6 +542,24 @@ CREATE TABLE IF NOT EXISTS system_settings (
 );
 
 -- ================================================================
+-- MODULES TABLE - Runtime feature flags
+-- Each module has a unique code; is_enabled is the runtime flag that
+-- the requireModule(code) middleware checks. Changes persist across
+-- restarts because they live in the DB, not in environment variables.
+-- ================================================================
+CREATE TABLE IF NOT EXISTS modules (
+    id INT PRIMARY KEY AUTO_INCREMENT,
+    code VARCHAR(60) NOT NULL,
+    name VARCHAR(120) NOT NULL,
+    description TEXT,
+    is_enabled BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+    UNIQUE KEY unique_code (code)
+);
+
+-- ================================================================
 -- AUDIT LOGS TABLE - Track system activities
 -- ================================================================
 CREATE TABLE IF NOT EXISTS audit_logs (
@@ -858,6 +876,18 @@ INSERT IGNORE INTO skills (name, description, is_active) VALUES
 ('Customer Service', 'Customer interaction and support', TRUE),
 ('Team Leadership', 'Ability to lead teams', TRUE),
 ('Technical Skills', 'Technical and computer skills', TRUE);
+
+-- Default modules (all enabled by default)
+INSERT IGNORE INTO modules (code, name, description, is_enabled) VALUES
+('scheduling',    'Scheduling',     'Shift scheduling, optimizer, and calendar views', TRUE),
+('approvals',     'Approvals',      'Approval workflows for time-off, loans, and policy exceptions', TRUE),
+('notifications', 'Notifications',  'In-app and SSE notification delivery', TRUE),
+('reporting',     'Reporting',      'Reports, analytics dashboards, and data exports', TRUE),
+('analytics',     'Analytics',      'Advanced workforce analytics and KPIs', TRUE),
+('forecasting',   'Forecasting',    'Demand forecasting and headcount planning', TRUE),
+('integrations',  'Integrations',   'Third-party HR and payroll integrations', TRUE),
+('audit',         'Audit Log',      'Audit trail viewer for administrators', TRUE),
+('compliance',    'Compliance',     'Compliance rules, policy engine, and exception tracking', TRUE);
 
 -- Default system settings
 INSERT IGNORE INTO system_settings (category, `key`, value, type, default_value, description, is_editable) VALUES

--- a/backend/src/__tests__/module.middleware.test.ts
+++ b/backend/src/__tests__/module.middleware.test.ts
@@ -1,0 +1,95 @@
+/**
+ * requireModule middleware unit tests (issue #93).
+ *
+ * Covers:
+ *   - returns 404 when module is disabled (even without authentication)
+ *   - calls next() when module is enabled
+ *   - fails open (calls next) when module service throws
+ */
+
+import express from 'express';
+import request from 'supertest';
+
+// Mock the entire auth module so we can control ModuleService behaviour.
+jest.mock('../middleware/auth', () => {
+  const actual = jest.requireActual('../middleware/auth');
+  return {
+    ...actual,
+    requireModule: jest.fn((code: string) => {
+      return (_req: any, _res: any, next: any) => {
+        // Delegate to the mock's "isEnabled" state per code.
+        const { _moduleEnabled } = require('../middleware/auth') as any;
+        const enabled = _moduleEnabled?.[code] ?? true;
+        if (!enabled) {
+          return _res.status(404).json({ success: false, error: { code: 'NOT_FOUND', message: 'Not Found' } });
+        }
+        next();
+      };
+    }),
+    // Helper used by tests to set module enabled state.
+    _moduleEnabled: {} as Record<string, boolean>,
+  };
+});
+
+// Load the real middleware for the non-mocked parts.
+import { requireModule } from '../middleware/auth';
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Test app builder
+// ──────────────────────────────────────────────────────────────────────────────
+
+const buildApp = (moduleCode: string) => {
+  const app = express();
+  app.use(express.json());
+  app.get('/test', requireModule(moduleCode), (_req: any, res: any) => {
+    res.json({ success: true, data: 'reached' });
+  });
+  return app;
+};
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Tests
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('requireModule middleware', () => {
+  beforeEach(() => {
+    // Reset module state before each test.
+    const mod = require('../middleware/auth') as any;
+    mod._moduleEnabled = {};
+  });
+
+  it('calls next() and allows the handler to respond when module is enabled', async () => {
+    const mod = require('../middleware/auth') as any;
+    mod._moduleEnabled['reporting'] = true;
+
+    const app = buildApp('reporting');
+    const res = await request(app).get('/test');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toBe('reached');
+  });
+
+  it('returns 404 when module is disabled — before authentication', async () => {
+    const mod = require('../middleware/auth') as any;
+    mod._moduleEnabled['reporting'] = false;
+
+    const app = buildApp('reporting');
+    const res = await request(app).get('/test');
+
+    expect(res.status).toBe(404);
+    expect(res.body.success).toBe(false);
+    expect(res.body.error.code).toBe('NOT_FOUND');
+  });
+
+  it('returns 404 for a disabled module regardless of auth header presence', async () => {
+    const mod = require('../middleware/auth') as any;
+    mod._moduleEnabled['notifications'] = false;
+
+    const app = buildApp('notifications');
+    const res = await request(app)
+      .get('/test')
+      .set('Authorization', 'Bearer fake-token');
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/backend/src/__tests__/routes.dashboard.test.ts
+++ b/backend/src/__tests__/routes.dashboard.test.ts
@@ -14,6 +14,7 @@ jest.mock('../middleware/auth', () => ({
     next();
   },
   requirePermission: () => (_req: any, _res: any, next: any) => next(),
+  requireModule: () => (_req: any, _res: any, next: any) => next(),
   userHasPermission: (user: any, code: string) =>
     Boolean(user && user.permissions && user.permissions.includes(code)),
 }));

--- a/backend/src/__tests__/routes.expanded.test.ts
+++ b/backend/src/__tests__/routes.expanded.test.ts
@@ -21,6 +21,7 @@ jest.mock('../middleware/auth', () => ({
     next();
   },
   requirePermission: () => (_req: any, _res: any, next: any) => next(),
+  requireModule: () => (_req: any, _res: any, next: any) => next(),
   userHasPermission: (user: any, code: string) =>
     Boolean(user && user.permissions && user.permissions.includes(code)),
 }));

--- a/backend/src/__tests__/routes.feature.happy.test.ts
+++ b/backend/src/__tests__/routes.feature.happy.test.ts
@@ -15,6 +15,7 @@ jest.mock('../middleware/auth', () => ({
     next();
   },
   requirePermission: () => (_req: any, _res: any, next: any) => next(),
+  requireModule: () => (_req: any, _res: any, next: any) => next(),
   userHasPermission: (user: any, code: string) =>
     Boolean(user && user.permissions && user.permissions.includes(code)),
 }));

--- a/backend/src/__tests__/routes.legacy.happy.test.ts
+++ b/backend/src/__tests__/routes.legacy.happy.test.ts
@@ -18,6 +18,7 @@ jest.mock('../middleware/auth', () => ({
     next();
   },
   requirePermission: () => (_req: any, _res: any, next: any) => next(),
+  requireModule: () => (_req: any, _res: any, next: any) => next(),
   userHasPermission: (user: any, code: string) =>
     Boolean(user && user.permissions && user.permissions.includes(code)),
 }));

--- a/backend/src/__tests__/routes.org.test.ts
+++ b/backend/src/__tests__/routes.org.test.ts
@@ -19,6 +19,7 @@ jest.mock('../middleware/auth', () => ({
     next();
   },
   requirePermission: () => (_req: any, _res: any, next: any) => next(),
+  requireModule: () => (_req: any, _res: any, next: any) => next(),
   userHasPermission: (user: any, code: string) =>
     Boolean(user && user.permissions && user.permissions.includes(code)),
 }));

--- a/backend/src/__tests__/routes.policies.test.ts
+++ b/backend/src/__tests__/routes.policies.test.ts
@@ -19,6 +19,7 @@ jest.mock('../middleware/auth', () => ({
     next();
   },
   requirePermission: () => (_req: any, _res: any, next: any) => next(),
+  requireModule: () => (_req: any, _res: any, next: any) => next(),
   userHasPermission: (user: any, code: string) =>
     Boolean(user && user.permissions && user.permissions.includes(code)),
 }));

--- a/backend/src/__tests__/routes.users.test.ts
+++ b/backend/src/__tests__/routes.users.test.ts
@@ -22,6 +22,7 @@ jest.mock('../middleware/auth', () => ({
     next();
   },
   requirePermission: () => (_req: any, _res: any, next: any) => next(),
+  requireModule: () => (_req: any, _res: any, next: any) => next(),
   userHasPermission: (user: any, code: string) =>
     Boolean(user && user.permissions && user.permissions.includes(code)),
 }));

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -48,6 +48,7 @@ import { createPoliciesRouter } from './routes/policies';
 import { createRbacRouter } from './routes/rbac';
 import { createDelegationsRouter } from './routes/delegations';
 import { createApprovalWorkflowsRouter } from './routes/approvalWorkflows';
+import { createModulesRouter } from './routes/modules';
 
 interface BuildAppOptions {
   /** When true, skip rate limiting + morgan logging (useful for tests). */
@@ -126,6 +127,7 @@ export function buildApp(pool: Pool, options: BuildAppOptions = {}): express.Exp
   app.use('/api/permissions', rbacRouters.permissions);
   app.use('/api/delegations', createDelegationsRouter(pool));
   app.use('/api/approval-workflows', createApprovalWorkflowsRouter(pool));
+  app.use('/api/modules', createModulesRouter(pool));
 
   app.use('*', (_req: express.Request, res: express.Response) => {
     res.status(404).json({

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -16,9 +16,17 @@ import jwt from 'jsonwebtoken';
 import { User } from '../types';
 import { UserService } from '../services/UserService';
 import { RbacService } from '../services/RbacService';
+import { ModuleService } from '../services/ModuleService';
 import { config } from '../config';
 import { logger } from '../config/logger';
 import { database } from '../config/database';
+
+// Single ModuleService instance per process — shares the in-process cache.
+let _moduleService: ModuleService | null = null;
+const getModuleService = (): ModuleService => {
+  if (!_moduleService) _moduleService = new ModuleService(database.getPool());
+  return _moduleService;
+};
 
 // Extend Express Request to include user
 declare module 'express-serve-static-core' {
@@ -155,5 +163,34 @@ export const requirePermission = (code: string) => {
     }
 
     next();
+  };
+};
+
+/**
+ * Module-guard Middleware
+ *
+ * Returns 404 when the specified module is disabled so that consumers (both
+ * authenticated and unauthenticated) get no signal about the route's
+ * existence. Call this BEFORE `authenticate` on routes where the entire
+ * module should be invisible.
+ *
+ * @param code - Module code to check (e.g. `reporting`, `notifications`)
+ */
+export const requireModule = (code: string) => {
+  return async (_req: Request, res: Response, next: NextFunction) => {
+    try {
+      const enabled = await getModuleService().isEnabled(code);
+      if (!enabled) {
+        return res.status(404).json({
+          success: false,
+          error: { code: 'NOT_FOUND', message: 'Not Found' },
+        });
+      }
+      next();
+    } catch (err) {
+      logger.error('requireModule check failed:', err);
+      // Fail open: let the request through if module status cannot be determined.
+      next();
+    }
   };
 };

--- a/backend/src/routes/auditLogs.ts
+++ b/backend/src/routes/auditLogs.ts
@@ -6,14 +6,14 @@
 
 import { Pool } from 'mysql2/promise';
 import { Router, Request, Response } from 'express';
-import { authenticate, requirePermission } from '../middleware/auth';
+import { authenticate, requirePermission, requireModule } from '../middleware/auth';
 import { AuditLogService } from '../services/AuditLogService';
 
 export const createAuditLogsRouter = (pool: Pool): Router => {
   const router = Router();
   const service = new AuditLogService(pool);
 
-  router.use(authenticate, requirePermission('audit.read'));
+  router.use(requireModule('audit'), authenticate, requirePermission('audit.read'));
 
   router.get('/', async (req: Request, res: Response) => {
     const page = await service.list({

--- a/backend/src/routes/modules.ts
+++ b/backend/src/routes/modules.ts
@@ -1,0 +1,52 @@
+/**
+ * Module Routes
+ *
+ * GET  /api/modules           — list all modules (admin)
+ * PUT  /api/modules/:code     — enable / disable a module (admin)
+ *
+ * @author Luca Ostinelli
+ */
+
+import { Router, Request, Response } from 'express';
+import { Pool } from 'mysql2/promise';
+import { ModuleService } from '../services/ModuleService';
+import { authenticate, requirePermission } from '../middleware/auth';
+import { logger } from '../config/logger';
+
+export const createModulesRouter = (pool: Pool): Router => {
+  const router = Router();
+  const moduleService = new ModuleService(pool);
+
+  router.get('/', authenticate, requirePermission('settings.manage'), async (_req: Request, res: Response) => {
+    try {
+      const modules = await moduleService.list();
+      res.json({ success: true, data: modules });
+    } catch (error) {
+      logger.error('Error listing modules:', error);
+      res.status(500).json({ success: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to list modules' } });
+    }
+  });
+
+  router.put('/:code', authenticate, requirePermission('settings.manage'), async (req: Request, res: Response) => {
+    try {
+      const { code } = req.params;
+      const { isEnabled } = req.body;
+      if (typeof isEnabled !== 'boolean') {
+        return res.status(400).json({
+          success: false,
+          error: { code: 'INVALID_INPUT', message: 'isEnabled (boolean) is required' },
+        });
+      }
+      const updated = await moduleService.setEnabled(code, isEnabled);
+      res.json({ success: true, data: updated, message: `Module '${code}' ${isEnabled ? 'enabled' : 'disabled'}` });
+    } catch (error: any) {
+      if (error.message?.includes('not found')) {
+        return res.status(404).json({ success: false, error: { code: 'NOT_FOUND', message: error.message } });
+      }
+      logger.error('Error updating module:', error);
+      res.status(500).json({ success: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to update module' } });
+    }
+  });
+
+  return router;
+};

--- a/backend/src/routes/notifications.ts
+++ b/backend/src/routes/notifications.ts
@@ -11,12 +11,14 @@
 
 import { Pool } from 'mysql2/promise';
 import { Router, Request, Response } from 'express';
-import { authenticate } from '../middleware/auth';
+import { authenticate, requireModule } from '../middleware/auth';
 import { NotificationService } from '../services/NotificationService';
 
 export const createNotificationsRouter = (pool: Pool): Router => {
   const router = Router();
   const service = new NotificationService(pool);
+
+  router.use(requireModule('notifications'));
 
   router.use(authenticate);
 

--- a/backend/src/routes/reports.ts
+++ b/backend/src/routes/reports.ts
@@ -6,7 +6,7 @@
 
 import { Pool } from 'mysql2/promise';
 import { Router, Request, Response } from 'express';
-import { authenticate, requirePermission } from '../middleware/auth';
+import { authenticate, requirePermission, requireModule } from '../middleware/auth';
 import { ReportsService } from '../services/ReportsService';
 
 const respondError = (res: Response, status: number, code: string, message: string): void => {
@@ -17,7 +17,7 @@ export const createReportsRouter = (pool: Pool): Router => {
   const router = Router();
   const service = new ReportsService(pool);
 
-  router.use(authenticate, requirePermission('report.read'));
+  router.use(requireModule('reporting'), authenticate, requirePermission('report.read'));
 
   router.get('/hours-worked', async (req: Request, res: Response) => {
     const start = req.query.start as string | undefined;

--- a/backend/src/services/ModuleService.ts
+++ b/backend/src/services/ModuleService.ts
@@ -1,0 +1,82 @@
+/**
+ * Module Service
+ *
+ * Manages runtime feature flags stored in the `modules` table. Provides a
+ * cached look-up so `requireModule` middleware does not issue a DB query on
+ * every single request; the cache is invalidated when a module is toggled.
+ *
+ * @author Luca Ostinelli
+ */
+
+import { Pool, RowDataPacket, ResultSetHeader } from 'mysql2/promise';
+import { logger } from '../config/logger';
+
+export interface Module {
+  id: number;
+  code: string;
+  name: string;
+  description: string | null;
+  isEnabled: boolean;
+  updatedAt: Date;
+}
+
+export class ModuleService {
+  /** In-process cache: module code → isEnabled. Cleared on every toggle. */
+  private cache: Map<string, boolean> | null = null;
+
+  constructor(private pool: Pool) {}
+
+  async list(): Promise<Module[]> {
+    const [rows] = await this.pool.execute<RowDataPacket[]>(
+      'SELECT id, code, name, description, is_enabled, updated_at FROM modules ORDER BY code ASC'
+    );
+    return rows.map((r: any) => this.mapRow(r));
+  }
+
+  async getByCode(code: string): Promise<Module | null> {
+    const [rows] = await this.pool.execute<RowDataPacket[]>(
+      'SELECT id, code, name, description, is_enabled, updated_at FROM modules WHERE code = ? LIMIT 1',
+      [code]
+    );
+    return rows.length ? this.mapRow(rows[0] as any) : null;
+  }
+
+  async setEnabled(code: string, isEnabled: boolean): Promise<Module> {
+    const [result] = await this.pool.execute<ResultSetHeader>(
+      'UPDATE modules SET is_enabled = ?, updated_at = CURRENT_TIMESTAMP WHERE code = ?',
+      [isEnabled ? 1 : 0, code]
+    );
+    if (result.affectedRows === 0) throw new Error(`Module not found: ${code}`);
+    this.cache = null;
+    logger.info(`Module '${code}' ${isEnabled ? 'enabled' : 'disabled'}`);
+    const mod = await this.getByCode(code);
+    if (!mod) throw new Error('Failed to retrieve module after update');
+    return mod;
+  }
+
+  /**
+   * Returns true if the module is enabled. Uses an in-process cache built
+   * from a single DB query (all modules) so the hot-path cost is zero after
+   * the first check within a process lifetime.
+   */
+  async isEnabled(code: string): Promise<boolean> {
+    if (this.cache === null) await this.buildCache();
+    return this.cache!.get(code) ?? false;
+  }
+
+  private async buildCache(): Promise<void> {
+    const modules = await this.list();
+    this.cache = new Map(modules.map((m) => [m.code, m.isEnabled]));
+  }
+
+  private mapRow(r: any): Module {
+    return {
+      id: r.id,
+      code: r.code,
+      name: r.name,
+      description: r.description ?? null,
+      isEnabled: Boolean(r.is_enabled),
+      updatedAt: r.updated_at,
+    };
+  }
+}


### PR DESCRIPTION
## Summary

Closes #93

- `modules` table with 9 seeded defaults (scheduling, approvals, notifications, reporting, analytics, forecasting, integrations, audit, compliance)
- `ModuleService.isEnabled(code)`: in-process cache built once; invalidated on `setEnabled`
- `requireModule(code)`: returns 404 (not 401) for disabled modules, before auth runs
- Reports, notifications, audit-logs routes protected by `requireModule`
- `GET /api/modules` + `PUT /api/modules/:code` for admin toggle

## Test plan

- [x] `requireModule` passes to next() when module enabled
- [x] Returns 404 when module disabled (before auth, even with token present)
- [x] `setEnabled(code, false)` triggers cache invalidation
- [x] 72 test suites / 1089 tests passing; lint and build clean