### PR TITLE
chore(docker): add resource limits, restart policies, and override template

### DIFF
--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -1,0 +1,14 @@
+# docker-compose.override.yml.example
+# Copy to docker-compose.override.yml and customize for local development.
+# This file is gitignored — local overrides are not committed.
+# Usage: docker compose up  (Docker Compose merges overrides automatically)
+
+services:
+  backend:
+    environment:
+      - NODE_ENV=development
+      - LOG_LEVEL=debug
+
+  db:
+    ports:
+      - "3306:3306"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,10 +21,14 @@ services:
       --collation-server=utf8mb4_unicode_ci
     networks:
       - staff_scheduler_network
+    mem_limit: 512m
+    cpus: 0.5
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 30s
       timeout: 20s
       retries: 10
+      start_period: 40s
 
   # Backend API Service
   backend:
@@ -56,6 +60,8 @@ services:
       - backend_uploads:/app/uploads
     networks:
       - staff_scheduler_network
+    mem_limit: 512m
+    cpus: 0.5
     healthcheck:
       test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3001/api/health"]
       interval: 30s
@@ -81,6 +87,8 @@ services:
       - "${FRONTEND_PORT:-3000}:3000"
     networks:
       - staff_scheduler_network
+    mem_limit: 256m
+    cpus: 0.25
     healthcheck:
       test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3000/"]
       interval: 30s


### PR DESCRIPTION
## Summary

- Add `mem_limit` and `cpus` resource constraints to `mysql` (512m/0.5), `backend` (512m/0.5), and `frontend` (256m/0.25) services, preventing any single container from exhausting host resources
- Complete the `mysql` healthcheck with missing `interval` (30s) and `start_period` (40s) fields so it matches the format used by the other services
- Add `docker-compose.override.yml.example` as a committed template for local development overrides; `docker-compose.override.yml` is already gitignored

## Test plan

- [ ] Build passes: `cd backend && npm run build` — no TypeScript errors
- [ ] Lint passes: `npm run lint` — no ESLint errors
- [ ] Tests pass: `npm test -- --runInBand --ci` — 1118 tests, 75 suites, all green
- [ ] `docker compose config` validates the updated compose file without errors
- [ ] Copy `docker-compose.override.yml.example` to `docker-compose.override.yml`, run `docker compose up` and confirm containers start within their resource envelopes