### PR TITLE
refactor(frontend): replace alert with setError, add useMemo/debounce/aria-labels

### DIFF
--- a/frontend/src/pages/Employees/Employees.tsx
+++ b/frontend/src/pages/Employees/Employees.tsx
@@ -16,7 +16,7 @@
  * @author Luca Ostinelli
  */
 
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { Employee } from '../../types';
 import * as employeeService from '../../services/employeeService';
 import ConfirmModal from '../../components/ConfirmModal';
@@ -35,18 +35,20 @@ const Employees: React.FC = () => {
   const [showAddModal, setShowAddModal] = useState(false);
   const [editingEmployee, setEditingEmployee] = useState<Employee | null>(null);
   const [confirmDelete, setConfirmDelete] = useState<{ open: boolean; employeeId: number | string | null }>({ open: false, employeeId: null });
+  const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const isInitialMount = useRef(true);
 
-  const loadEmployees = useCallback(async () => {
+  const loadEmployees = useCallback(async (search: string, department: string, showLoading = true) => {
     try {
-      setLoading(true);
+      if (showLoading) setLoading(true);
       setError(null);
-      
+
       const response = await employeeService.getEmployees({
-        search: searchTerm || undefined,
-        department: selectedDepartment || undefined,
+        search: search || undefined,
+        department: department || undefined,
         limit: 50
       });
-      
+
       if (response.success && response.data) {
         setEmployees(response.data);
       } else {
@@ -57,13 +59,25 @@ const Employees: React.FC = () => {
       setError('Failed to load employees. Please check your connection and try again.');
       setEmployees([]);
     } finally {
-      setLoading(false);
+      if (showLoading) setLoading(false);
     }
-  }, [searchTerm, selectedDepartment]);
+  }, []);
 
   useEffect(() => {
-    loadEmployees();
-  }, [loadEmployees]);
+    if (isInitialMount.current) {
+      isInitialMount.current = false;
+      loadEmployees(searchTerm, selectedDepartment, true);
+      return;
+    }
+    if (debounceTimer.current) clearTimeout(debounceTimer.current);
+    debounceTimer.current = setTimeout(() => {
+      loadEmployees(searchTerm, selectedDepartment, false);
+    }, 300);
+    return () => {
+      if (debounceTimer.current) clearTimeout(debounceTimer.current);
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchTerm, selectedDepartment, loadEmployees]);
 
   const handleDeleteEmployee = (id: number | string) => {
     setConfirmDelete({ open: true, employeeId: id });
@@ -75,24 +89,27 @@ const Employees: React.FC = () => {
     setConfirmDelete({ open: false, employeeId: null });
     try {
       await employeeService.deleteEmployee(id);
-      await loadEmployees(); // Reload the list
+      await loadEmployees(searchTerm, selectedDepartment); // Reload the list
     } catch (err) {
-      alert('Failed to delete employee');
+      setError('Failed to delete employee');
     }
   };
 
-  const filteredEmployees = employees.filter(employee => {
-    const matchesSearch = !searchTerm || 
+  const filteredEmployees = useMemo(() => employees.filter(employee => {
+    const matchesSearch = !searchTerm ||
       `${employee.firstName} ${employee.lastName}`.toLowerCase().includes(searchTerm.toLowerCase()) ||
       employee.email.toLowerCase().includes(searchTerm.toLowerCase()) ||
       (employee.employeeId || '').toLowerCase().includes(searchTerm.toLowerCase());
-    
-    const matchesDepartment = !selectedDepartment || employee.department === selectedDepartment;
-    
-    return matchesSearch && matchesDepartment;
-  });
 
-  const departments = Array.from(new Set(employees.map(emp => emp.department).filter(Boolean)));
+    const matchesDepartment = !selectedDepartment || employee.department === selectedDepartment;
+
+    return matchesSearch && matchesDepartment;
+  }), [employees, searchTerm, selectedDepartment]);
+
+  const departments = useMemo(
+    () => Array.from(new Set(employees.map(emp => emp.department).filter(Boolean))),
+    [employees]
+  );
 
   if (loading) {
     return (
@@ -141,6 +158,7 @@ const Employees: React.FC = () => {
               type="text"
               className="form-control"
               placeholder="Search employees..."
+              aria-label="Search employees"
               value={searchTerm}
               onChange={(e) => setSearchTerm(e.target.value)}
             />
@@ -243,13 +261,15 @@ const Employees: React.FC = () => {
                           className="btn btn-outline-primary"
                           onClick={() => setEditingEmployee(employee)}
                           title="Edit Employee"
+                          aria-label="Edit employee"
                         >
                           <i className="bi bi-pencil"></i>
                         </button>
                         <button
                           className="btn btn-outline-danger"
-                            onClick={() => employee.id !== undefined && handleDeleteEmployee(employee.id)}
+                          onClick={() => employee.id !== undefined && handleDeleteEmployee(employee.id)}
                           title="Delete Employee"
+                          aria-label="Delete employee"
                         >
                           <i className="bi bi-trash"></i>
                         </button>
@@ -337,11 +357,11 @@ const Employees: React.FC = () => {
                     } else {
                       await employeeService.createEmployee(employeeData);
                     }
-                    await loadEmployees();
+                    await loadEmployees(searchTerm, selectedDepartment);
                     setShowAddModal(false);
                     setEditingEmployee(null);
                   } catch (err) {
-                    alert('Failed to save employee');
+                    setError('Failed to save employee');
                   }
                 }}>
                   <div className="row">

--- a/frontend/src/pages/Schedule/Schedule.tsx
+++ b/frontend/src/pages/Schedule/Schedule.tsx
@@ -319,6 +319,7 @@ const Schedule: React.FC = () => {
                 <button
                   type="button"
                   className={`btn ${viewMode === 'week' ? 'btn-primary' : 'btn-outline-primary'}`}
+                  aria-label="Week view"
                   onClick={() => setViewMode('week')}
                 >
                   Week
@@ -326,6 +327,7 @@ const Schedule: React.FC = () => {
                 <button
                   type="button"
                   className={`btn ${viewMode === 'month' ? 'btn-primary' : 'btn-outline-primary'}`}
+                  aria-label="Month view"
                   onClick={() => setViewMode('month')}
                 >
                   Month

--- a/frontend/src/pages/Shifts/Shifts.tsx
+++ b/frontend/src/pages/Shifts/Shifts.tsx
@@ -42,6 +42,14 @@ const Shifts: React.FC = () => {
   const [editingShift, setEditingShift] = useState<Shift | null>(null);
   const [formError, setFormError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedSearch(searchTerm);
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [searchTerm]);
 
   const [confirm, setConfirm] = useState<ConfirmState>({
     show: false,
@@ -115,14 +123,14 @@ const Shifts: React.FC = () => {
     });
   };
 
-  const filteredShifts = shifts.filter((shift) => {
+  const filteredShifts = useMemo(() => shifts.filter((shift) => {
     const matchesSearch =
-      !searchTerm ||
-      (shift.name || '').toLowerCase().includes(searchTerm.toLowerCase()) ||
+      !debouncedSearch ||
+      (shift.name || '').toLowerCase().includes(debouncedSearch.toLowerCase()) ||
       (shift.departmentName || shift.department || '')
         .toLowerCase()
-        .includes(searchTerm.toLowerCase()) ||
-      (shift.notes && shift.notes.toLowerCase().includes(searchTerm.toLowerCase()));
+        .includes(debouncedSearch.toLowerCase()) ||
+      (shift.notes && shift.notes.toLowerCase().includes(debouncedSearch.toLowerCase()));
 
     const matchesDepartment =
       !selectedDepartment ||
@@ -131,7 +139,7 @@ const Shifts: React.FC = () => {
       shift.department === selectedDepartment;
 
     return matchesSearch && matchesDepartment;
-  });
+  }), [shifts, debouncedSearch, selectedDepartment]);
 
   const handleSubmitShift = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -231,6 +239,7 @@ const Shifts: React.FC = () => {
               type="text"
               className="form-control"
               placeholder="Search shifts..."
+              aria-label="Search shifts"
               value={searchTerm}
               onChange={(e) => setSearchTerm(e.target.value)}
             />

--- a/frontend/src/pages/shifts/ShiftTable.tsx
+++ b/frontend/src/pages/shifts/ShiftTable.tsx
@@ -85,6 +85,7 @@ const ShiftTable: React.FC<Props> = ({
                   <button
                     className="btn btn-sm btn-outline-secondary"
                     type="button"
+                    aria-label="Shift actions"
                     data-bs-toggle="dropdown"
                   >
                     <i className="bi bi-three-dots"></i>


### PR DESCRIPTION
## Summary

- **Employees**: replace two `alert()` calls with `setError()`; wrap `filteredEmployees` and `departments` derivations in `useMemo`; add 300ms debounced API search (background refresh only — no loading spinner interruption); add `aria-label` to search input, edit button, and delete button.
- **Shifts**: wrap `filteredShifts` in `useMemo`; add 300ms debounce on the search term via `debouncedSearch` state; add `aria-label="Search shifts"` to the search input.
- **Schedule**: add `aria-label="Week view"` and `aria-label="Month view"` to the view-toggle buttons.
- **ShiftTable**: add `aria-label="Shift actions"` to the three-dots dropdown trigger button.

## Test plan

- [ ] All 103 existing frontend unit tests pass (`npm test -- --watchAll=false --ci`)
- [ ] `@testing-library/dom` peer dependency added to resolve pre-existing test runner failure
- [ ] No new ESLint warnings introduced
- [ ] Debounce in Employees uses a non-loading background refresh so open modals (ConfirmModal, edit modal) are not interrupted by background search reloads