### PR TITLE
fix(backend): SSE double-cleanup guard + express-rate-limit upgrade to v7

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -13,7 +13,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
-        "express-rate-limit": "^6.8.1",
+        "express-rate-limit": "^7.5.1",
         "helmet": "^7.0.0",
         "jsonwebtoken": "^9.0.2",
         "morgan": "^1.10.0",
@@ -4222,15 +4222,18 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "6.11.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-6.11.2.tgz",
-      "integrity": "sha512-a7uwwfNTh1U60ssiIkuLFWHt4hAC5yxlLGU2VP0X4YNlyEDZAqF4tK3GD3NSitVBrCQmQ0++0uOyFOgC2y4DDw==",
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
+      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
       "license": "MIT",
       "engines": {
-        "node": ">= 14"
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
       },
       "peerDependencies": {
-        "express": "^4 || ^5"
+        "express": ">= 4.11"
       }
     },
     "node_modules/express/node_modules/debug": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -27,7 +27,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
-    "express-rate-limit": "^6.8.1",
+    "express-rate-limit": "^7.5.1",
     "helmet": "^7.0.0",
     "jsonwebtoken": "^9.0.2",
     "morgan": "^1.10.0",

--- a/backend/src/routes/events.ts
+++ b/backend/src/routes/events.ts
@@ -40,7 +40,10 @@ export const createEventsRouter = (): Router => {
     }, HEARTBEAT_MS);
     if (typeof heartbeat.unref === 'function') heartbeat.unref();
 
+    let cleaned = false;
     const cleanup = (): void => {
+      if (cleaned) return;
+      cleaned = true;
       clearInterval(heartbeat);
       eventBus.unsubscribe(userId, res);
     };


### PR DESCRIPTION
## Summary

- **SSE cleanup guard** (`backend/src/routes/events.ts`): Added a `cleaned` boolean flag so the `cleanup()` function is idempotent — both `req.on('close')` and `req.on('end')` listeners can fire without double-clearing the heartbeat interval or double-unsubscribing from the EventBus.
- **express-rate-limit 6.x → 7.x** (`backend/package.json`): Upgraded to `7.5.1`. No API changes required — the codebase does not use `onLimitReached` (removed in v7), and `standardHeaders` is already set explicitly so the v7 default change has no effect.

## Test plan

- [x] `npm run build` — clean TypeScript compile, no type errors
- [x] `npm run lint` — no lint warnings
- [x] `npm test -- --runInBand --ci` — 1374 tests, 83 suites, all pass