### PR TITLE
chore(ci): add npm audit, Dependabot, and .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,27 @@
+# Default: normalize line endings
+* text=auto
+
+# Force LF for source files
+*.ts    text eol=lf
+*.tsx   text eol=lf
+*.js    text eol=lf
+*.json  text eol=lf
+*.md    text eol=lf
+*.yml   text eol=lf
+*.yaml  text eol=lf
+*.sh    text eol=lf
+*.py    text eol=lf
+*.sql   text eol=lf
+*.css   text eol=lf
+*.html  text eol=lf
+
+# Binary files
+*.png   binary
+*.jpg   binary
+*.jpeg  binary
+*.gif   binary
+*.ico   binary
+*.woff  binary
+*.woff2 binary
+*.ttf   binary
+*.eot   binary

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "backend"
+
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "frontend"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "ci"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Install dependencies
         run: npm ci --prefer-offline --no-audit --no-fund
 
+      - name: Audit dependencies
+        run: npm audit --audit-level=high --production
+
       - name: Lint
         run: npm run lint
 
@@ -103,6 +106,9 @@ jobs:
 
       - name: Install dependencies
         run: npm ci --prefer-offline --no-audit --no-fund
+
+      - name: Audit dependencies
+        run: npm audit --audit-level=high --production
 
       - name: Lint
         run: npm run lint


### PR DESCRIPTION
## Summary
- Add `npm audit --audit-level=high --production` step to backend and frontend CI jobs, running immediately after `npm ci` to catch high-severity production dependency vulnerabilities before lint/build/test
- Add `.github/dependabot.yml` to automate weekly dependency updates for backend npm packages, frontend npm packages, and GitHub Actions
- Add `.gitattributes` at project root to enforce LF line endings for all source file types and mark binary assets as binary

## Test plan
- [ ] YAML files validated with `python3 -c "import yaml; yaml.safe_load(...)"` — both pass
- [ ] Backend build (`npm run build`) passes cleanly
- [ ] Backend lint (`npm run lint`) passes cleanly
- [ ] Backend tests: 75 suites, 1118 tests all pass (`npm test -- --runInBand --ci`)
- [ ] Audit steps use `--production` flag to avoid blocking CI on devDependency vulnerabilities
- [ ] CI triggers unchanged (push/PR to main only)