### PR TITLE
feat(scheduling): harden scheduling engine and document constraints

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -288,22 +288,79 @@ Users cannot assign roles that contain permissions they do not themselves hold (
 
 ## 6. Scheduling engine
 
-The optimizer is optional. Set `OPTIMIZATION_ENGINE=or-tools` in `backend/.env` to enable.
+Two engines are available: a TypeScript greedy solver (always active) and a
+Python OR-Tools CP-SAT solver (opt-in). The system degrades gracefully —
+when Python is unavailable, the greedy solver runs automatically.
+
+### Engine selection
+
+| `OPTIMIZATION_ENGINE` env value | Effect |
+|---|---|
+| `javascript` (default) | Greedy TypeScript solver only |
+| `or-tools` | CP-SAT Python solver; greedy fallback on any failure |
+
+To enable OR-Tools:
 
 ```bash
 cd backend
 pip3 install -r optimization-scripts/requirements.txt
 python3 optimization-scripts/schedule_optimizer.py --help
+# Then set OPTIMIZATION_ENGINE=or-tools in backend/.env
 ```
 
-### CP-SAT formulation
+### Greedy TypeScript solver (`ScheduleOptimizer.generateGreedySchedule`)
+
+Entry point: `backend/src/optimization/ScheduleOptimizerORTools.ts`  
+Called by: `AutoScheduleService.generate` → `ScheduleOptimizationOrchestrator.generateOptimizedSchedule`
+
+**Algorithm**: O(shifts × employees). Shifts are sorted earliest-first; for each shift the first employees that pass all constraints are selected up to `min_staff`.
+
+**Constraints enforced (in evaluation order inside `evaluateCandidate`)**:
+
+| # | Constraint | Source of truth |
+|---|---|---|
+| 1 | Staff cap | `shift.max_staff` — never exceeded |
+| 2 | No double-booking | Time-overlap check within the calendar day |
+| 3 | Declared unavailability | `user_unavailability` rows, expanded to per-day dates |
+| 4 | Skill requirements | `shift_skills` join; employee must hold every required skill |
+| 5 | Daily hours cap | `max(8, emp.max_hours_per_week / 5)` hours per employee per day |
+
+**How to add a new constraint**:
+
+1. Add any needed state tracking in `generateGreedySchedule` (e.g. a new `Map`).
+2. Add the check to `evaluateCandidate(emp, ctx)` — the method is pure; no DB calls allowed there.
+3. Update the state map after each successful assignment in `generateGreedySchedule`.
+4. Write a unit test in `backend/src/__tests__/scheduleOptimizer.test.ts` against `evaluateCandidate` directly (no DB needed).
+
+**Known limitations**:
+- No backtracking: a locally greedy choice can block a later shift from being staffed. The CP-SAT path solves this globally.
+- Weekly hours are not tracked across the full schedule period; only the per-day budget is enforced.
+- Employee ordering within the candidate list is deterministic (input order) but not optimized for fairness — workload balancing is a soft constraint in CP-SAT only.
+
+### Python CP-SAT solver (`schedule_optimizer.py`)
+
+Entry point: `backend/optimization-scripts/schedule_optimizer.py`  
+Bridge: `ScheduleOptimizer.optimize()` serializes the problem as JSON, spawns `python3` via `child_process.spawn`, and parses the JSON response from stdout.
+
+**Failure handling**:
+
+| Failure mode | Behaviour |
+|---|---|
+| `python3` not found (ENOENT) | `spawn` emits `error` → `optimize()` logs a warning and falls back to greedy |
+| Non-zero exit code | Rejected promise → `optimize()` logs a warning and falls back to greedy |
+| Timeout (`OPTIMIZATION_TIMEOUT` ms, default 300 000 ms) | SIGTERM → SIGKILL after 5 s → `optimize()` falls back to greedy |
+| Malformed JSON output | Parse error → `optimize()` falls back to greedy |
+
+The `optimize()` return status is `GREEDY_FALLBACK` when the Python solver was unavailable.
+
+**CP-SAT formulation**:
 
 - **Variables** — one boolean per `(employee, shift)` candidate assignment.
 - **Hard constraints** — coverage windows, no double-booking, declared availability, weekly hour caps, skill requirements.
-- **Soft constraints** — preferences, workload fairness, minimum rest, consecutive-day caps. Each has a configurable weight.
+- **Soft constraints** — preferences, workload fairness, minimum rest, consecutive-day caps. Each has a configurable weight (see `_getDefaultWeights()` in `ScheduleOptimizerORTools.ts`).
 - **Objective** — weighted sum to minimize.
 
-The Node bridge is `backend/src/optimization/ScheduleOptimizerORTools.ts`. It serializes input as JSON, spawns `schedule_optimizer.py` as a child process, and parses the JSON response. A pure-TypeScript fallback (`ScheduleOptimizer.ts`) is used when OR-Tools is not available.
+**Performance characteristics**: CP-SAT is branch-and-bound with propagation. Small problems (< 50 shifts, < 30 employees) typically solve in under 1 s. Large problems run until `timeLimitSeconds` (default 300 s for the Python call) then return the best feasible solution found.
 
 ---
 

--- a/backend/src/__tests__/scheduleOptimizer.test.ts
+++ b/backend/src/__tests__/scheduleOptimizer.test.ts
@@ -2,14 +2,19 @@
  * ScheduleOptimizer (OR-Tools wrapper + greedy fallback) tests.
  *
  * The Python path is mocked away — we only test the greedy fallback,
- * problem validation, and the helpers (_hasOverlappingShift,
- * _timesOverlap, _calculateShiftHours) via the public surface.
+ * evaluateCandidate(), problem validation, and the helpers
+ * (_hasOverlappingShift, _timesOverlap, _calculateShiftHours) via the
+ * public surface.
  */
 
 import { EventEmitter } from 'events';
 import { spawn } from 'child_process';
 import { config } from '../config';
-import { ScheduleOptimizer, OptimizationProblem } from '../optimization/ScheduleOptimizerORTools';
+import {
+  ScheduleOptimizer,
+  OptimizationProblem,
+  CandidateContext,
+} from '../optimization/ScheduleOptimizerORTools';
 
 jest.mock('child_process', () => ({
   spawn: jest.fn(),
@@ -141,6 +146,137 @@ describe('ScheduleOptimizer.generateGreedySchedule', () => {
   });
 });
 
+describe('ScheduleOptimizer — greedy constraint tests', () => {
+  it('does not assign more than max_staff employees to a shift', async () => {
+    const opt = new ScheduleOptimizer();
+    // Shift allows at most 2 employees but there are 4 available
+    const out = await opt.generateGreedySchedule(
+      buildProblem({
+        shifts: [buildShift({ id: 's1', min_staff: 4, max_staff: 2 })],
+        employees: [
+          buildEmployee({ id: 'e1' }),
+          buildEmployee({ id: 'e2' }),
+          buildEmployee({ id: 'e3' }),
+          buildEmployee({ id: 'e4' }),
+        ],
+      })
+    );
+    // max_staff=2 caps the assignments even though min_staff asks for 4
+    expect(out.length).toBeLessThanOrEqual(2);
+  });
+
+  it('blocks assignment when daily hours budget is exhausted', async () => {
+    const opt = new ScheduleOptimizer();
+    // Employee has max 8h/week => daily budget = max(8, 8/5=1.6) = 8h
+    // First shift is 8h; second shift on the same day would exceed budget
+    const out = await opt.generateGreedySchedule(
+      buildProblem({
+        shifts: [
+          buildShift({ id: 's1', date: '2026-05-01', start_time: '00:00', end_time: '08:00', min_staff: 1 }),
+          buildShift({ id: 's2', date: '2026-05-01', start_time: '10:00', end_time: '14:00', min_staff: 1 }),
+        ],
+        employees: [buildEmployee({ id: 'e1', max_hours_per_week: 8 })],
+      })
+    );
+    // Only the first shift should be assigned — daily budget exhausted after it
+    expect(out).toHaveLength(1);
+    expect(out[0].shiftId).toBe('s1');
+  });
+
+  it('respects min_staff requirement — assigns exactly min_staff when enough candidates', async () => {
+    const opt = new ScheduleOptimizer();
+    const out = await opt.generateGreedySchedule(
+      buildProblem({
+        shifts: [buildShift({ id: 's1', min_staff: 3, max_staff: 5 })],
+        employees: [
+          buildEmployee({ id: 'e1' }),
+          buildEmployee({ id: 'e2' }),
+          buildEmployee({ id: 'e3' }),
+          buildEmployee({ id: 'e4' }),
+          buildEmployee({ id: 'e5' }),
+        ],
+      })
+    );
+    expect(out).toHaveLength(3);
+  });
+
+  it('skips a fully-unavailable employee while assigning an available one', async () => {
+    const opt = new ScheduleOptimizer();
+    const out = await opt.generateGreedySchedule(
+      buildProblem({
+        shifts: [buildShift({ id: 's1', date: '2026-05-01', min_staff: 1 })],
+        employees: [
+          buildEmployee({ id: 'e1', unavailable_dates: ['2026-05-01'] }),
+          buildEmployee({ id: 'e2', unavailable_dates: [] }),
+        ],
+      })
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0].employeeId).toBe('e2');
+  });
+
+  it('requires all skills — rejects employee missing any one required skill', async () => {
+    const opt = new ScheduleOptimizer();
+    const out = await opt.generateGreedySchedule(
+      buildProblem({
+        shifts: [
+          buildShift({ id: 's1', min_staff: 1, required_skills: ['Triage', 'CPR'] }),
+        ],
+        employees: [
+          buildEmployee({ id: 'e1', skills: ['Triage'] }),           // missing CPR
+          buildEmployee({ id: 'e2', skills: ['CPR'] }),              // missing Triage
+          buildEmployee({ id: 'e3', skills: ['Triage', 'CPR'] }),   // qualifies
+        ],
+      })
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0].employeeId).toBe('e3');
+  });
+});
+
+describe('ScheduleOptimizer.evaluateCandidate (pure unit tests)', () => {
+  const buildCtx = (overrides: Partial<CandidateContext> = {}): CandidateContext => ({
+    shift: buildShift({ id: 's1', max_staff: 5 }) as any,
+    assignedShiftIds: new Set<string>(),
+    allShifts: [],
+    dailyHoursMap: new Map<string, number>(),
+    currentShiftAssignmentCount: 0,
+    ...overrides,
+  });
+
+  it('returns true for a clean, unconstrained candidate', () => {
+    const opt = new ScheduleOptimizer();
+    expect(opt.evaluateCandidate(buildEmployee() as any, buildCtx())).toBe(true);
+  });
+
+  it('returns false when max_staff is already reached', () => {
+    const opt = new ScheduleOptimizer();
+    const ctx = buildCtx({
+      shift: buildShift({ id: 's1', max_staff: 2 }) as any,
+      currentShiftAssignmentCount: 2,
+    });
+    expect(opt.evaluateCandidate(buildEmployee() as any, ctx)).toBe(false);
+  });
+
+  it('returns false when employee is marked unavailable on that date', () => {
+    const opt = new ScheduleOptimizer();
+    const emp = buildEmployee({ unavailable_dates: ['2026-05-01'] }) as any;
+    expect(opt.evaluateCandidate(emp, buildCtx())).toBe(false);
+  });
+
+  it('returns false when daily hours budget would be exceeded', () => {
+    const opt = new ScheduleOptimizer();
+    // budget = max(8, 16/5=3.2) = 8h; shift is 8h; already has 1h today → total 9h > 8h
+    const emp = buildEmployee({ id: 'e1', max_hours_per_week: 16 }) as any;
+    const dailyHoursMap = new Map([['e1|2026-05-01', 1]]);
+    const ctx = buildCtx({
+      shift: buildShift({ id: 's1', start_time: '08:00', end_time: '16:00' }) as any,
+      dailyHoursMap,
+    });
+    expect(opt.evaluateCandidate(emp, ctx)).toBe(false);
+  });
+});
+
 describe('ScheduleOptimizer.optimize falls back to greedy when Python is unavailable', () => {
   it('returns assignments via the fallback path', async () => {
     const opt = new ScheduleOptimizer();
@@ -154,6 +290,26 @@ describe('ScheduleOptimizer.optimize falls back to greedy when Python is unavail
       })
     );
     expect(result).toHaveLength(1);
+  });
+
+  it('optimize() returns GREEDY_FALLBACK status when Python process fails', async () => {
+    // Simulate python3 not found by making spawn emit an error event
+    const proc = buildHangingProcess();
+    mockedSpawn.mockReturnValue(proc);
+
+    const opt = new ScheduleOptimizer();
+    const problem = buildProblem({
+      shifts: [buildShift({ id: 's1', min_staff: 1 })],
+      employees: [buildEmployee({ id: 'e1' })],
+    });
+
+    // Start the optimize call, then immediately emit ENOENT to simulate missing python3
+    const resultPromise = opt.optimize(problem);
+    proc.emit('error', Object.assign(new Error('spawn python3 ENOENT'), { code: 'ENOENT' }));
+
+    const result = await resultPromise;
+    expect(result.status).toBe('GREEDY_FALLBACK');
+    expect(result.assignments.length).toBeGreaterThanOrEqual(1);
   });
 });
 

--- a/backend/src/optimization/ScheduleOptimizerORTools.ts
+++ b/backend/src/optimization/ScheduleOptimizerORTools.ts
@@ -1,15 +1,33 @@
 /**
  * Staff Schedule Optimization Engine - OR-Tools Integration
- * 
- * Wrapper for Python OR-Tools CP-SAT solver.
- * Uses Google OR-Tools constraint programming inspired by PoliTO Timetable Allocator.
- * 
+ *
+ * Wrapper for Python OR-Tools CP-SAT solver with a TypeScript greedy fallback.
+ *
  * Architecture:
  * - TypeScript prepares problem data (shifts, employees, preferences, constraints)
  * - Calls Python script with OR-Tools CP-SAT solver via child_process
  * - Python script returns optimal/feasible solution
- * - TypeScript processes and stores results in database
- * 
+ * - On Python failure (not installed, timeout, non-zero exit), optimize() falls
+ *   back to the TypeScript greedy solver automatically
+ *
+ * Greedy algorithm complexity: O(shifts × employees) per run.
+ *
+ * Constraints enforced by the greedy fallback (in priority order):
+ *   1. Skill requirements — employee must hold every skill the shift demands
+ *   2. Declared unavailability — date-level blocks from user_unavailability
+ *   3. No double-booking — time-overlap detection within a calendar day
+ *   4. Daily hours cap — total hours already assigned on that date must not
+ *      exceed the employee's daily budget (max_hours_per_week / 5)
+ *   5. Staff cap — assignments per shift are capped at max_staff
+ *
+ * To add a new constraint:
+ *   1. Add any needed state tracking in generateGreedySchedule (e.g. a new Map).
+ *   2. Add the check inside evaluateCandidate() so it is unit-testable without
+ *      touching the database.
+ *   3. Update the tracking map after each successful assignment in
+ *      generateGreedySchedule.
+ *   4. Write a unit test in scheduleOptimizer.test.ts.
+ *
  * @author Luca Ostinelli
  * @inspiration PoliTO_Timetable_Allocator constraint programming with docplex
  */
@@ -30,19 +48,19 @@ interface ScheduleAssignment {
 
 interface OptimizationConfig {
   timeLimitSeconds?: number;
-  
+
   // Constraint weights (inspired by PoliTO Parameters.py)
   weights?: {
-    shiftCoverage?: number;           // Default: 100
-    noDoubleBooking?: number;         // Default: 90
-    skillRequirements?: number;       // Default: 85
-    availability?: number;            // Default: 80
-    maxHoursPerWeek?: number;         // Default: 75
-    employeePreferences?: number;     // Default: 55 (like teaching_overlaps_penalty)
-    workloadFairness?: number;        // Default: 40
-    consecutiveDays?: number;         // Default: 30
-    restPeriods?: number;             // Default: 25
-    shiftContinuity?: number;         // Default: 20
+    shiftCoverage?: number;       // Default: 100
+    noDoubleBooking?: number;     // Default: 90
+    skillRequirements?: number;   // Default: 85
+    availability?: number;        // Default: 80
+    maxHoursPerWeek?: number;     // Default: 75
+    employeePreferences?: number; // Default: 55 (like teaching_overlaps_penalty)
+    workloadFairness?: number;    // Default: 40
+    consecutiveDays?: number;     // Default: 30
+    restPeriods?: number;         // Default: 25
+    shiftContinuity?: number;     // Default: 20
   };
 }
 
@@ -81,7 +99,7 @@ export interface OptimizationProblem {
 }
 
 interface OptimizationResult {
-  status: 'OPTIMAL' | 'FEASIBLE' | 'INFEASIBLE' | 'ERROR';
+  status: 'OPTIMAL' | 'FEASIBLE' | 'INFEASIBLE' | 'ERROR' | 'GREEDY_FALLBACK';
   objectiveValue?: number;
   solveTimeSeconds: number;
   assignments: ScheduleAssignment[];
@@ -99,78 +117,126 @@ interface OptimizationResult {
   error?: string;
 }
 
+/**
+ * Context passed to evaluateCandidate so the check is pure (no DB access).
+ * Add new tracking fields here when introducing new greedy constraints.
+ */
+export interface CandidateContext {
+  /** Shift being evaluated. */
+  shift: Shift;
+  /** IDs of shifts already assigned to this employee. */
+  assignedShiftIds: Set<string>;
+  /** All shifts in the problem (needed for overlap detection). */
+  allShifts: Shift[];
+  /** Hours already scheduled per employee per date key "empId|date". */
+  dailyHoursMap: Map<string, number>;
+  /** Assignments already committed to this shift (for max_staff check). */
+  currentShiftAssignmentCount: number;
+}
+
 export class ScheduleOptimizer {
   private pythonScriptPath: string;
-  
+
   constructor() {
     // Path to Python optimizer script
     this.pythonScriptPath = join(__dirname, '../../optimization-scripts/schedule_optimizer.py');
   }
-  
+
   /**
    * Optimize schedule using OR-Tools CP-SAT solver.
-   * 
+   *
+   * Falls back to the greedy TypeScript solver when Python is unavailable,
+   * the process times out, or the process exits with a non-zero code.
+   *
    * @param problem - Problem data with shifts, employees, preferences
-   * @param config - Optimization configuration
+   * @param optimizationConfig - Optimization configuration
    * @returns Promise with optimization result
    */
   async optimize(
     problem: OptimizationProblem,
-    config: OptimizationConfig = {}
+    optimizationConfig: OptimizationConfig = {}
   ): Promise<OptimizationResult> {
     logger.info('Starting schedule optimization with OR-Tools CP-SAT');
     logger.info(`Problem size: ${problem.shifts.length} shifts, ${problem.employees.length} employees`);
-    
+
     const startTime = Date.now();
-    
+
     try {
       // Validate input
       this._validateProblem(problem);
-      
+
       // Prepare problem data with config
       const problemData = {
         ...problem,
-        weights: config.weights || this._getDefaultWeights()
+        weights: optimizationConfig.weights || this._getDefaultWeights(),
       };
-      
+
       // Call Python optimizer
       const result = await this._callPythonOptimizer(
         problemData,
-        config.timeLimitSeconds || 300
+        optimizationConfig.timeLimitSeconds || 300
       );
-      
+
       const elapsedTime = (Date.now() - startTime) / 1000;
-      
+
       logger.info(`Optimization completed in ${elapsedTime.toFixed(2)}s`);
       logger.info(`Status: ${result.status}, Assignments: ${result.assignments.length}`);
-      
+
       if (result.statistics.coverageStats) {
         logger.info(`Coverage: ${result.statistics.coverageStats.coveragePercentage.toFixed(1)}%`);
       }
-      
+
       return result;
-      
     } catch (error) {
-      logger.error('Optimization error:', error);
-      
-      return {
-        status: 'ERROR',
-        solveTimeSeconds: (Date.now() - startTime) / 1000,
-        assignments: [],
-        statistics: {
-          isOptimal: false,
-          totalAssignedShifts: 0,
-          coverageStats: {
-            totalShifts: problem.shifts.length,
-            fullyCoveredShifts: 0,
-            coveragePercentage: 0
-          }
-        },
-        error: error instanceof Error ? error.message : 'Unknown error'
-      };
+      // Python not installed, process timed out, or non-zero exit — fall back
+      // to the TypeScript greedy solver so callers always get a usable result.
+      const reason = error instanceof Error ? error.message : 'Unknown error';
+      logger.warn(`Python optimizer unavailable (${reason}); falling back to greedy solver`);
+
+      try {
+        const greedy = await this.generateGreedySchedule(problem);
+        const elapsedTime = (Date.now() - startTime) / 1000;
+        const totalShifts = problem.shifts.length;
+        const covered = problem.shifts.filter(
+          (s) => greedy.filter((a) => a.shiftId === s.id).length >= s.min_staff
+        ).length;
+
+        return {
+          status: 'GREEDY_FALLBACK',
+          solveTimeSeconds: elapsedTime,
+          assignments: greedy,
+          statistics: {
+            isOptimal: false,
+            totalAssignedShifts: greedy.length,
+            coverageStats: {
+              totalShifts,
+              fullyCoveredShifts: covered,
+              coveragePercentage: totalShifts > 0 ? Math.round((covered / totalShifts) * 100) : 0,
+            },
+          },
+          error: reason,
+        };
+      } catch (greedyError) {
+        logger.error('Greedy fallback also failed:', greedyError);
+        return {
+          status: 'ERROR',
+          solveTimeSeconds: (Date.now() - startTime) / 1000,
+          assignments: [],
+          statistics: {
+            isOptimal: false,
+            totalAssignedShifts: 0,
+            coverageStats: {
+              totalShifts: problem.shifts.length,
+              fullyCoveredShifts: 0,
+              coveragePercentage: 0,
+            },
+          },
+          error: greedyError instanceof Error ? greedyError.message : 'Unknown error',
+        };
+      }
     }
   }
-  
+
   /**
    * Call Python optimizer script via child_process.
    */
@@ -185,7 +251,7 @@ export class ScheduleOptimizer {
         '--stdin',
         '--stdout',
         '--time-limit',
-        timeLimitSeconds.toString()
+        timeLimitSeconds.toString(),
       ]);
 
       let stdoutData = '';
@@ -247,19 +313,23 @@ export class ScheduleOptimizer {
             try {
               const result = JSON.parse(stdoutData);
               resolve(result);
-            } catch (error) {
-              reject(new Error(`Failed to parse optimizer output: ${error instanceof Error ? error.message : 'Unknown error'}`));
+            } catch (parseError) {
+              reject(
+                new Error(
+                  `Failed to parse optimizer output: ${parseError instanceof Error ? parseError.message : 'Unknown error'}`
+                )
+              );
             }
           } else {
-            // Error
+            // Non-zero exit — treat as hard error so optimize() can fall back
             reject(new Error(`Optimizer failed with code ${code}: ${stderrData}`));
           }
         });
       });
 
-      // Handle process errors
-      pythonProcess.on('error', (error) => {
-        finalize(() => reject(new Error(`Failed to start Python optimizer: ${error.message}`)));
+      // Handle process errors (e.g. python3 not found / ENOENT)
+      pythonProcess.on('error', (err) => {
+        finalize(() => reject(new Error(`Failed to start Python optimizer: ${err.message}`)));
       });
 
       // Send problem data to stdin
@@ -267,7 +337,7 @@ export class ScheduleOptimizer {
       pythonProcess.stdin.end();
     });
   }
-  
+
   /**
    * Validate problem data before optimization.
    */
@@ -275,18 +345,18 @@ export class ScheduleOptimizer {
     if (!problem.shifts || problem.shifts.length === 0) {
       throw new Error('No shifts provided for optimization');
     }
-    
+
     if (!problem.employees || problem.employees.length === 0) {
       throw new Error('No employees provided for optimization');
     }
-    
+
     // Validate shifts
     for (const shift of problem.shifts) {
       if (!shift.id || !shift.date || !shift.start_time || !shift.end_time) {
         throw new Error(`Invalid shift data: ${JSON.stringify(shift)}`);
       }
     }
-    
+
     // Validate employees
     for (const employee of problem.employees) {
       if (!employee.id) {
@@ -294,7 +364,7 @@ export class ScheduleOptimizer {
       }
     }
   }
-  
+
   /**
    * Get default constraint weights (inspired by PoliTO Parameters.py).
    */
@@ -305,120 +375,189 @@ export class ScheduleOptimizer {
       skill_requirements: 85,
       availability: 80,
       max_hours_per_week: 75,
-      employee_preferences: 55,  // Similar to teaching_overlaps_penalty in PoliTO
+      employee_preferences: 55, // Similar to teaching_overlaps_penalty in PoliTO
       workload_fairness: 40,
       consecutive_days: 30,
       rest_periods: 25,
-      shift_continuity: 20
+      shift_continuity: 20,
     };
   }
-  
+
   /**
-   * Generate a simple greedy schedule (fallback if optimizer fails).
-   * Assigns employees to shifts based on availability and skills.
+   * Evaluate whether an employee is a valid candidate for a shift.
+   *
+   * This is a pure function — it receives all required context as arguments
+   * so it can be unit-tested without any database interaction. Add new
+   * constraint checks here (see module-level comment for the full recipe).
+   *
+   * @param emp     - Employee being evaluated
+   * @param ctx     - Immutable snapshot of current scheduling state
+   * @returns true if the employee can be assigned to ctx.shift
+   */
+  evaluateCandidate(emp: Employee, ctx: CandidateContext): boolean {
+    const { shift, assignedShiftIds, allShifts, dailyHoursMap, currentShiftAssignmentCount } = ctx;
+
+    // 1. Staff cap — never exceed max_staff for this shift
+    if (shift.max_staff !== undefined && currentShiftAssignmentCount >= shift.max_staff) {
+      return false;
+    }
+
+    // 2. No double-booking — reject if already on an overlapping shift today
+    if (this._hasOverlappingShift(shift, assignedShiftIds, allShifts)) {
+      return false;
+    }
+
+    // 3. Declared unavailability
+    if (emp.unavailable_dates.includes(shift.date)) {
+      return false;
+    }
+
+    // 4. Skill requirements
+    const requiredSkills = shift.required_skills || [];
+    const empSkills = new Set(emp.skills);
+    for (const skill of requiredSkills) {
+      if (!empSkills.has(skill)) {
+        return false;
+      }
+    }
+
+    // 5. Daily hours cap — guard against assigning more hours than a single
+    //    workday budget (max_hours_per_week / 5, floored at 8h).
+    const dailyBudget = Math.max(8, emp.max_hours_per_week / 5);
+    const shiftHours = this._calculateShiftHours(shift);
+    const dailyKey = `${emp.id}|${shift.date}`;
+    const hoursAlreadyToday = dailyHoursMap.get(dailyKey) ?? 0;
+    if (hoursAlreadyToday + shiftHours > dailyBudget) {
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Generate a greedy schedule.
+   *
+   * Used directly by AutoScheduleService when OPTIMIZATION_ENGINE is not
+   * 'or-tools', and as the automatic fallback inside optimize() when Python
+   * is unavailable.
+   *
+   * Algorithm: O(shifts × employees). For each shift (earliest-first), pick
+   * the first employees that pass evaluateCandidate(), up to min_staff. This
+   * is deterministic and reproducible given the same input ordering.
+   *
+   * Known limitations:
+   * - No backtracking — a locally greedy choice may block a later shift from
+   *   being staffed. The CP-SAT path handles this globally.
+   * - Weekly hours are not tracked across the full schedule period; only the
+   *   per-day budget is enforced here.
    */
   async generateGreedySchedule(problem: OptimizationProblem): Promise<ScheduleAssignment[]> {
     logger.info('Generating greedy schedule as fallback');
-    
+
     const assignments: ScheduleAssignment[] = [];
-    
-    // Sort shifts by date and time
+
+    // Sort shifts by date and time so earlier shifts are filled first
     const sortedShifts = [...problem.shifts].sort((a, b) => {
       if (a.date !== b.date) return a.date.localeCompare(b.date);
       return a.start_time.localeCompare(b.start_time);
     });
-    
-    // Track employee assignments
+
+    // Track which shift IDs each employee has been assigned to (for overlap detection)
     const employeeAssignments = new Map<string, Set<string>>();
-    problem.employees.forEach(emp => employeeAssignments.set(emp.id, new Set()));
-    
+    problem.employees.forEach((emp) => employeeAssignments.set(emp.id, new Set()));
+
+    // Track hours already assigned per employee per date ("empId|date" -> hours)
+    const dailyHoursMap = new Map<string, number>();
+
     // Assign employees to shifts greedily
     for (const shift of sortedShifts) {
-      const requiredSkills = new Set(shift.required_skills || []);
+      // Candidate filtering: exclude employees that violate any constraint
+      // independent of assignment order (unavailability, skills, overlap,
+      // daily budget). The max_staff check is enforced per-assignment below.
+      const candidates = problem.employees.filter((emp) =>
+        this.evaluateCandidate(emp, {
+          shift,
+          assignedShiftIds: employeeAssignments.get(emp.id)!,
+          allShifts: sortedShifts,
+          dailyHoursMap,
+          // Pass 0 here — max_staff is re-enforced in the assignment loop below
+          // so we collect all eligible candidates first.
+          currentShiftAssignmentCount: 0,
+        })
+      );
 
-      // Find available employees with required skills
-      const candidates = problem.employees.filter(emp => {
-        // Check if already assigned to overlapping shift
-        const empShifts = employeeAssignments.get(emp.id)!;
-        if (this._hasOverlappingShift(shift, empShifts, sortedShifts)) {
-          return false;
-        }
-        
-        // Check availability
-        if (emp.unavailable_dates.includes(shift.date)) {
-          return false;
-        }
-        
-        // Check skills
-        const empSkills = new Set(emp.skills);
-        for (const skill of requiredSkills) {
-          if (!empSkills.has(skill)) return false;
-        }
-        
-        return true;
-      });
-      
-      // Assign up to min_staff employees
-      const toAssign = Math.min(candidates.length, shift.min_staff);
+      // Assign up to min_staff employees, never exceeding max_staff
+      const staffCap = shift.max_staff !== undefined ? shift.max_staff : shift.min_staff;
+      const toAssign = Math.min(candidates.length, shift.min_staff, staffCap);
       for (let i = 0; i < toAssign; i++) {
         const emp = candidates[i];
-        
+        const shiftHours = this._calculateShiftHours(shift);
+
         assignments.push({
           employeeId: emp.id,
           shiftId: shift.id,
           date: shift.date,
           startTime: shift.start_time,
           endTime: shift.end_time,
-          hours: this._calculateShiftHours(shift)
+          hours: shiftHours,
         });
-        
+
+        // Update tracking state
         employeeAssignments.get(emp.id)!.add(shift.id);
+        const dailyKey = `${emp.id}|${shift.date}`;
+        dailyHoursMap.set(dailyKey, (dailyHoursMap.get(dailyKey) ?? 0) + shiftHours);
       }
     }
-    
+
     logger.info(`Greedy schedule generated: ${assignments.length} assignments`);
     return assignments;
   }
-  
+
   private _hasOverlappingShift(
     shift: Shift,
     assignedShiftIds: Set<string>,
     allShifts: Shift[]
   ): boolean {
     for (const shiftId of assignedShiftIds) {
-      const assignedShift = allShifts.find(s => s.id === shiftId);
+      const assignedShift = allShifts.find((s) => s.id === shiftId);
       if (assignedShift && assignedShift.date === shift.date) {
         // Check time overlap
-        if (this._timesOverlap(shift.start_time, shift.end_time, assignedShift.start_time, assignedShift.end_time)) {
+        if (
+          this._timesOverlap(
+            shift.start_time,
+            shift.end_time,
+            assignedShift.start_time,
+            assignedShift.end_time
+          )
+        ) {
           return true;
         }
       }
     }
     return false;
   }
-  
+
   private _timesOverlap(start1: string, end1: string, start2: string, end2: string): boolean {
     const s1 = this._timeToMinutes(start1);
     const e1 = this._timeToMinutes(end1);
     const s2 = this._timeToMinutes(start2);
     const e2 = this._timeToMinutes(end2);
-    
+
     return !(e1 <= s2 || e2 <= s1);
   }
-  
+
   private _timeToMinutes(time: string): number {
     const [hours, minutes] = time.split(':').map(Number);
     return hours * 60 + minutes;
   }
-  
+
   private _calculateShiftHours(shift: Shift): number {
     const start = this._timeToMinutes(shift.start_time);
     let end = this._timeToMinutes(shift.end_time);
-    
+
     // Handle overnight shifts
     if (end < start) end += 24 * 60;
-    
-    return Math.round((end - start) / 60 * 10) / 10; // Round to 1 decimal
+
+    return Math.round(((end - start) / 60) * 10) / 10; // Round to 1 decimal
   }
 }
-


### PR DESCRIPTION
## Summary

- **Python fallback**: `optimize()` now catches all Python failure modes (ENOENT, timeout, non-zero exit, JSON parse error) and automatically falls back to the TypeScript greedy solver, returning `GREEDY_FALLBACK` status instead of `ERROR`.
- **`evaluateCandidate` extraction**: Constraint evaluation logic is now in a pure, exported method `evaluateCandidate(emp, ctx)` that takes all state as parameters — no DB access, directly unit-testable.
- **`max_staff` cap**: The greedy loop now caps assignments at `min(min_staff, max_staff)` per shift.
- **Daily hours budget**: A new constraint blocks a second shift assignment when the employee's hours on that calendar day already equal or exceed `max(8, max_hours_per_week / 5)`.
- **10 new unit tests** covering: max_staff cap, daily-hours budget exhaustion, min_staff exact fill, unavailability skip, multi-skill enforcement, `evaluateCandidate` direct tests, and `optimize()` falling back to greedy on Python ENOENT.
- **DOCUMENTATION.md section 6** fully rewritten with engine selection table, constraint list, failure-handling table, how-to-add-a-constraint recipe, and performance characteristics.

## Test plan

- [x] `npm run build` — no TypeScript errors
- [x] `npm run lint` — no lint errors
- [x] `npm test -- --runInBand --ci` — 1343 tests pass across 82 suites
- [x] New tests cover all four Priority 1 items from the task specification
- [x] No AI attribution in commit history