### PR TITLE
fix: eliminate remaining as-any casts and fix Schedule type

### DIFF
--- a/backend/src/routes/departments.ts
+++ b/backend/src/routes/departments.ts
@@ -21,7 +21,7 @@ export const createDepartmentsRouter = (pool: Pool) => {
   // Get all departments
   router.get('/', authenticate, async (req, res) => {
     try {
-      const user = (req as any).user;
+      const user = req.user;
 
       let departments;
       if (userHasPermission(user, 'settings.manage')) {
@@ -43,7 +43,7 @@ export const createDepartmentsRouter = (pool: Pool) => {
   // Get single department
   router.get('/:id', authenticate, validateParams(idParam), async (req, res) => {
     try {
-      const user = (req as any).user;
+      const user = req.user;
       const departmentId = res.locals.params.id;
 
       if (!userHasPermission(user, 'settings.manage')) {
@@ -79,7 +79,7 @@ export const createDepartmentsRouter = (pool: Pool) => {
   // Create new department
   router.post('/', authenticate, async (req, res) => {
     try {
-      const user = (req as any).user;
+      const user = req.user;
 
       if (!userHasPermission(user, 'department.manage')) {
         return res.status(403).json({
@@ -127,7 +127,7 @@ export const createDepartmentsRouter = (pool: Pool) => {
   // Update department
   router.put('/:id', authenticate, validateParams(idParam), async (req, res) => {
     try {
-      const user = (req as any).user;
+      const user = req.user;
       const departmentId = res.locals.params.id;
       const departmentData: UpdateDepartmentRequest = req.body;
 
@@ -175,7 +175,7 @@ export const createDepartmentsRouter = (pool: Pool) => {
   // Delete department
   router.delete('/:id', authenticate, validateParams(idParam), async (req, res) => {
     try {
-      const user = (req as any).user;
+      const user = req.user;
       const departmentId = res.locals.params.id;
 
       if (!userHasPermission(user, 'settings.manage')) {
@@ -208,7 +208,7 @@ export const createDepartmentsRouter = (pool: Pool) => {
   // Add user to department
   router.post('/:id/users', authenticate, validateParams(idParam), validateBody(addUserToDepartmentBody), async (req, res) => {
     try {
-      const user = (req as any).user;
+      const user = req.user;
       const departmentId = res.locals.params.id;
       const { userId } = res.locals.body;
 
@@ -262,7 +262,7 @@ export const createDepartmentsRouter = (pool: Pool) => {
   // Remove user from department
   router.delete('/:id/users/:userId', authenticate, validateParams(idAndUserIdParam), async (req, res) => {
     try {
-      const user = (req as any).user;
+      const user = req.user;
       const departmentId = res.locals.params.id;
       const targetUserId = res.locals.params.userId;
 
@@ -300,7 +300,7 @@ export const createDepartmentsRouter = (pool: Pool) => {
   // Get department statistics
   router.get('/:id/stats', authenticate, validateParams(idParam), async (req, res) => {
     try {
-      const user = (req as any).user;
+      const user = req.user;
       const departmentId = res.locals.params.id;
 
       if (!userHasPermission(user, 'settings.manage')) {

--- a/backend/src/routes/schedules.ts
+++ b/backend/src/routes/schedules.ts
@@ -53,8 +53,7 @@ router.get('/:id', authenticate, validateParams(idParam), async (req: Request, r
 
     const scope = req.user?.allowedOrgUnitIds;
     if (scope !== null && scope !== undefined) {
-      const dept = schedule as any;
-      const deptOrgUnitId = dept.departmentOrgUnitId ?? null;
+      const deptOrgUnitId = schedule.departmentOrgUnitId ?? null;
       if (deptOrgUnitId === null || !scope.includes(deptOrgUnitId)) {
         return res.status(403).json({
           success: false,
@@ -89,8 +88,7 @@ router.get('/:id/shifts', authenticate, validateParams(idParam), async (req: Req
     // Enforce org-unit scope — same rule as GET /:id.
     const scope = req.user?.allowedOrgUnitIds;
     if (scope !== null && scope !== undefined) {
-      const dept = schedule as any;
-      const deptOrgUnitId = dept.departmentOrgUnitId ?? null;
+      const deptOrgUnitId = schedule.departmentOrgUnitId ?? null;
       if (deptOrgUnitId === null || !scope.includes(deptOrgUnitId)) {
         return res.status(403).json({
           success: false,

--- a/backend/src/services/CalendarService.ts
+++ b/backend/src/services/CalendarService.ts
@@ -135,8 +135,10 @@ export class CalendarService {
   }
 
   /**
-   * Returns the raw token on first call (creates it); on subsequent calls
-   * rotates and returns a new raw token. Kept for route backwards-compatibility.
+   * Returns the raw token on first call (creates and stores its SHA-256 hash).
+   * On subsequent calls rotates: generates a new token, overwrites the stored hash,
+   * and returns the new raw value — the old subscription URL is invalidated.
+   * Kept for route backwards-compatibility with GET /api/calendar/token.
    */
   async getOrCreateToken(userId: number): Promise<string> {
     const raw = await this.getToken(userId);

--- a/backend/src/services/ScheduleService.ts
+++ b/backend/src/services/ScheduleService.ts
@@ -102,7 +102,7 @@ export class ScheduleService {
       if (rows.length === 0) return null;
 
       const row = rows[0];
-      const schedule: Schedule & { departmentOrgUnitId?: number | null } = {
+      const schedule: Schedule = {
         id: row.id,
         name: row.name,
         departmentId: row.department_id,

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -244,6 +244,7 @@ export interface Schedule {
   status: 'draft' | 'published' | 'archived';
   departmentId?: number;
   departmentName?: string;
+  departmentOrgUnitId?: number | null;
   createdBy?: number;
   createdByName?: string;
   publishedBy?: number;

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -188,7 +188,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
           payload: { user, token },
         });
       } else {
-        throw new Error((response.error as any)?.message || 'Login failed');
+        throw new Error(response.error?.message || 'Login failed');
       }
     } catch (error) {
       dispatch({ type: 'LOGIN_FAILURE', payload: error instanceof Error ? error.message : 'Login failed' });


### PR DESCRIPTION
## Summary

- Removed all 8 occurrences of `(req as any).user` in `backend/src/routes/departments.ts` — the express-serve-static-core module augmentation in `auth.ts` already declares `req.user: User`, making the cast unnecessary
- Added `departmentOrgUnitId?: number | null` to the `Schedule` interface in `backend/src/types/index.ts`, allowing `schedules.ts` to read that field directly without `schedule as any`
- Removed the now-redundant local `Schedule & { departmentOrgUnitId?: number | null }` intersection type from `ScheduleService.ts`
- Removed `(response.error as any)` cast in `frontend/src/contexts/AuthContext.tsx:191`; `ApiResponse.error` is already typed with a `message: string` field
- Replaced the inaccurate JSDoc of `CalendarService.getOrCreateToken()` with a precise description of the create-then-rotate behaviour

## Test plan

- [x] `backend/node_modules/.bin/tsc --noEmit` — no new errors in changed files
- [x] Backend test suite: 87 suites, 1472 tests, all passing
- [x] `frontend/node_modules/.bin/tsc --noEmit` — clean
- [x] lint-staged ran eslint --fix on all 6 changed files without warnings