### PR TITLE
refactor(frontend): replace window.confirm with ConfirmModal in Employees page

### DIFF
--- a/frontend/src/pages/Employees/Employees.test.tsx
+++ b/frontend/src/pages/Employees/Employees.test.tsx
@@ -25,7 +25,6 @@ const ok = <T,>(data: T) => Promise.resolve({ success: true as const, data });
 
 describe('<Employees />', () => {
   beforeEach(() => {
-    jest.spyOn(window, 'confirm').mockReturnValue(true);
     jest.spyOn(window, 'alert').mockImplementation(() => undefined);
 
     mockGetEmployees.mockResolvedValue(
@@ -116,10 +115,13 @@ describe('<Employees />', () => {
     await userEvent.click(screen.getByRole('button', { name: /create employee/i }));
     expect(mockCreateEmployee).toHaveBeenCalled();
 
-    // Delete flow (delete the currently visible row)
+    // Delete flow: click delete button, confirm via modal
     const delBtn = within(adaRow as HTMLElement).getByTitle(/delete employee/i);
     await userEvent.click(delBtn);
-    expect(window.confirm).toHaveBeenCalled();
+    // ConfirmModal should now be visible
+    const confirmModal = await screen.findByRole('dialog');
+    expect(confirmModal).toBeInTheDocument();
+    await userEvent.click(within(confirmModal).getByRole('button', { name: /^delete$/i }));
     expect(mockDeleteEmployee).toHaveBeenCalled();
   });
 

--- a/frontend/src/pages/Employees/Employees.tsx
+++ b/frontend/src/pages/Employees/Employees.tsx
@@ -19,6 +19,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { Employee } from '../../types';
 import * as employeeService from '../../services/employeeService';
+import ConfirmModal from '../../components/ConfirmModal';
 
 
 /**
@@ -33,6 +34,7 @@ const Employees: React.FC = () => {
   const [selectedDepartment, setSelectedDepartment] = useState('');
   const [showAddModal, setShowAddModal] = useState(false);
   const [editingEmployee, setEditingEmployee] = useState<Employee | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState<{ open: boolean; employeeId: number | string | null }>({ open: false, employeeId: null });
 
   const loadEmployees = useCallback(async () => {
     try {
@@ -63,11 +65,14 @@ const Employees: React.FC = () => {
     loadEmployees();
   }, [loadEmployees]);
 
-  const handleDeleteEmployee = async (id: number | string) => {
-    if (!window.confirm('Are you sure you want to delete this employee?')) {
-      return;
-    }
+  const handleDeleteEmployee = (id: number | string) => {
+    setConfirmDelete({ open: true, employeeId: id });
+  };
 
+  const executeDelete = async () => {
+    if (confirmDelete.employeeId === null) return;
+    const id = confirmDelete.employeeId;
+    setConfirmDelete({ open: false, employeeId: null });
     try {
       await employeeService.deleteEmployee(id);
       await loadEmployees(); // Reload the list
@@ -279,6 +284,15 @@ const Employees: React.FC = () => {
           )}
         </div>
       </div>
+
+      <ConfirmModal
+        show={confirmDelete.open}
+        title="Delete Employee"
+        message="Are you sure you want to delete this employee?"
+        confirmLabel="Delete"
+        onConfirm={executeDelete}
+        onCancel={() => setConfirmDelete({ open: false, employeeId: null })}
+      />
 
       {/* Add/Edit Modal Placeholder */}
       {(showAddModal || editingEmployee) && (


### PR DESCRIPTION
## Summary
- Replaces the native `window.confirm` dialog on employee delete with the shared `ConfirmModal` component
- Adds `confirmDelete` state (`{ open, employeeId }`) and splits the delete handler into a modal opener (`handleDeleteEmployee`) and an async executor (`executeDelete`) that closes the modal before awaiting the network call
- Widens `employeeId` state type to `number | string | null` to match the `Employee.id: ID` (`number | string`) type, removing the need for any type casts

## Test plan
- [ ] `Employees.test.tsx` — removed `window.confirm` mock; delete flow now clicks the Delete button inside the rendered `ConfirmModal`
- [ ] All 103 frontend tests pass (`npm test -- --watchAll=false --ci`)
- [ ] `npm run lint` exits clean
- [ ] `npx tsc --noEmit` reports no new errors (pre-existing casing errors in other files are unrelated)