### PR TITLE
fix: complete POST /users OpenAPI schema; remove blank maxHoursPerWeek column

### DIFF
--- a/backend/openapi/openapi.json
+++ b/backend/openapi/openapi.json
@@ -1212,6 +1212,31 @@
                     "items": {
                       "type": "integer"
                     }
+                  },
+                  "employeeId": {
+                    "type": "string"
+                  },
+                  "phone": {
+                    "type": "string"
+                  },
+                  "position": {
+                    "type": "string"
+                  },
+                  "hourlyRate": {
+                    "type": "number",
+                    "minimum": 0
+                  },
+                  "departmentIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "integer"
+                    }
+                  },
+                  "skillIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "integer"
+                    }
                   }
                 }
               }

--- a/frontend/src/pages/Employees/Employees.tsx
+++ b/frontend/src/pages/Employees/Employees.tsx
@@ -221,7 +221,6 @@ const Employees: React.FC = () => {
                   <th>Department</th>
                   <th>Position</th>
                   <th>Hourly Rate</th>
-                  <th>Max Hours/Week</th>
                   <th>Status</th>
                   <th style={{ width: '120px' }}>Actions</th>
                 </tr>
@@ -249,7 +248,6 @@ const Employees: React.FC = () => {
                     <td>
                       {employee.hourlyRate ? `€${employee.hourlyRate.toFixed(2)}` : '-'}
                     </td>
-                    <td>{employee.maxHoursPerWeek}</td>
                     <td>
                       <span className={`badge ${
                         employee.isActive ? 'bg-success' : 'bg-secondary'


### PR DESCRIPTION
## Summary
- `POST /users` OpenAPI schema was missing `position`, `hourlyRate`, `employeeId`, `phone`, `departmentIds`, `skillIds` — all fields accepted by the Zod schema (added in PR #173) but not reflected in the spec. CLAUDE.md requires syncing the spec on every code change.
- `maxHoursPerWeek` column in the employees table was always blank: the value lives in `user_preferences`, which `UserService` does not JOIN. Removed the column consistent with how `employeeType` was removed in PR #172.

## Test plan
- [ ] Swagger UI at `/api/docs` shows full POST /users body schema
- [ ] Employees table no longer has a blank Max Hours/Week column
- [ ] CI tests pass