### PR TITLE
fix(security): redact setting value from log, batch delegation perms, add composite indexes

### DIFF
--- a/backend/database/init.sql
+++ b/backend/database/init.sql
@@ -112,6 +112,7 @@ CREATE TABLE IF NOT EXISTS user_roles (
     INDEX idx_user (user_id),
     INDEX idx_role (role_id),
     INDEX idx_scope (scope_org_unit_id),
+    INDEX idx_user_roles_user_expires (user_id, expires_at),
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
     FOREIGN KEY (role_id) REFERENCES roles(id) ON DELETE CASCADE
     -- scope_org_unit_id intentionally has no FK: org_units is created later in
@@ -322,7 +323,8 @@ CREATE TABLE IF NOT EXISTS shift_assignments (
     INDEX idx_shift (shift_id),
     INDEX idx_user (user_id),
     INDEX idx_status (status),
-    
+    INDEX idx_assignment_user_status (user_id, status),
+
     FOREIGN KEY (shift_id) REFERENCES shifts(id) ON DELETE CASCADE,
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
     FOREIGN KEY (assigned_by) REFERENCES users(id) ON DELETE SET NULL
@@ -635,6 +637,7 @@ CREATE TABLE IF NOT EXISTS user_org_units (
     UNIQUE KEY unique_user_org_unit (user_id, org_unit_id),
     INDEX idx_user (user_id),
     INDEX idx_org_unit (org_unit_id),
+    INDEX idx_user_org_primary (user_id, is_primary),
 
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
     FOREIGN KEY (org_unit_id) REFERENCES org_units(id) ON DELETE CASCADE
@@ -999,12 +1002,8 @@ ALTER TABLE departments
 -- END OF SCHEMA
 -- ================================================================
 
--- Performance indexes added for auth hot paths and assignment queries.
--- Use DROP + CREATE to remain idempotent on older MySQL 8.0 versions that
--- do not support CREATE INDEX IF NOT EXISTS.
-DROP INDEX IF EXISTS idx_user_roles_user_expires   ON user_roles;
-CREATE INDEX idx_user_roles_user_expires            ON user_roles(user_id, expires_at);
-DROP INDEX IF EXISTS idx_user_org_primary           ON user_org_units;
-CREATE INDEX idx_user_org_primary                   ON user_org_units(user_id, is_primary);
-DROP INDEX IF EXISTS idx_assignment_user_status     ON shift_assignments;
-CREATE INDEX idx_assignment_user_status             ON shift_assignments(user_id, status);
+-- Composite indexes for auth hot paths and assignment queries are defined
+-- inline inside their respective CREATE TABLE IF NOT EXISTS statements above:
+--   user_roles:        idx_user_roles_user_expires  (user_id, expires_at)
+--   user_org_units:    idx_user_org_primary         (user_id, is_primary)
+--   shift_assignments: idx_assignment_user_status   (user_id, status)

--- a/backend/database/init.sql
+++ b/backend/database/init.sql
@@ -999,7 +999,12 @@ ALTER TABLE departments
 -- END OF SCHEMA
 -- ================================================================
 
--- Performance indexes added for auth hot paths and assignment queries
-CREATE INDEX IF NOT EXISTS idx_user_roles_user_expires   ON user_roles(user_id, expires_at);
-CREATE INDEX IF NOT EXISTS idx_user_org_primary          ON user_org_units(user_id, is_primary);
-CREATE INDEX IF NOT EXISTS idx_assignment_user_status    ON shift_assignments(user_id, status);
+-- Performance indexes added for auth hot paths and assignment queries.
+-- Use DROP + CREATE to remain idempotent on older MySQL 8.0 versions that
+-- do not support CREATE INDEX IF NOT EXISTS.
+DROP INDEX IF EXISTS idx_user_roles_user_expires   ON user_roles;
+CREATE INDEX idx_user_roles_user_expires            ON user_roles(user_id, expires_at);
+DROP INDEX IF EXISTS idx_user_org_primary           ON user_org_units;
+CREATE INDEX idx_user_org_primary                   ON user_org_units(user_id, is_primary);
+DROP INDEX IF EXISTS idx_assignment_user_status     ON shift_assignments;
+CREATE INDEX idx_assignment_user_status             ON shift_assignments(user_id, status);

--- a/backend/database/init.sql
+++ b/backend/database/init.sql
@@ -453,6 +453,8 @@ CREATE TABLE IF NOT EXISTS user_calendar_tokens (
 
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 );
+-- SECURITY: The token column stores raw tokens. Future improvement: store SHA-256(token)
+--           and compare hashes on lookup to reduce exposure if the DB is compromised.
 
 -- ================================================================
 -- SHIFT SWAP REQUESTS TABLE - Employee-to-employee shift exchanges
@@ -996,3 +998,8 @@ ALTER TABLE departments
 -- ================================================================
 -- END OF SCHEMA
 -- ================================================================
+
+-- Performance indexes added for auth hot paths and assignment queries
+CREATE INDEX IF NOT EXISTS idx_user_roles_user_expires   ON user_roles(user_id, expires_at);
+CREATE INDEX IF NOT EXISTS idx_user_org_primary          ON user_org_units(user_id, is_primary);
+CREATE INDEX IF NOT EXISTS idx_assignment_user_status    ON shift_assignments(user_id, status);

--- a/backend/src/__tests__/delegation.service.test.ts
+++ b/backend/src/__tests__/delegation.service.test.ts
@@ -119,8 +119,8 @@ describe('RbacService.getEffectivePermissions — delegation merge', () => {
       [{ delegator_id: 99, permission_codes: JSON.stringify(['timeoff.approve']) }],
       null,
     ]);
-    // Third call: delegator's current role permissions (cap check)
-    execute.mockResolvedValueOnce([[{ code: 'timeoff.approve' }], null]);
+    // Third call: batch query for all delegators' current role permissions (cap check)
+    execute.mockResolvedValueOnce([[{ user_id: 99, code: 'timeoff.approve' }], null]);
 
     const service = new RbacService(pool);
     const perms = await service.getEffectivePermissions(7);
@@ -153,8 +153,11 @@ describe('RbacService.getEffectivePermissions — delegation merge', () => {
       [{ delegator_id: 99, permission_codes: JSON.stringify(['schedule.read', 'timeoff.approve']) }],
       null,
     ]);
-    // Delegator's current role permissions (cap check) — delegator holds both
-    execute.mockResolvedValueOnce([[{ code: 'schedule.read' }, { code: 'timeoff.approve' }], null]);
+    // Batch query for all delegators' current role permissions — delegator holds both
+    execute.mockResolvedValueOnce([
+      [{ user_id: 99, code: 'schedule.read' }, { user_id: 99, code: 'timeoff.approve' }],
+      null,
+    ]);
 
     const service = new RbacService(pool);
     const perms = await service.getEffectivePermissions(7);

--- a/backend/src/__tests__/rbac.service.extended.test.ts
+++ b/backend/src/__tests__/rbac.service.extended.test.ts
@@ -54,8 +54,8 @@ describe('RbacService.getEffectivePermissions', () => {
       .mockResolvedValueOnce([[permRow('schedule.read'), permRow('employee.read')], null])
       // 2nd call: active delegations (includes delegator_id)
       .mockResolvedValueOnce([[{ delegator_id: 5, permission_codes: JSON.stringify(['timeoff.approve']) }], null])
-      // 3rd call: delegator's current role permissions (cap check)
-      .mockResolvedValueOnce([[permRow('timeoff.approve')], null]);
+      // 3rd call: batch query for all delegators' current role permissions (cap check)
+      .mockResolvedValueOnce([[{ user_id: 5, code: 'timeoff.approve' }], null]);
 
     const svc = new RbacService(pool);
     const perms = await svc.getEffectivePermissions(1);
@@ -72,8 +72,8 @@ describe('RbacService.getEffectivePermissions', () => {
       .mockResolvedValueOnce([[permRow('schedule.read')], null])
       // 2nd call: active delegations
       .mockResolvedValueOnce([[{ delegator_id: 5, permission_codes: JSON.stringify(['schedule.read']) }], null])
-      // 3rd call: delegator's current role permissions (cap check)
-      .mockResolvedValueOnce([[permRow('schedule.read')], null]);
+      // 3rd call: batch query for all delegators' current role permissions (cap check)
+      .mockResolvedValueOnce([[{ user_id: 5, code: 'schedule.read' }], null]);
 
     const svc = new RbacService(pool);
     const perms = await svc.getEffectivePermissions(1);
@@ -118,10 +118,15 @@ describe('RbacService.getEffectivePermissions', () => {
         ],
         null,
       ])
-      // 3rd call: delegator 10's current role permissions (cap check for first row)
-      .mockResolvedValueOnce([[permRow('timeoff.approve'), permRow('employee.read')], null])
-      // 4th call: delegator 11's current role permissions (cap check for second row)
-      .mockResolvedValueOnce([[permRow('shift.create')], null]);
+      // 3rd call: single batch query for all delegators' current role permissions
+      .mockResolvedValueOnce([
+        [
+          { user_id: 10, code: 'timeoff.approve' },
+          { user_id: 10, code: 'employee.read' },
+          { user_id: 11, code: 'shift.create' },
+        ],
+        null,
+      ]);
 
     const svc = new RbacService(pool);
     const perms = await svc.getEffectivePermissions(3);

--- a/backend/src/services/RbacService.ts
+++ b/backend/src/services/RbacService.ts
@@ -65,23 +65,37 @@ export class RbacService {
     );
 
     const fromDelegations: string[] = [];
-    for (const row of delegRows as any[]) {
-      const delegatedCodes: string[] = JSON.parse(row.permission_codes as string);
-      // Resolve the delegator's current role-based permissions (no recursion:
-      // sub-delegation is not allowed by design).
-      const [delegatorRows] = await this.pool.execute<RowDataPacket[]>(
-        `SELECT DISTINCT p.code
+    const delegatorIds = (delegRows as any[]).map((r) => r.delegator_id as number);
+
+    if (delegatorIds.length > 0) {
+      // Batch-fetch all delegators' current permissions in a single query.
+      // No recursion: sub-delegation is not allowed by design.
+      const [batchRows] = await this.pool.execute<RowDataPacket[]>(
+        `SELECT DISTINCT ur.user_id, p.code
            FROM user_roles ur
            JOIN role_permissions rp ON rp.role_id = ur.role_id
-           JOIN permissions p ON p.id = rp.permission_id
-          WHERE ur.user_id = ?
+           JOIN permissions p       ON p.id = rp.permission_id
+          WHERE ur.user_id IN (${delegatorIds.map(() => '?').join(',')})
             AND (ur.expires_at IS NULL OR ur.expires_at > NOW())`,
-        [row.delegator_id]
+        delegatorIds
       );
-      const delegatorPerms = new Set(delegatorRows.map((r: any) => r.code as string));
-      // Only grant codes the delegator still holds.
-      const safeCodes = delegatedCodes.filter((c) => delegatorPerms.has(c));
-      safeCodes.forEach((c) => fromDelegations.push(c));
+
+      // Build a per-delegator permission set from the batch result.
+      const delegatorPerms = new Map<number, Set<string>>();
+      for (const br of batchRows as any[]) {
+        const uid = br.user_id as number;
+        if (!delegatorPerms.has(uid)) delegatorPerms.set(uid, new Set());
+        delegatorPerms.get(uid)!.add(br.code as string);
+      }
+
+      // For each active delegation, cap the granted codes to what the delegator still holds.
+      for (const row of delegRows as any[]) {
+        const delegatedCodes: string[] = JSON.parse(row.permission_codes as string);
+        const allowedCodes = delegatedCodes.filter(
+          (c) => (delegatorPerms.get(row.delegator_id) ?? new Set()).has(c)
+        );
+        allowedCodes.forEach((c) => fromDelegations.push(c));
+      }
     }
 
     return [...new Set([...fromRoles, ...fromDelegations])];

--- a/backend/src/services/SystemSettingsService.ts
+++ b/backend/src/services/SystemSettingsService.ts
@@ -172,7 +172,7 @@ export class SystemSettingsService {
 
       await connection.commit();
       
-      logger.info(`Setting ${category}.${key} updated to: ${value}`);
+      logger.info(`Setting ${category}.${key} updated`);
       return updatedRows[0] as SystemSetting;
     } catch (error) {
       await connection.rollback();


### PR DESCRIPTION
## Summary

- **`SystemSettingsService`**: Remove setting value from the update log line (`updated to: ${value}` stripped) to prevent secrets/API keys from leaking into log files.
- **`RbacService.getEffectivePermissions`**: Replace the N+1 per-delegator permission query loop with a single batched `IN(...)` query, building a `Map<userId, Set<code>>` to cap delegated codes at what each delegator currently holds. Zero behavior change, O(1) DB round-trips instead of O(delegations).
- **`init.sql`**: Add three composite indexes (`idx_user_roles_user_expires`, `idx_user_org_primary`, `idx_assignment_user_status`) for auth hot paths and assignment queries. Add a SECURITY comment on `user_calendar_tokens` noting the raw-token storage trade-off.
- Tests updated to reflect the new single-batch query shape (`{ user_id, code }` rows instead of per-delegator sequential calls).

## Test plan

- [ ] `npm run build` — TypeScript compiles clean
- [ ] `npm run lint` — no ESLint errors
- [ ] `npm run deadcode` — no dead code
- [ ] `npm test -- --runInBand --ci` — all 1368 tests pass