### PR TITLE
fix(employees): remove unpopulated type column, fix EUR currency symbol

### DIFF
--- a/frontend/src/pages/Employees/Employees.tsx
+++ b/frontend/src/pages/Employees/Employees.tsx
@@ -220,7 +220,6 @@ const Employees: React.FC = () => {
                   <th>Employee</th>
                   <th>Department</th>
                   <th>Position</th>
-                  <th>Type</th>
                   <th>Hourly Rate</th>
                   <th>Max Hours/Week</th>
                   <th>Status</th>
@@ -248,16 +247,7 @@ const Employees: React.FC = () => {
                     <td>{employee.department || '-'}</td>
                     <td>{employee.position || '-'}</td>
                     <td>
-                      <span className={`badge ${
-                        employee.employeeType === 'full-time' ? 'bg-success' :
-                        employee.employeeType === 'part-time' ? 'bg-warning' :
-                        'bg-info'
-                      }`}>
-                        {employee.employeeType}
-                      </span>
-                    </td>
-                    <td>
-                      {employee.hourlyRate ? `$${employee.hourlyRate.toFixed(2)}` : '-'}
+                      {employee.hourlyRate ? `€${employee.hourlyRate.toFixed(2)}` : '-'}
                     </td>
                     <td>{employee.maxHoursPerWeek}</td>
                     <td>


### PR DESCRIPTION
## Summary
- Remove the **Type** column from the employees table: `employee_type` has no corresponding DB column or UserService SELECT, so the badge always rendered with undefined content and a hardcoded `bg-info` class.
- Fix the hourly-rate currency symbol from `$` (USD) to `€` (EUR), consistent with the form label "Hourly Rate (€)".

## Test plan
- [ ] Employees table loads and shows no Type column
- [ ] Hourly rate cells now show e.g. `€55.50` instead of `$55.50`
- [ ] Existing unit tests still pass