### PR TITLE
feat(observability): add structured HTTP access logging middleware

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -18,6 +18,7 @@ import type { Pool } from 'mysql2/promise';
 import { config } from './config';
 import { logger } from './config/logger';
 import { requestId } from './middleware/requestContext';
+import { requestLogger } from './middleware/requestLogger';
 
 import { createAuthRouter } from './routes/auth';
 import { createUsersRouter } from './routes/users';
@@ -134,6 +135,7 @@ export function buildApp(pool: Pool, options: BuildAppOptions = {}): express.Exp
   }
 
   app.use(requestId);
+  app.use(requestLogger);
   app.use(compression());
   // Body parser: 10 MB ceiling is intentional — bulk import CSVs and schedule payloads
   // can be large, but we keep this well below the 50 MB nginx default to limit DoS surface.

--- a/backend/src/middleware/requestLogger.ts
+++ b/backend/src/middleware/requestLogger.ts
@@ -1,0 +1,33 @@
+/**
+ * HTTP Access Logger Middleware
+ *
+ * Emits one structured JSON log line per request upon response finish.
+ * Fields logged: method, path, statusCode, durationMs, userId, requestId.
+ *
+ * Mount this middleware immediately after the requestId middleware so that
+ * getRequestId() can read the AsyncLocalStorage context set by requestId.
+ *
+ * @author Luca Ostinelli
+ */
+
+import { Request, Response, NextFunction } from 'express';
+import { logger } from '../config/logger';
+import { getRequestId } from './requestContext';
+
+export function requestLogger(req: Request, res: Response, next: NextFunction): void {
+  const start = Date.now();
+
+  res.on('finish', () => {
+    const durationMs = Date.now() - start;
+    logger.info('http', {
+      method: req.method,
+      path: req.path,
+      statusCode: res.statusCode,
+      durationMs,
+      userId: req.user?.id ?? null,
+      requestId: getRequestId() ?? null,
+    });
+  });
+
+  next();
+}


### PR DESCRIPTION
## Summary

- Add `backend/src/middleware/requestLogger.ts` — a new Express middleware that listens to the `res.finish` event and emits one structured JSON log line per request
- Each log line carries: `method`, `path`, `statusCode`, `durationMs`, `userId`, `requestId`
- Mount `requestLogger` immediately after `requestId` in `app.ts` so the AsyncLocalStorage context is populated before the logger reads it

## Test plan

- [ ] TypeScript compiles without errors (`tsc --noEmit`)
- [ ] ESLint passes (`npm run lint`)
- [ ] Knip dead-code check passes (`npm run deadcode`)
- [ ] All 1118 existing unit tests pass (`npm test -- --runInBand --ci`)
- [ ] In a live run, verify each request produces a structured JSON log line in the application log with all six fields