### PR TITLE
fix(backend): eliminate N+1 queries and improve API consistency

### DIFF
--- a/backend/src/__tests__/approval.engine.extended.test.ts
+++ b/backend/src/__tests__/approval.engine.extended.test.ts
@@ -78,10 +78,19 @@ describe('ApprovalEngineService.listWorkflows', () => {
 
   it('returns hydrated workflows with their steps', async () => {
     const { pool, execute } = makePool();
-    // list query
-    execute.mockResolvedValueOnce([[wfRow], null]);
-    // hydrateWorkflow — steps for workflow 1
-    execute.mockResolvedValueOnce([[stepRow], null]);
+    // Single JOIN query returns workflow columns + step columns merged
+    const joinedRow = {
+      ...wfRow,
+      step_id: stepRow.id,
+      step_workflow_id: stepRow.workflow_id,
+      step_order: stepRow.step_order,
+      approver_scope: stepRow.approver_scope,
+      approver_role_id: stepRow.approver_role_id,
+      approver_user_id: stepRow.approver_user_id,
+      auto_approve_for_owner: stepRow.auto_approve_for_owner,
+      escalate_after_hours: stepRow.escalate_after_hours,
+    };
+    execute.mockResolvedValueOnce([[joinedRow], null]);
 
     const svc = new ApprovalEngineService(pool);
     const result = await svc.listWorkflows();

--- a/backend/src/__tests__/routes.departments.test.ts
+++ b/backend/src/__tests__/routes.departments.test.ts
@@ -389,7 +389,7 @@ describe('departments router POST /:id/users', () => {
       .post('/api/departments/3/users')
       .send({ userId: 7 });
 
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(201);
     expect(res.body.success).toBe(true);
   });
 });

--- a/backend/src/__tests__/routes.expanded.test.ts
+++ b/backend/src/__tests__/routes.expanded.test.ts
@@ -862,13 +862,13 @@ describe('employees router (extended)', () => {
     expect(res.status).toBe(500);
   });
 
-  it('POST /:id/skills 400/200/500', async () => {
+  it('POST /:id/skills 400/201/500', async () => {
     let res = await request(app()).post('/api/employees/abc/skills').send({});
     expect(res.status).toBe(400);
 
     (EmployeeService.prototype.addEmployeeSkill as jest.Mock) = jest.fn().mockResolvedValue(undefined);
     res = await request(app()).post('/api/employees/1/skills').send({ skillId: 1, proficiencyLevel: 3 });
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(201);
 
     (EmployeeService.prototype.addEmployeeSkill as jest.Mock) = jest
       .fn()
@@ -1080,7 +1080,7 @@ describe('departments router (extended)', () => {
       .fn()
       .mockResolvedValue(undefined);
     res = await request(app()).post('/api/departments/1/users').send({ userId: 9 });
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(201);
 
     (DepartmentService.prototype.addUserToDepartment as jest.Mock) = jest
       .fn()

--- a/backend/src/__tests__/routes.feature.happy.test.ts
+++ b/backend/src/__tests__/routes.feature.happy.test.ts
@@ -310,7 +310,7 @@ describe('on-call router', () => {
     const res = await request(mountApp('/api/on-call', createOnCallRouter(fakePool)))
       .post('/api/on-call/periods/1/assign')
       .send({ userId: 7 });
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(201);
   });
 
   it('DELETE /periods/:id/assign/:userId returns 200 when removed', async () => {

--- a/backend/src/__tests__/schedule.service.extended.test.ts
+++ b/backend/src/__tests__/schedule.service.extended.test.ts
@@ -325,9 +325,7 @@ describe('ScheduleService convenience helpers', () => {
   it('getSchedulesByUser returns mapped schedules; bubbles errors', async () => {
     const { pool, execute } = makePool();
     execute
-      .mockResolvedValueOnce([[{ id: 1 }, { id: 2 }], null] as Tuple) // user schedules
-      .mockResolvedValueOnce([[buildScheduleRow({ id: 1 })], null] as Tuple)
-      .mockResolvedValueOnce([[], null] as Tuple) // null filtered
+      .mockResolvedValueOnce([[buildScheduleRow({ id: 1 })], null] as Tuple) // single batched query
       .mockRejectedValueOnce(new Error('boom'));
     const svc = new ScheduleService(pool);
     const out = await svc.getSchedulesByUser(7);

--- a/backend/src/routes/departments.ts
+++ b/backend/src/routes/departments.ts
@@ -249,7 +249,7 @@ export const createDepartmentsRouter = (pool: Pool) => {
 
       await departmentService.addUserToDepartment(departmentId, userId);
 
-      res.json({ success: true, data: { message: 'User added to department successfully' } });
+      res.status(201).json({ success: true, data: { message: 'User added to department successfully' } });
     } catch (error) {
       logger.error('Add user to department error:', error);
       res.status(500).json({

--- a/backend/src/routes/employees.ts
+++ b/backend/src/routes/employees.ts
@@ -169,7 +169,7 @@ router.post('/:id/skills', authenticate, requirePermission('employee.manage'), v
 
     await employeeService.addEmployeeSkill(id, skillId, proficiencyLevel);
 
-    res.json({
+    res.status(201).json({
       success: true,
       message: 'Skill added to employee successfully'
     });

--- a/backend/src/routes/onCall.ts
+++ b/backend/src/routes/onCall.ts
@@ -95,7 +95,7 @@ export const createOnCallRouter = (pool: Pool): Router => {
         req.user!.id,
         req.body?.notes ?? null
       );
-      res.json({ success: true, data });
+      res.status(201).json({ success: true, data });
     } catch (err) {
       const msg = (err as Error).message;
       const status = msg.includes('not found') ? 404 : msg.includes('max capacity') ? 409 : 400;

--- a/backend/src/services/ApprovalEngineService.ts
+++ b/backend/src/services/ApprovalEngineService.ts
@@ -42,12 +42,43 @@ export class ApprovalEngineService {
   // --------------------------------------------------------------------------
 
   async listWorkflows(): Promise<ApprovalWorkflow[]> {
-    const [wRows] = await this.pool.execute<RowDataPacket[]>(
-      `SELECT id, change_type, require_all, description, created_at, updated_at
-         FROM approval_workflows ORDER BY change_type ASC`
+    const [rows] = await this.pool.execute<RowDataPacket[]>(
+      `SELECT
+         w.id, w.change_type, w.require_all, w.description, w.created_at, w.updated_at,
+         s.id AS step_id, s.workflow_id AS step_workflow_id, s.step_order,
+         s.approver_scope, s.approver_role_id, s.approver_user_id,
+         s.auto_approve_for_owner, s.escalate_after_hours
+       FROM approval_workflows w
+       LEFT JOIN approval_steps s ON s.workflow_id = w.id
+       ORDER BY w.change_type ASC, s.step_order ASC`
     );
-    const workflows = await Promise.all(wRows.map((w: any) => this.hydrateWorkflow(w)));
-    return workflows;
+    const workflowMap = new Map<number, ApprovalWorkflow>();
+    for (const row of rows as any[]) {
+      if (!workflowMap.has(row.id)) {
+        workflowMap.set(row.id, {
+          id: row.id,
+          changeType: row.change_type,
+          requireAll: Boolean(row.require_all),
+          description: row.description ?? null,
+          steps: [],
+          createdAt: row.created_at,
+          updatedAt: row.updated_at,
+        });
+      }
+      if (row.step_id !== null) {
+        workflowMap.get(row.id)!.steps.push({
+          id: row.step_id,
+          workflowId: row.step_workflow_id,
+          stepOrder: row.step_order,
+          approverScope: row.approver_scope as ApproverScope,
+          approverRoleId: row.approver_role_id ?? null,
+          approverUserId: row.approver_user_id ?? null,
+          autoApproveForOwner: Boolean(row.auto_approve_for_owner),
+          escalateAfterHours: row.escalate_after_hours ?? null,
+        });
+      }
+    }
+    return Array.from(workflowMap.values());
   }
 
   async getWorkflowByChangeType(changeType: string): Promise<ApprovalWorkflow | null> {

--- a/backend/src/services/ScheduleOptimizationOrchestrator.ts
+++ b/backend/src/services/ScheduleOptimizationOrchestrator.ts
@@ -128,14 +128,41 @@ export class ScheduleOptimizationOrchestrator {
   async getSchedulesByUser(userId: number): Promise<Schedule[]> {
     try {
       const [rows] = await this.pool.execute<RowDataPacket[]>(
-        `SELECT DISTINCT s.id FROM schedules s
-        JOIN shifts sh ON s.id = sh.schedule_id
-        JOIN shift_assignments sa ON sh.id = sa.shift_id
-        WHERE sa.user_id = ?`,
+        `SELECT
+          s.id, s.name, s.department_id, s.start_date, s.end_date,
+          s.status, s.published_at, s.notes, s.created_at, s.updated_at,
+          d.name as department_name,
+          COUNT(DISTINCT sh2.id) as total_shifts,
+          COUNT(DISTINCT sa2.id) as total_assignments
+        FROM schedules s
+        LEFT JOIN departments d ON s.department_id = d.id
+        LEFT JOIN shifts sh2 ON s.id = sh2.schedule_id
+        LEFT JOIN shift_assignments sa2 ON sh2.id = sa2.shift_id AND sa2.status IN ('pending', 'confirmed')
+        WHERE s.id IN (
+          SELECT DISTINCT sh.schedule_id
+          FROM shifts sh
+          JOIN shift_assignments sa ON sh.id = sa.shift_id
+          WHERE sa.user_id = ?
+        )
+        GROUP BY s.id
+        ORDER BY s.start_date DESC`,
         [userId]
       );
-      const schedules = await Promise.all(rows.map((row: any) => this.fetchScheduleById(row.id)));
-      return schedules.filter((s): s is Schedule => s !== null);
+      return rows.map((row: any) => ({
+        id: row.id,
+        name: row.name,
+        departmentId: row.department_id,
+        departmentName: row.department_name,
+        startDate: row.start_date,
+        endDate: row.end_date,
+        status: row.status,
+        publishedAt: row.published_at,
+        totalShifts: row.total_shifts || 0,
+        totalAssignments: row.total_assignments || 0,
+        notes: row.notes,
+        createdAt: row.created_at,
+        updatedAt: row.updated_at
+      }));
     } catch (error) {
       logger.error('Failed to get schedules by user:', error);
       throw error;


### PR DESCRIPTION
## Summary

- **N+1 query fix**: `ScheduleOptimizationOrchestrator.getSchedulesByUser()` previously issued one `SELECT` per schedule ID via `Promise.all(rows.map(...fetchScheduleById))`. Replaced with a single batched `JOIN` query using a correlated subquery.
- **N+1 query fix**: `ApprovalEngineService.listWorkflows()` previously called `hydrateWorkflow()` (a separate `SELECT` on `approval_steps`) for each workflow row. Replaced with a single `LEFT JOIN` across `approval_workflows` and `approval_steps`, assembling results in-process.
- **HTTP 201 on resource creation**: Three `POST` endpoints were returning `200` instead of `201`: `POST /employees/:id/skills`, `POST /departments/:id/users`, and `POST /on-call/periods/:id/assign`. All corrected to `201 Created`.
- **Tests updated** to match new status codes and single-query mock expectations (no behavior regression — all 1333 tests pass).

## Test plan

- [x] `npm run build` — TypeScript compiles cleanly
- [x] `npm run lint` — no lint errors
- [x] `npm run deadcode` — no unused exports
- [x] `npm test -- --runInBand --ci` — 1333/1333 tests pass