### PR TITLE
perf: push pagination to DB for users, schedules, and shifts

### DIFF
--- a/backend/src/__tests__/pagination.test.ts
+++ b/backend/src/__tests__/pagination.test.ts
@@ -120,10 +120,11 @@ describe('GET /api/v1/schedules', () => {
   });
 
   it('returns meta envelope when page and pageSize are provided', async () => {
+    // countSchedules provides the true total; getAllSchedules returns only the requested page.
+    (ScheduleService.prototype.countSchedules as jest.Mock).mockResolvedValue(3);
     (ScheduleService.prototype.getAllSchedules as jest.Mock).mockResolvedValue([
       { id: 1, name: 'S1' },
       { id: 2, name: 'S2' },
-      { id: 3, name: 'S3' },
     ]);
 
     const app = buildApp({} as never, { silent: true });

--- a/backend/src/routes/schedules.ts
+++ b/backend/src/routes/schedules.ts
@@ -23,11 +23,14 @@ router.get('/', authenticate, async (req: Request, res: Response) => {
     const scope = req.user?.allowedOrgUnitIds;
     const filters = scope !== null && scope !== undefined ? { orgUnitIds: scope } : undefined;
     const pagination = parsePagination(req);
-    const schedules = await scheduleService.getAllSchedules(filters);
     if (pagination) {
-      const sliced = schedules.slice(pagination.offset, pagination.offset + pagination.pageSize);
-      return sendPaginated(res, sliced, schedules.length, pagination);
+      const [total, schedules] = await Promise.all([
+        scheduleService.countSchedules(filters),
+        scheduleService.getAllSchedules(filters, { limit: pagination.pageSize, offset: pagination.offset }),
+      ]);
+      return sendPaginated(res, schedules, total, pagination);
     }
+    const schedules = await scheduleService.getAllSchedules(filters);
     res.json({ success: true, data: schedules });
   } catch (error) {
     logger.error('Error fetching schedules:', error);

--- a/backend/src/routes/shifts.ts
+++ b/backend/src/routes/shifts.ts
@@ -149,14 +149,16 @@ router.delete('/templates/:id', authenticate, requirePermission('shift.manage'),
 router.get('/', authenticate, async (req: Request, res: Response) => {
   try {
     const scope = req.user?.allowedOrgUnitIds;
-    const shifts = await shiftService.getAllShifts(
-      scope !== null && scope !== undefined ? { orgUnitIds: scope } : undefined
-    );
+    const filters = scope !== null && scope !== undefined ? { orgUnitIds: scope } : undefined;
     const pagination = parsePagination(req);
     if (pagination) {
-      const sliced = shifts.slice(pagination.offset, pagination.offset + pagination.pageSize);
-      return sendPaginated(res, sliced, shifts.length, pagination);
+      const [total, shifts] = await Promise.all([
+        shiftService.countShifts(filters),
+        shiftService.getAllShifts(filters, { limit: pagination.pageSize, offset: pagination.offset }),
+      ]);
+      return sendPaginated(res, shifts, total, pagination);
     }
+    const shifts = await shiftService.getAllShifts(filters);
     res.json({ success: true, data: shifts });
   } catch (error) {
     logger.error('Error fetching shifts:', error);

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -39,26 +39,35 @@ export const createUsersRouter = (pool: Pool) => {
       const user = req.user as User;
       const { search, department, roleId } = req.query;
 
-      let users;
+      const filters = {
+        search: search as string | undefined,
+        departmentId: department ? parseInt(department as string) : undefined,
+        roleId: roleId ? parseInt(roleId as string) : undefined,
+      };
+      const pagination = parsePagination(req);
+
       if (userHasPermission(user, 'settings.manage')) {
-        users = await userService.getAllUsers({
-          search: search as string,
-          departmentId: department ? parseInt(department as string) : undefined,
-          roleId: roleId ? parseInt(roleId as string) : undefined
-        });
-      } else {
-        // Filters are pushed into SQL — no in-memory post-filtering needed.
-        users = await userService.getUsersForManager(user, {
-          search: search as string | undefined,
-          departmentId: department ? parseInt(department as string) : undefined,
-        });
+        if (pagination) {
+          const [total, users] = await Promise.all([
+            userService.countUsers(filters),
+            userService.getAllUsers(filters, { limit: pagination.pageSize, offset: pagination.offset }),
+          ]);
+          return sendPaginated(res, users, total, pagination);
+        }
+        const users = await userService.getAllUsers(filters);
+        return res.json({ success: true, data: users });
       }
 
-      const pagination = parsePagination(req);
+      // Manager path — scoped to departments managed by this user.
+      const managerFilters = { search: filters.search, departmentId: filters.departmentId };
       if (pagination) {
-        const sliced = users.slice(pagination.offset, pagination.offset + pagination.pageSize);
-        return sendPaginated(res, sliced, users.length, pagination);
+        const [total, users] = await Promise.all([
+          userService.countUsersForManager(user, managerFilters),
+          userService.getUsersForManager(user, managerFilters, { limit: pagination.pageSize, offset: pagination.offset }),
+        ]);
+        return sendPaginated(res, users, total, pagination);
       }
+      const users = await userService.getUsersForManager(user, managerFilters);
       res.json({ success: true, data: users });
     } catch (error) {
       logger.error('Get users error:', error);

--- a/backend/src/services/ScheduleService.ts
+++ b/backend/src/services/ScheduleService.ts
@@ -131,7 +131,7 @@ export class ScheduleService {
     startDate?: string;
     endDate?: string;
     orgUnitIds?: number[];
-  }): Promise<Schedule[]> {
+  }, pagination?: { limit: number; offset: number }): Promise<Schedule[]> {
     try {
       let query = `
         SELECT
@@ -160,7 +160,13 @@ export class ScheduleService {
       }
 
       if (conditions.length > 0) query += ' WHERE ' + conditions.join(' AND ');
-      query += ' GROUP BY s.id ORDER BY s.start_date DESC LIMIT 1000'; // Bounded at 1000; use pagination for larger datasets.
+      query += ' GROUP BY s.id ORDER BY s.start_date DESC';
+      if (pagination) {
+        query += ' LIMIT ? OFFSET ?';
+        params.push(pagination.limit, pagination.offset);
+      } else {
+        query += ' LIMIT 1000';
+      }
 
       const [rows] = await this.pool.execute<RowDataPacket[]>(query, params);
 
@@ -181,6 +187,38 @@ export class ScheduleService {
       }));
     } catch (error) {
       logger.error('Failed to get all schedules:', error);
+      throw error;
+    }
+  }
+
+  async countSchedules(filters?: {
+    departmentId?: number;
+    status?: string;
+    startDate?: string;
+    endDate?: string;
+    orgUnitIds?: number[];
+  }): Promise<number> {
+    try {
+      let query = `SELECT COUNT(DISTINCT s.id) AS total FROM schedules s LEFT JOIN departments d ON s.department_id = d.id`;
+      const conditions: string[] = [];
+      const params: any[] = [];
+
+      if (filters?.departmentId) { conditions.push('s.department_id = ?'); params.push(filters.departmentId); }
+      if (filters?.status) { conditions.push('s.status = ?'); params.push(filters.status); }
+      if (filters?.startDate) { conditions.push('s.end_date >= ?'); params.push(filters.startDate); }
+      if (filters?.endDate) { conditions.push('s.start_date <= ?'); params.push(filters.endDate); }
+      if (filters?.orgUnitIds && filters.orgUnitIds.length > 0) {
+        const placeholders = filters.orgUnitIds.map(() => '?').join(', ');
+        conditions.push(`d.org_unit_id IN (${placeholders})`);
+        params.push(...filters.orgUnitIds);
+      }
+
+      if (conditions.length > 0) query += ' WHERE ' + conditions.join(' AND ');
+
+      const [rows] = await this.pool.execute<RowDataPacket[]>(query, params);
+      return Number(rows[0]?.total ?? 0);
+    } catch (error) {
+      logger.error('Failed to count schedules:', error);
       throw error;
     }
   }

--- a/backend/src/services/ShiftService.ts
+++ b/backend/src/services/ShiftService.ts
@@ -232,7 +232,7 @@ export class ShiftService {
     endDate?: string;
     status?: string;
     orgUnitIds?: number[];
-  }): Promise<Shift[]> {
+  }, pagination?: { limit: number; offset: number }): Promise<Shift[]> {
     try {
       let query = `
         SELECT 
@@ -286,7 +286,13 @@ export class ShiftService {
         query += ' WHERE ' + conditions.join(' AND ');
       }
 
-      query += ' GROUP BY s.id ORDER BY s.date ASC, s.start_time ASC LIMIT 2000'; // Bounded at 2000; use pagination for larger datasets.
+      query += ' GROUP BY s.id ORDER BY s.date ASC, s.start_time ASC';
+      if (pagination) {
+        query += ' LIMIT ? OFFSET ?';
+        params.push(pagination.limit, pagination.offset);
+      } else {
+        query += ' LIMIT 2000';
+      }
 
       const [rows] = await this.pool.execute<RowDataPacket[]>(query, params);
 
@@ -312,6 +318,40 @@ export class ShiftService {
       return shifts;
     } catch (error) {
       logger.error('Failed to get all shifts:', error);
+      throw error;
+    }
+  }
+
+  async countShifts(filters?: {
+    scheduleId?: number;
+    departmentId?: number;
+    startDate?: string;
+    endDate?: string;
+    status?: string;
+    orgUnitIds?: number[];
+  }): Promise<number> {
+    try {
+      let query = `SELECT COUNT(DISTINCT s.id) AS total FROM shifts s LEFT JOIN departments d ON s.department_id = d.id`;
+      const conditions: string[] = [];
+      const params: any[] = [];
+
+      if (filters?.scheduleId) { conditions.push('s.schedule_id = ?'); params.push(filters.scheduleId); }
+      if (filters?.departmentId) { conditions.push('s.department_id = ?'); params.push(filters.departmentId); }
+      if (filters?.startDate) { conditions.push('s.date >= ?'); params.push(filters.startDate); }
+      if (filters?.endDate) { conditions.push('s.date <= ?'); params.push(filters.endDate); }
+      if (filters?.status) { conditions.push('s.status = ?'); params.push(filters.status); }
+      if (filters?.orgUnitIds && filters.orgUnitIds.length > 0) {
+        const placeholders = filters.orgUnitIds.map(() => '?').join(', ');
+        conditions.push(`d.org_unit_id IN (${placeholders})`);
+        params.push(...filters.orgUnitIds);
+      }
+
+      if (conditions.length > 0) query += ' WHERE ' + conditions.join(' AND ');
+
+      const [rows] = await this.pool.execute<RowDataPacket[]>(query, params);
+      return Number(rows[0]?.total ?? 0);
+    } catch (error) {
+      logger.error('Failed to count shifts:', error);
       throw error;
     }
   }

--- a/backend/src/services/UserService.ts
+++ b/backend/src/services/UserService.ts
@@ -504,14 +504,15 @@ export class UserService {
    */
   async getUsersForManager(
     actor: User,
-    filters: { search?: string; departmentId?: number } = {}
+    filters: { search?: string; departmentId?: number } = {},
+    pagination?: { limit: number; offset: number }
   ): Promise<User[]> {
     try {
-      if (actor.permissions?.includes('settings.manage')) return this.getAllUsers(filters);
+      if (actor.permissions?.includes('settings.manage')) return this.getAllUsers(filters, pagination);
 
       const params: (string | number)[] = [actor.id];
       let sql = `SELECT DISTINCT u.id, u.email, u.first_name, u.last_name,
-                u.employee_id, u.phone, u.is_active, u.last_login,
+                u.employee_id, u.phone, u.position, u.hourly_rate, u.is_active, u.last_login,
                 u.created_at, u.updated_at,
                 d.name AS department_name
          FROM users u
@@ -530,7 +531,13 @@ export class UserService {
         params.push(filters.departmentId);
       }
 
-      sql += ` ORDER BY u.last_name ASC, u.first_name ASC LIMIT 1000`; // Hard cap — use pagination for larger teams.
+      sql += ` ORDER BY u.last_name ASC, u.first_name ASC`;
+      if (pagination) {
+        sql += ` LIMIT ? OFFSET ?`;
+        params.push(pagination.limit, pagination.offset);
+      } else {
+        sql += ` LIMIT 1000`;
+      }
 
       const [userRows] = await this.pool.execute<RowDataPacket[]>(sql, params);
 
@@ -541,6 +548,8 @@ export class UserService {
         lastName: row.last_name,
         employeeId: row.employee_id,
         phone: row.phone,
+        position: row.position ?? undefined,
+        hourlyRate: row.hourly_rate != null ? Number(row.hourly_rate) : undefined,
         isActive: Boolean(row.is_active),
         lastLogin: row.last_login,
         department: row.department_name ?? undefined,
@@ -549,6 +558,38 @@ export class UserService {
       }));
     } catch (error) {
       logger.error('Failed to get users for manager:', error);
+      throw error;
+    }
+  }
+
+  async countUsersForManager(
+    actor: User,
+    filters: { search?: string; departmentId?: number } = {}
+  ): Promise<number> {
+    if (actor.permissions?.includes('settings.manage')) return this.countUsers(filters);
+    try {
+      const params: (string | number)[] = [actor.id];
+      let sql = `SELECT COUNT(DISTINCT u.id) AS total
+         FROM users u
+         JOIN user_departments ud ON u.id = ud.user_id
+         JOIN departments d ON ud.department_id = d.id
+         WHERE d.manager_id = ?`;
+
+      if (filters.search) {
+        sql += ` AND (u.first_name LIKE ? OR u.last_name LIKE ? OR u.email LIKE ? OR u.employee_id LIKE ?)`;
+        const term = `%${filters.search}%`;
+        params.push(term, term, term, term);
+      }
+
+      if (filters.departmentId) {
+        sql += ` AND ud.department_id = ?`;
+        params.push(filters.departmentId);
+      }
+
+      const [rows] = await this.pool.execute<RowDataPacket[]>(sql, params);
+      return Number(rows[0]?.total ?? 0);
+    } catch (error) {
+      logger.error('Failed to count users for manager:', error);
       throw error;
     }
   }


### PR DESCRIPTION
## Summary
- `GET /users`, `GET /schedules`, and `GET /shifts` were loading full result sets into memory before slicing for pagination. Each route now uses `LIMIT ? OFFSET ?` with a parallel `COUNT` query, consistent with the employees route pattern from PR #171.
- `UserService.getUsersForManager` now accepts an optional `pagination` param and also returns `position`/`hourlyRate` fields that were missing from its SELECT.
- New methods: `UserService.countUsersForManager`, `ScheduleService.countSchedules`, `ShiftService.countShifts`.

## Test plan
- [ ] Backend unit tests pass (122 tests)
- [ ] `GET /users?page=1&limit=10` returns correct `meta.total` and only 10 rows
- [ ] `GET /schedules?page=1&limit=5` and `GET /shifts?page=1&limit=20` behave the same
- [ ] Without pagination params, all routes fall back to the unbounded response as before