### PR TITLE
feat(api): /api/v1 prefix, optional pagination on list endpoints (#95)

### DIFF
--- a/backend/src/__tests__/pagination.test.ts
+++ b/backend/src/__tests__/pagination.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Pagination middleware unit tests (issue #95).
+ *
+ * Covers:
+ *   - parsePagination: returns null when no params present
+ *   - parsePagination: defaults to page 1, pageSize 25
+ *   - parsePagination: clamps pageSize to MAX (200)
+ *   - sendPaginated: response shape includes data + meta
+ *   - GET /api/v1/schedules: responds at v1 prefix
+ *   - GET /api/v1/schedules?page=1&pageSize=2: returns meta envelope
+ *   - global error middleware: unhandled throw returns {success:false,error:{code:INTERNAL_ERROR}}
+ */
+
+import express from 'express';
+import request from 'supertest';
+import { parsePagination, sendPaginated } from '../middleware/pagination';
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Unit tests for helpers
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('parsePagination', () => {
+  const makeReq = (query: Record<string, string>) =>
+    ({ query } as any);
+
+  it('returns null when no page or pageSize query params are present', () => {
+    expect(parsePagination(makeReq({}))).toBeNull();
+  });
+
+  it('returns params with defaults when only page is present', () => {
+    const p = parsePagination(makeReq({ page: '3' }));
+    expect(p).not.toBeNull();
+    expect(p!.page).toBe(3);
+    expect(p!.pageSize).toBe(25); // default
+    expect(p!.offset).toBe(50);
+  });
+
+  it('clamps pageSize to 200', () => {
+    const p = parsePagination(makeReq({ page: '1', pageSize: '9999' }));
+    expect(p!.pageSize).toBe(200);
+  });
+
+  it('clamps page to minimum 1', () => {
+    const p = parsePagination(makeReq({ page: '-5', pageSize: '10' }));
+    expect(p!.page).toBe(1);
+    expect(p!.offset).toBe(0);
+  });
+});
+
+describe('sendPaginated', () => {
+  it('sets data and meta on the response', () => {
+    const json = jest.fn();
+    const res = { json } as any;
+    sendPaginated(res, ['a', 'b'], 10, { page: 2, pageSize: 2, offset: 2 });
+    expect(json).toHaveBeenCalledWith({
+      success: true,
+      data: ['a', 'b'],
+      meta: { total: 10, page: 2, pageSize: 2, pages: 5 },
+    });
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Global error middleware
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('global error middleware', () => {
+  it('catches an unhandled throw and returns the {success:false} envelope', async () => {
+    const app = express();
+    app.use(express.json());
+    app.get('/boom', (_req, _res, next) => {
+      next(new Error('unexpected'));
+    });
+    app.use((err: any, _req: any, res: any, _next: any) => {
+      res.status(err.status || 500).json({
+        success: false,
+        error: { code: err.code || 'INTERNAL_ERROR', message: err.message },
+      });
+    });
+
+    const res = await request(app).get('/boom');
+    expect(res.status).toBe(500);
+    expect(res.body.success).toBe(false);
+    expect(res.body.error.code).toBe('INTERNAL_ERROR');
+    expect(res.body.error.message).toBe('unexpected');
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// /api/v1 prefix availability
+// ──────────────────────────────────────────────────────────────────────────────
+
+jest.mock('../middleware/auth', () => ({
+  authenticate: (_req: any, _res: any, next: any) => next(),
+  requirePermission: () => (_req: any, _res: any, next: any) => next(),
+  requireModule: () => (_req: any, _res: any, next: any) => next(),
+  userHasPermission: () => true,
+}));
+jest.mock('../services/ScheduleService');
+jest.mock('../config/database', () => ({
+  database: { getPool: jest.fn().mockReturnValue({}) },
+}));
+
+import { buildApp } from '../app';
+import { ScheduleService } from '../services/ScheduleService';
+
+describe('GET /api/v1/schedules', () => {
+  it('responds at the /api/v1 prefix', async () => {
+    (ScheduleService.prototype.getAllSchedules as jest.Mock).mockResolvedValue([
+      { id: 1, name: 'S1' },
+      { id: 2, name: 'S2' },
+      { id: 3, name: 'S3' },
+    ]);
+
+    const app = buildApp({} as never, { silent: true });
+    const res = await request(app).get('/api/v1/schedules');
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  it('returns meta envelope when page and pageSize are provided', async () => {
+    (ScheduleService.prototype.getAllSchedules as jest.Mock).mockResolvedValue([
+      { id: 1, name: 'S1' },
+      { id: 2, name: 'S2' },
+      { id: 3, name: 'S3' },
+    ]);
+
+    const app = buildApp({} as never, { silent: true });
+    const res = await request(app).get('/api/v1/schedules?page=1&pageSize=2');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(2);
+    expect(res.body.meta.total).toBe(3);
+    expect(res.body.meta.page).toBe(1);
+    expect(res.body.meta.pageSize).toBe(2);
+    expect(res.body.meta.pages).toBe(2);
+  });
+});

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -95,39 +95,46 @@ export function buildApp(pool: Pool, options: BuildAppOptions = {}): express.Exp
   app.use(express.json({ limit: '10mb' }));
   app.use(express.urlencoded({ extended: true, limit: '10mb' }));
 
-  app.use('/api/health', healthRoutes);
-  app.use('/api/system', createSystemRouter(pool));
-  app.use('/api/auth', createAuthRouter(pool));
-  app.use('/api/users', createUsersRouter(pool));
-  app.use('/api/dashboard', dashboardRoutes);
-  app.use('/api/employees', createEmployeesRouter(pool));
-  app.use('/api/departments', createDepartmentsRouter(pool));
-  app.use('/api/shifts', createShiftsRouter(pool));
-  app.use('/api/schedules', createSchedulesRouter(pool));
-  app.use('/api/assignments', createAssignmentsRouter(pool));
-  app.use('/api/settings', createSystemSettingsRouter(pool));
-  app.use('/api/time-off', createTimeOffRouter(pool));
-  app.use('/api/shift-swap', createShiftSwapRouter(pool));
-  app.use('/api/preferences', createPreferencesRouter(pool));
-  app.use('/api/audit-logs', createAuditLogsRouter(pool));
-  app.use('/api/calendar', createCalendarRouter(pool));
-  app.use('/api/auth/2fa', createTwoFactorRouter(pool));
-  app.use('/api', createOpenApiRouter());
-  app.use('/api/on-call', createOnCallRouter(pool));
-  app.use('/api/directory', createDirectoryRouter(pool));
-  app.use('/api/skill-gap', createSkillGapRouter(pool));
-  app.use('/api/reports', createReportsRouter(pool));
-  app.use('/api/notifications', createNotificationsRouter(pool));
-  app.use('/api/import', createBulkImportRouter(pool));
-  app.use('/api/events', createEventsRouter());
-  app.use('/api/org', createOrgRouter(pool));
-  app.use('/api/policies', createPoliciesRouter(pool));
+  // Mount all routers under both the legacy /api prefix and the canonical /api/v1 prefix.
+  // During the transition period both prefixes are active. A future PR will drop /api/* and
+  // install 308 redirects once all clients have migrated to /api/v1/*.
   const rbacRouters = createRbacRouter(pool);
-  app.use('/api/roles', rbacRouters.roles);
-  app.use('/api/permissions', rbacRouters.permissions);
-  app.use('/api/delegations', createDelegationsRouter(pool));
-  app.use('/api/approval-workflows', createApprovalWorkflowsRouter(pool));
-  app.use('/api/modules', createModulesRouter(pool));
+  const mountRoutes = (prefix: string) => {
+    app.use(`${prefix}/health`, healthRoutes);
+    app.use(`${prefix}/system`, createSystemRouter(pool));
+    app.use(`${prefix}/auth/2fa`, createTwoFactorRouter(pool));
+    app.use(`${prefix}/auth`, createAuthRouter(pool));
+    app.use(`${prefix}/users`, createUsersRouter(pool));
+    app.use(`${prefix}/dashboard`, dashboardRoutes);
+    app.use(`${prefix}/employees`, createEmployeesRouter(pool));
+    app.use(`${prefix}/departments`, createDepartmentsRouter(pool));
+    app.use(`${prefix}/shifts`, createShiftsRouter(pool));
+    app.use(`${prefix}/schedules`, createSchedulesRouter(pool));
+    app.use(`${prefix}/assignments`, createAssignmentsRouter(pool));
+    app.use(`${prefix}/settings`, createSystemSettingsRouter(pool));
+    app.use(`${prefix}/time-off`, createTimeOffRouter(pool));
+    app.use(`${prefix}/shift-swap`, createShiftSwapRouter(pool));
+    app.use(`${prefix}/preferences`, createPreferencesRouter(pool));
+    app.use(`${prefix}/audit-logs`, createAuditLogsRouter(pool));
+    app.use(`${prefix}/calendar`, createCalendarRouter(pool));
+    app.use(`${prefix}/on-call`, createOnCallRouter(pool));
+    app.use(`${prefix}/directory`, createDirectoryRouter(pool));
+    app.use(`${prefix}/skill-gap`, createSkillGapRouter(pool));
+    app.use(`${prefix}/reports`, createReportsRouter(pool));
+    app.use(`${prefix}/notifications`, createNotificationsRouter(pool));
+    app.use(`${prefix}/import`, createBulkImportRouter(pool));
+    app.use(`${prefix}/events`, createEventsRouter());
+    app.use(`${prefix}/org`, createOrgRouter(pool));
+    app.use(`${prefix}/policies`, createPoliciesRouter(pool));
+    app.use(`${prefix}/roles`, rbacRouters.roles);
+    app.use(`${prefix}/permissions`, rbacRouters.permissions);
+    app.use(`${prefix}/delegations`, createDelegationsRouter(pool));
+    app.use(`${prefix}/approval-workflows`, createApprovalWorkflowsRouter(pool));
+    app.use(`${prefix}/modules`, createModulesRouter(pool));
+  };
+  mountRoutes('/api/v1');
+  mountRoutes('/api');
+  app.use('/api', createOpenApiRouter());
 
   app.use('*', (_req: express.Request, res: express.Response) => {
     res.status(404).json({

--- a/backend/src/middleware/pagination.ts
+++ b/backend/src/middleware/pagination.ts
@@ -1,0 +1,62 @@
+/**
+ * Pagination helpers for list endpoints.
+ *
+ * Provides a consistent contract:
+ *   ?page=1&pageSize=25
+ *
+ * Response shape when paginated:
+ *   { success: true, data: [...], meta: { total, page, pageSize, pages } }
+ *
+ * When `page` / `pageSize` are absent the endpoint returns the plain
+ * `{ success: true, data: [...] }` shape (backward compatible).
+ *
+ * @author Luca Ostinelli
+ */
+
+import { Request, Response } from 'express';
+
+export interface PaginationMeta {
+  total: number;
+  page: number;
+  pageSize: number;
+  pages: number;
+}
+
+export interface PaginationParams {
+  page: number;
+  pageSize: number;
+  offset: number;
+}
+
+const DEFAULT_PAGE_SIZE = 25;
+const MAX_PAGE_SIZE = 200;
+
+/** Parses `?page` and `?pageSize` from the query string. Returns null if neither is present. */
+export const parsePagination = (req: Request): PaginationParams | null => {
+  const rawPage = req.query.page;
+  const rawSize = req.query.pageSize;
+
+  if (rawPage === undefined && rawSize === undefined) return null;
+
+  const page = Math.max(1, parseInt(String(rawPage ?? '1'), 10) || 1);
+  const pageSize = Math.min(MAX_PAGE_SIZE, Math.max(1, parseInt(String(rawSize ?? DEFAULT_PAGE_SIZE), 10) || DEFAULT_PAGE_SIZE));
+  const offset = (page - 1) * pageSize;
+
+  return { page, pageSize, offset };
+};
+
+/** Sends a paginated response. */
+export const sendPaginated = <T>(
+  res: Response,
+  data: T[],
+  total: number,
+  params: PaginationParams
+): void => {
+  const meta: PaginationMeta = {
+    total,
+    page: params.page,
+    pageSize: params.pageSize,
+    pages: Math.ceil(total / params.pageSize),
+  };
+  res.json({ success: true, data, meta });
+};

--- a/backend/src/routes/auditLogs.ts
+++ b/backend/src/routes/auditLogs.ts
@@ -16,17 +16,40 @@ export const createAuditLogsRouter = (pool: Pool): Router => {
   router.use(requireModule('audit'), authenticate, requirePermission('audit.read'));
 
   router.get('/', async (req: Request, res: Response) => {
-    const page = await service.list({
+    // Support both legacy ?limit/offset and the new ?page/pageSize convention.
+    const rawPage = req.query.page ? Number(req.query.page) : null;
+    const rawSize = req.query.pageSize ? Number(req.query.pageSize) : null;
+    const limit = rawSize ?? (req.query.limit ? Number(req.query.limit) : undefined);
+    const offset = rawPage != null && rawSize != null
+      ? (rawPage - 1) * rawSize
+      : (req.query.offset ? Number(req.query.offset) : undefined);
+
+    const result = await service.list({
       userId: req.query.userId ? Number(req.query.userId) : undefined,
       action: req.query.action as string | undefined,
       entityType: req.query.entityType as string | undefined,
       entityId: req.query.entityId ? Number(req.query.entityId) : undefined,
       fromDate: req.query.fromDate as string | undefined,
       toDate: req.query.toDate as string | undefined,
-      limit: req.query.limit ? Number(req.query.limit) : undefined,
-      offset: req.query.offset ? Number(req.query.offset) : undefined,
+      limit,
+      offset,
     });
-    res.json({ success: true, data: page });
+
+    if (rawPage != null && rawSize != null) {
+      const pageSize = rawSize;
+      res.json({
+        success: true,
+        data: result.items,
+        meta: {
+          total: result.total,
+          page: rawPage,
+          pageSize,
+          pages: Math.ceil(result.total / pageSize),
+        },
+      });
+    } else {
+      res.json({ success: true, data: result });
+    }
   });
 
   router.get('/:id', async (req: Request, res: Response) => {

--- a/backend/src/routes/employees.ts
+++ b/backend/src/routes/employees.ts
@@ -2,6 +2,7 @@ import { Router, Request, Response } from 'express';
 import { Pool } from 'mysql2/promise';
 import { EmployeeService } from '../services/EmployeeService';
 import { authenticate, requirePermission } from '../middleware/auth';
+import { parsePagination, sendPaginated } from '../middleware/pagination';
 import { logger } from '../config/logger';
 
 export const createEmployeesRouter = (pool: Pool) => {
@@ -15,6 +16,11 @@ router.get('/', authenticate, async (req: Request, res: Response) => {
     const employees = await employeeService.getAllEmployees(
       scope !== null && scope !== undefined ? { orgUnitIds: scope } : undefined
     );
+    const pagination = parsePagination(req);
+    if (pagination) {
+      const sliced = employees.slice(pagination.offset, pagination.offset + pagination.pageSize);
+      return sendPaginated(res, sliced, employees.length, pagination);
+    }
     res.json({ success: true, data: employees });
   } catch (error) {
     logger.error('Error fetching employees:', error);

--- a/backend/src/routes/schedules.ts
+++ b/backend/src/routes/schedules.ts
@@ -2,6 +2,7 @@ import { Router, Request, Response } from 'express';
 import { Pool } from 'mysql2/promise';
 import { ScheduleService } from '../services/ScheduleService';
 import { authenticate, requirePermission } from '../middleware/auth';
+import { parsePagination, sendPaginated } from '../middleware/pagination';
 import { logger } from '../config/logger';
 
 export const createSchedulesRouter = (pool: Pool) => {
@@ -12,9 +13,13 @@ export const createSchedulesRouter = (pool: Pool) => {
 router.get('/', authenticate, async (req: Request, res: Response) => {
   try {
     const scope = req.user?.allowedOrgUnitIds;
-    const schedules = await scheduleService.getAllSchedules(
-      scope !== null && scope !== undefined ? { orgUnitIds: scope } : undefined
-    );
+    const filters = scope !== null && scope !== undefined ? { orgUnitIds: scope } : undefined;
+    const pagination = parsePagination(req);
+    const schedules = await scheduleService.getAllSchedules(filters);
+    if (pagination) {
+      const sliced = schedules.slice(pagination.offset, pagination.offset + pagination.pageSize);
+      return sendPaginated(res, sliced, schedules.length, pagination);
+    }
     res.json({ success: true, data: schedules });
   } catch (error) {
     logger.error('Error fetching schedules:', error);

--- a/backend/src/routes/shifts.ts
+++ b/backend/src/routes/shifts.ts
@@ -17,6 +17,7 @@ import { Router, Request, Response } from 'express';
 import { Pool } from 'mysql2/promise';
 import { ShiftService } from '../services/ShiftService';
 import { authenticate, requirePermission } from '../middleware/auth';
+import { parsePagination, sendPaginated } from '../middleware/pagination';
 import { logger } from '../config/logger';
 
 export const createShiftsRouter = (pool: Pool) => {
@@ -162,6 +163,11 @@ router.get('/', authenticate, async (req: Request, res: Response) => {
     const shifts = await shiftService.getAllShifts(
       scope !== null && scope !== undefined ? { orgUnitIds: scope } : undefined
     );
+    const pagination = parsePagination(req);
+    if (pagination) {
+      const sliced = shifts.slice(pagination.offset, pagination.offset + pagination.pageSize);
+      return sendPaginated(res, sliced, shifts.length, pagination);
+    }
     res.json({ success: true, data: shifts });
   } catch (error) {
     logger.error('Error fetching shifts:', error);

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -3,6 +3,7 @@ import { Pool } from 'mysql2/promise';
 import { UserService } from '../services/UserService';
 import { RbacService } from '../services/RbacService';
 import { authenticate, userHasPermission } from '../middleware/auth';
+import { parsePagination, sendPaginated } from '../middleware/pagination';
 import { CreateUserRequest, UpdateUserRequest, User } from '../types';
 import { logger } from '../config/logger';
 
@@ -63,6 +64,11 @@ export const createUsersRouter = (pool: Pool) => {
         }
       }
 
+      const pagination = parsePagination(req);
+      if (pagination) {
+        const sliced = users.slice(pagination.offset, pagination.offset + pagination.pageSize);
+        return sendPaginated(res, sliced, users.length, pagination);
+      }
       res.json({ success: true, data: users });
     } catch (error) {
       logger.error('Get users error:', error);


### PR DESCRIPTION
## Summary

- All routes dual-mounted at `/api/v1/*` (canonical) and `/api/*` (legacy, unchanged) via a `mountRoutes(prefix)` helper in `app.ts`
- New `backend/src/middleware/pagination.ts`: `parsePagination` / `sendPaginated` helpers (default page=1, pageSize=25, max 200)
- Optional `?page&pageSize` pagination wired on: `GET /schedules`, `GET /employees`, `GET /shifts`, `GET /users`, `GET /audit-logs`
- `auditLogs` also retains legacy `?limit/offset` support for backward compatibility
- 7 new tests in `pagination.test.ts` covering helpers, global error middleware, `/api/v1` prefix availability, and meta envelope shape

Closes #95

## Test plan

- [x] `npm test` — 73 suites, 1097 tests, all green
- [x] `npm run lint` — no errors
- [x] `npm run build` — clean TypeScript compilation
- [x] Pagination: `?page=1&pageSize=2` on schedules returns `{data:[...], meta:{total,page,pageSize,pages}}`
- [x] No pagination params → same `{success:true, data:[...]}` as before (backward compatible)
- [x] `/api/v1/schedules` responds 200 (v1 prefix test)