### PR TITLE
docs: document CRA audit findings and add Future Work section

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -697,6 +697,20 @@ The following capabilities are planned but not yet implemented. Pull requests fo
 | Bulk API | Batch endpoints for high-volume integrations |
 | Kiosk / QR clocking | Tablet kiosk mode and QR-code-based clock-in |
 
+### Future Work
+
+#### CRA → Vite migration
+
+`react-scripts@5.0.1` is the last Create React App release and is no longer maintained. The build toolchain carries 13 HIGH-severity transitive vulnerabilities that cannot be patched without replacing the build tool. Recommended path: migrate to Vite 5.x (drop `react-scripts`, add `vite` + `@vitejs/plugin-react`). No application code API changes are required; the migration affects only dev-server and build configuration.
+
+#### Express 4 → Express 5
+
+The backend runs Express 4.18.x. Express 5.0 was released in October 2024. Key improvements: native async error propagation (no more wrapping async handlers), updated `path-to-regexp`, and removal of deprecated 4.x APIs. Migration effort is low-to-medium. Recommended trigger: when Express 4 enters security-only maintenance.
+
+#### Dual API prefix cleanup
+
+All routes are mounted under both `/api/*` (legacy) and `/api/v1/*` (canonical) in `src/app.ts`. Once all clients have migrated to `/api/v1/*`, add HTTP 308 redirects from `/api/*` to `/api/v1/*` and drop the legacy prefix.
+
 ---
 
 ## 18. Scalability analysis

--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ npm install
 npm start                  # http://localhost:3000
 ```
 
+> **Note**: `react-scripts@5.0.1` (Create React App) is unmaintained since October 2022.
+> `npm audit` reports 13 HIGH-severity findings — all in CRA's build toolchain (nth-check, serialize-javascript, svgo, etc.), none in the production JS bundle. They cannot be resolved without migrating to Vite. See DOCUMENTATION.md §Future Work.
+
 ### First admin user
 
 `npm run db:init` creates only the schema. There are no default


### PR DESCRIPTION
## Summary

- Add a callout in `README.md` (Frontend quick-start section) noting that `react-scripts@5.0.1` is unmaintained and that `npm audit` reports 13 HIGH-severity findings confined to the build toolchain, none in the production bundle.
- Add a **Future Work** subsection to `DOCUMENTATION.md` §17 with three entries: CRA → Vite migration, Express 4 → Express 5 upgrade, and dual API prefix cleanup.
- Verified that `DB_POOL_LIMIT`, `DB_QUEUE_LIMIT`, and `OPTIMIZATION_ENGINE` are already documented in §6 and §18/§21 — no additions needed.
- `openapi.json` validated: JSON OK.

## Test plan

- [ ] Render README.md locally and confirm the blockquote renders correctly under the Frontend heading.
- [ ] Confirm DOCUMENTATION.md §17 now contains the three new subsections under "Future Work".
- [ ] Verify no other files were modified.