### PR TITLE
chore(docker): upgrade Node.js 18→22-alpine, raise backend mem_limit to 1g

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage build for production optimization
-FROM node:18-alpine AS base
+FROM node:22-alpine AS base
 WORKDIR /app
 
 # Copy package files
@@ -17,14 +17,14 @@ COPY . .
 RUN npm run build
 
 # Production stage
-FROM node:18-alpine AS production
+FROM node:22-alpine AS production
 WORKDIR /app
 
 # Copy package files
 COPY package*.json ./
 
 # Install only production dependencies
-RUN npm ci --only=production && npm cache clean --force
+RUN npm ci --omit=dev && npm cache clean --force
 
 # Copy built application from build stage
 COPY --from=build /app/dist ./dist

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,7 @@ services:
       - backend_uploads:/app/uploads
     networks:
       - staff_scheduler_network
-    mem_limit: 512m
+    mem_limit: 1g
     cpus: 0.5
     healthcheck:
       test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3001/api/health"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage build for production optimization
-FROM node:18-alpine AS base
+FROM node:22-alpine AS base
 WORKDIR /app
 
 # Copy package files


### PR DESCRIPTION
## Summary
- Upgrade all Node.js Docker build stages from EOL `node:18-alpine` to Active LTS `node:22-alpine` (affects `backend/Dockerfile` base + production stages, and `frontend/Dockerfile` build stage)
- Replace deprecated `--only=production` flag with `--omit=dev` for npm 10 compatibility (Node 22 ships with npm 10)
- Raise backend container `mem_limit` from `512m` to `1g` in `docker-compose.yml`

## Test plan
- [ ] `cd backend && npm run build` passes (verified locally — exit 0, no type errors)
- [ ] Docker build: `docker compose build --no-cache backend` pulls `node:22-alpine` and succeeds
- [ ] Container starts and `/api/health` responds 200 within the new memory ceiling