### PR TITLE
perf: push user filters to DB and pre-index schedule assignments

### DIFF
--- a/backend/src/__tests__/routes.users.test.ts
+++ b/backend/src/__tests__/routes.users.test.ts
@@ -71,9 +71,11 @@ describe('users router GET /', () => {
     expect(all).toHaveBeenCalledWith({ search: undefined, departmentId: undefined, roleId: undefined });
   });
 
-  it('manager lists only own scope and applies post-filtering', async () => {
+  it('manager lists only own scope with filters pushed to service', async () => {
     currentUser = { id: 9, role: 'manager', email: 'm@x' };
-    (UserService.prototype.getUsersForManager as jest.Mock) = jest.fn().mockResolvedValue([
+    // Filtering is delegated to the service (and ultimately to SQL).
+    // The mock returns only the already-filtered result, matching what the DB would return.
+    const forManager = jest.fn().mockResolvedValue([
       {
         id: 2,
         email: 'a@x.com',
@@ -83,22 +85,19 @@ describe('users router GET /', () => {
         employeeId: 'EMP01',
         departments: [{ departmentId: 5 }],
       },
-      {
-        id: 3,
-        email: 'b@x.com',
-        firstName: 'Luca',
-        lastName: 'Rossi',
-        role: 'employee',
-        employeeId: 'EMP02',
-        departments: [{ departmentId: 7 }],
-      },
     ]);
+    (UserService.prototype.getUsersForManager as jest.Mock) = forManager;
     const res = await request(mountApp()).get(
-      '/api/users?search=anna&department=5&role=employee'
+      '/api/users?search=anna&department=5'
     );
     expect(res.status).toBe(200);
     expect(res.body.data).toHaveLength(1);
     expect(res.body.data[0].id).toBe(2);
+    // Verify that filters were forwarded to the service — not applied in-memory.
+    expect(forManager).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 9 }),
+      { search: 'anna', departmentId: 5 }
+    );
   });
 
   it('returns 500 when service throws', async () => {

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -47,23 +47,11 @@ export const createUsersRouter = (pool: Pool) => {
           roleId: roleId ? parseInt(roleId as string) : undefined
         });
       } else {
-        users = await userService.getUsersForManager(user);
-
-        if (search) {
-          const searchTerm = (search as string).toLowerCase();
-          users = users.filter((u: User) =>
-            u.firstName.toLowerCase().includes(searchTerm) ||
-            u.lastName.toLowerCase().includes(searchTerm) ||
-            u.email.toLowerCase().includes(searchTerm) ||
-            (u.employeeId && u.employeeId.toLowerCase().includes(searchTerm))
-          );
-        }
-
-        if (department) {
-          users = users.filter((u: User) =>
-            u.departments?.some((d: any) => d.departmentId === parseInt(department as string))
-          );
-        }
+        // Filters are pushed into SQL — no in-memory post-filtering needed.
+        users = await userService.getUsersForManager(user, {
+          search: search as string | undefined,
+          departmentId: department ? parseInt(department as string) : undefined,
+        });
       }
 
       const pagination = parsePagination(req);

--- a/backend/src/services/UserService.ts
+++ b/backend/src/services/UserService.ts
@@ -408,23 +408,40 @@ export class UserService {
    * all resources is tracked as a follow-up (hierarchical access scoping).
    *
    * Implemented as a single query (no per-user round-trip) so the listing
-   * stays O(1) in DB calls regardless of the team size.
+   * stays O(1) in DB calls regardless of the team size. Optional search and
+   * departmentId filters are pushed into SQL to avoid in-memory filtering on
+   * the full result set.
    */
-  async getUsersForManager(actor: User): Promise<User[]> {
+  async getUsersForManager(
+    actor: User,
+    filters: { search?: string; departmentId?: number } = {}
+  ): Promise<User[]> {
     try {
-      if (actor.permissions?.includes('settings.manage')) return this.getAllUsers();
+      if (actor.permissions?.includes('settings.manage')) return this.getAllUsers(filters);
 
-      const [userRows] = await this.pool.execute<RowDataPacket[]>(
-        `SELECT DISTINCT u.id, u.email, u.first_name, u.last_name,
+      const params: (string | number)[] = [actor.id];
+      let sql = `SELECT DISTINCT u.id, u.email, u.first_name, u.last_name,
                 u.employee_id, u.phone, u.is_active, u.last_login,
                 u.created_at, u.updated_at
          FROM users u
          JOIN user_departments ud ON u.id = ud.user_id
          JOIN departments d ON ud.department_id = d.id
-         WHERE d.manager_id = ?
-         ORDER BY u.last_name ASC, u.first_name ASC LIMIT 1000`, // Hard cap — use pagination for larger teams.
-        [actor.id]
-      );
+         WHERE d.manager_id = ?`;
+
+      if (filters.search) {
+        sql += ` AND (u.first_name LIKE ? OR u.last_name LIKE ? OR u.email LIKE ? OR u.employee_id LIKE ?)`;
+        const term = `%${filters.search}%`;
+        params.push(term, term, term, term);
+      }
+
+      if (filters.departmentId) {
+        sql += ` AND ud.department_id = ?`;
+        params.push(filters.departmentId);
+      }
+
+      sql += ` ORDER BY u.last_name ASC, u.first_name ASC LIMIT 1000`; // Hard cap — use pagination for larger teams.
+
+      const [userRows] = await this.pool.execute<RowDataPacket[]>(sql, params);
 
       return userRows.map((row: any) => ({
         id: row.id,

--- a/frontend/src/pages/Schedule/Schedule.tsx
+++ b/frontend/src/pages/Schedule/Schedule.tsx
@@ -143,14 +143,28 @@ const Schedule: React.FC = () => {
 
   const weekDates = generateWeekDates(selectedWeek);
 
-  const getAssignmentsForDateAndShift = (date: Date, shiftId: string | number) => {
+  // Pre-index assignments by "dateStr|shiftId" so each cell lookup is O(1)
+  // instead of scanning the full assignments array for every shift × date cell.
+  const assignmentIndex = useMemo(() => {
+    const index = new Map<string, Assignment[]>();
+    for (const a of assignments) {
+      const src = a.shiftDate || a.assignedAt;
+      if (!src) continue;
+      const dateStr = new Date(src).toISOString().split('T')[0];
+      const key = `${dateStr}|${String(a.shiftId)}`;
+      const bucket = index.get(key);
+      if (bucket) {
+        bucket.push(a);
+      } else {
+        index.set(key, [a]);
+      }
+    }
+    return index;
+  }, [assignments]);
+
+  const getAssignmentsForDateAndShift = (date: Date, shiftId: string | number): Assignment[] => {
     const dateStr = date.toISOString().split('T')[0];
-    return assignments.filter((a) => {
-      const assignmentDateSource = a.shiftDate || a.assignedAt;
-      if (!assignmentDateSource) return false;
-      const assignedDate = new Date(assignmentDateSource).toISOString().split('T')[0];
-      return assignedDate === dateStr && String(a.shiftId) === String(shiftId);
-    });
+    return assignmentIndex.get(`${dateStr}|${String(shiftId)}`) ?? [];
   };
 
   const getEmployeeById = (employeeId: string | number) =>


### PR DESCRIPTION
## Summary

- **`routes/users.ts` + `UserService.getUsersForManager`**: manager-scoped `GET /api/users` was loading up to 1,000 users and then filtering `search` and `department` in-memory. Filters are now parameterized and pushed into the SQL `WHERE` clause, so MySQL does the work.
- **`Schedule.tsx`**: `getAssignmentsForDateAndShift()` was called once per `shift × weekDate` cell, each time scanning the full assignments array (O(n²) in total). Replaced with a `useMemo` Map indexed by `"dateStr|shiftId"` — each cell lookup is now O(1).
- **Test update**: `routes.users.test.ts` updated to assert that filters are forwarded to the service, not applied in-memory.

## Test plan

- [x] `cd backend && npm run build` — clean compile
- [x] `cd backend && npm run lint` — no warnings
- [x] `cd backend && npm test --runInBand --ci` — 1479/1479 passed
- [x] `cd frontend && npx tsc --noEmit` — no type errors
- [x] `cd frontend && npm run lint` — no warnings
- [x] `cd frontend && npm test --watchAll=false --ci` — 103/103 passed