### PR TITLE
fix(backend): add LIMIT guards to unbounded queries, add OrgUnit TTL cache

### DIFF
--- a/backend/src/__tests__/auditLog.service.test.ts
+++ b/backend/src/__tests__/auditLog.service.test.ts
@@ -33,7 +33,10 @@ describe('AuditLogService.list', () => {
     const page = await service.list({});
     expect(page.total).toBe(2);
     expect(page.items).toHaveLength(2);
-    expect(execute.mock.calls[1][0]).toMatch(/LIMIT 100 OFFSET 0/);
+    expect(execute.mock.calls[1][0]).toMatch(/LIMIT \? OFFSET \?/);
+    const listParams = execute.mock.calls[1][1] as unknown[];
+    expect(listParams.at(-2)).toBe(100);
+    expect(listParams.at(-1)).toBe(0);
   });
 
   it('clamps a huge limit to 500', async () => {
@@ -44,7 +47,9 @@ describe('AuditLogService.list', () => {
 
     const service = new AuditLogService(pool);
     await service.list({ limit: 9999 });
-    expect(execute.mock.calls[1][0]).toMatch(/LIMIT 500/);
+    expect(execute.mock.calls[1][0]).toMatch(/LIMIT \? OFFSET \?/);
+    const listParams = execute.mock.calls[1][1] as unknown[];
+    expect(listParams.at(-2)).toBe(500);
   });
 
   it('builds the WHERE clause from supplied filters', async () => {

--- a/backend/src/services/ApprovalMatrixService.ts
+++ b/backend/src/services/ApprovalMatrixService.ts
@@ -70,7 +70,7 @@ export class ApprovalMatrixService {
 
   async list(): Promise<ApprovalMatrixRow[]> {
     const [rows] = await this.pool.execute<RowDataPacket[]>(
-      `SELECT * FROM approval_matrix ORDER BY change_type ASC`
+      `SELECT * FROM approval_matrix ORDER BY change_type ASC LIMIT 200`
     );
     return rows.map(mapRow);
   }

--- a/backend/src/services/AuditLogService.ts
+++ b/backend/src/services/AuditLogService.ts
@@ -122,8 +122,8 @@ export class AuditLogService {
     const [rows] = await this.pool.execute<RowDataPacket[]>(
       `SELECT * FROM audit_logs${where}
         ORDER BY created_at DESC
-        LIMIT ${limit} OFFSET ${offset}`,
-      params
+        LIMIT ? OFFSET ?`,
+      [...params, limit, offset]
     );
 
     return { total, items: rows.map(mapRow) };

--- a/backend/src/services/EmployeeLoanService.ts
+++ b/backend/src/services/EmployeeLoanService.ts
@@ -164,7 +164,7 @@ export class EmployeeLoanService {
     }
     const where = conditions.length ? ` WHERE ${conditions.join(' AND ')}` : '';
     const [rows] = await this.pool.execute<RowDataPacket[]>(
-      `SELECT * FROM employee_loans${where} ORDER BY start_date DESC`,
+      `SELECT * FROM employee_loans${where} ORDER BY start_date DESC LIMIT 500`,
       params
     );
     return rows.map(mapRow);

--- a/backend/src/services/OnCallService.ts
+++ b/backend/src/services/OnCallService.ts
@@ -183,7 +183,8 @@ export class OnCallService {
               AND a.status IN ('pending', 'confirmed')
          ${where}
         GROUP BY p.id
-        ORDER BY p.date ASC, p.start_time ASC`,
+        ORDER BY p.date ASC, p.start_time ASC
+        LIMIT 500`,
       params
     );
     return rows.map(mapPeriod);
@@ -327,7 +328,8 @@ export class OnCallService {
               AND a2.status IN ('pending', 'confirmed')
         WHERE ${conditions.join(' AND ')}
         GROUP BY p.id
-        ORDER BY p.date ASC, p.start_time ASC`,
+        ORDER BY p.date ASC, p.start_time ASC
+        LIMIT 500`,
       params
     );
     return rows.map((r) => ({

--- a/backend/src/services/OrgUnitService.ts
+++ b/backend/src/services/OrgUnitService.ts
@@ -49,6 +49,9 @@ interface UpdateOrgUnitInput {
   isActive?: boolean;
 }
 
+// Module-level 60-second TTL cache for the org unit tree.
+let _treeCache: { data: OrgUnitNode[]; expiresAt: number } | null = null;
+
 const mapUnit = (row: RowDataPacket): OrgUnit => ({
   id: row.id as number,
   name: row.name as string,
@@ -86,8 +89,11 @@ export class OrgUnitService {
     return rows.length === 0 ? null : mapUnit(rows[0]);
   }
 
-  /** Returns the org tree as a forest of nodes (multiple roots are allowed). */
+  /** Returns the org tree as a forest of nodes (multiple roots are allowed). Cached for 60 s. */
   async tree(): Promise<OrgUnitNode[]> {
+    if (_treeCache !== null && Date.now() < _treeCache.expiresAt) {
+      return _treeCache.data;
+    }
     const all = await this.list();
     const byId = new Map<number, OrgUnitNode>();
     all.forEach((u) => byId.set(u.id, { ...u, children: [] }));
@@ -99,6 +105,7 @@ export class OrgUnitService {
         roots.push(node);
       }
     });
+    _treeCache = { data: roots, expiresAt: Date.now() + 60_000 };
     return roots;
   }
 
@@ -120,6 +127,7 @@ export class OrgUnitService {
     );
     const created = await this.getById(res.insertId);
     if (!created) throw new Error('Failed to create org unit');
+    _treeCache = null;
     logger.info(`Org unit created: id=${created.id} name="${created.name}"`);
     return created;
   }
@@ -169,6 +177,7 @@ export class OrgUnitService {
     );
     const refreshed = await this.getById(id);
     if (!refreshed) throw new Error('Failed to refresh org unit');
+    _treeCache = null;
     return refreshed;
   }
 
@@ -176,6 +185,7 @@ export class OrgUnitService {
     const existing = await this.getById(id);
     if (!existing) throw new Error('Org unit not found');
     await this.pool.execute(`DELETE FROM org_units WHERE id = ?`, [id]);
+    _treeCache = null;
   }
 
   // -------- Memberships --------

--- a/backend/src/services/PolicyExceptionService.ts
+++ b/backend/src/services/PolicyExceptionService.ts
@@ -158,7 +158,7 @@ export class PolicyExceptionService {
     }
     const where = conditions.length ? ` WHERE ${conditions.join(' AND ')}` : '';
     const [rows] = await this.pool.execute<RowDataPacket[]>(
-      `SELECT * FROM policy_exception_requests${where} ORDER BY created_at DESC`,
+      `SELECT * FROM policy_exception_requests${where} ORDER BY created_at DESC LIMIT 500`,
       params
     );
     return rows.map(mapRow);

--- a/backend/src/services/PolicyService.ts
+++ b/backend/src/services/PolicyService.ts
@@ -78,7 +78,7 @@ export class PolicyService {
   async list(activeOnly = false): Promise<Policy[]> {
     const where = activeOnly ? ' WHERE is_active = 1' : '';
     const [rows] = await this.pool.execute<RowDataPacket[]>(
-      `SELECT * FROM policies${where} ORDER BY scope_type ASC, policy_key ASC`
+      `SELECT * FROM policies${where} ORDER BY scope_type ASC, policy_key ASC LIMIT 500`
     );
     return rows.map(mapRow);
   }

--- a/backend/src/services/ShiftService.ts
+++ b/backend/src/services/ShiftService.ts
@@ -685,7 +685,7 @@ export class ShiftService {
   async getAllShiftTemplates(): Promise<any[]> {
     try {
       const [rows] = await this.pool.execute<RowDataPacket[]>(
-        'SELECT * FROM shift_templates WHERE is_active = 1 ORDER BY name ASC'
+        'SELECT * FROM shift_templates WHERE is_active = 1 ORDER BY name ASC LIMIT 1000'
       );
       return rows.map((row: any) => ({
         id: row.id,

--- a/backend/src/services/ShiftSwapService.ts
+++ b/backend/src/services/ShiftSwapService.ts
@@ -133,7 +133,7 @@ export class ShiftSwapService {
     }
     const where = conditions.length ? ` WHERE ${conditions.join(' AND ')}` : '';
     const [rows] = await this.pool.execute<RowDataPacket[]>(
-      `SELECT * FROM shift_swap_requests${where} ORDER BY created_at DESC`,
+      `SELECT * FROM shift_swap_requests${where} ORDER BY created_at DESC LIMIT 500`,
       params
     );
     return rows.map(mapRow);

--- a/backend/src/services/TimeOffService.ts
+++ b/backend/src/services/TimeOffService.ts
@@ -129,7 +129,7 @@ export class TimeOffService {
 
     const where = conditions.length ? ` WHERE ${conditions.join(' AND ')}` : '';
     const [rows] = await this.pool.execute<RowDataPacket[]>(
-      `SELECT * FROM time_off_requests${where} ORDER BY start_date DESC`,
+      `SELECT * FROM time_off_requests${where} ORDER BY start_date DESC LIMIT 500`,
       params
     );
     return rows.map(mapRow);


### PR DESCRIPTION
## Summary

- Add `LIMIT` guards to 9 service list methods that previously issued unbounded `SELECT *` queries: `PolicyService` (500), `ShiftService` templates (1000), `TimeOffService` (500), `EmployeeLoanService` (500), `ShiftSwapService` (500), `PolicyExceptionService` (500), `OnCallService.listPeriods` and `listForUser` (500 each), `ApprovalMatrixService` (200).
- Replace string-interpolated `LIMIT ${limit} OFFSET ${offset}` in `AuditLogService` with parameterized `LIMIT ? OFFSET ?` placeholders; limit/offset values are appended to the params array.
- Add a module-level 60-second TTL cache for `OrgUnitService.tree()`, with cache invalidation on `create`, `update`, and `remove`.

## Test plan

- [ ] `npm run build` passes (tsc --noEmit clean)
- [ ] `npm run lint` passes
- [ ] All 1368 unit tests pass (`npm test -- --runInBand --ci`)
- [ ] `auditLog.service.test.ts` assertions updated to verify LIMIT/OFFSET values through the params array rather than string matching