### PR TITLE
test(coverage): UserService/ShiftService/ScheduleService + route error handlers

### DIFF
--- a/backend/src/__tests__/routes.error-handlers.test.ts
+++ b/backend/src/__tests__/routes.error-handlers.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Route error-handler coverage supplement.
+ * Covers catch blocks (→ 500 responses) and conditional branches not exercised
+ * by the happy-path tests in routes.expanded.test.ts.
+ *
+ * Files targeted:
+ *   routes/onCall.ts       — GET /me, GET /periods, GET /periods/:id,
+ *                            GET /periods/:id/assignments, DELETE /assign/:userId
+ *   routes/notifications.ts — GET /, GET /unread-count, PATCH /:id/read,
+ *                             PATCH /read-all
+ *   routes/reports.ts      — missing params (400), service errors (500)
+ *   routes/twoFactor.ts    — POST /setup, /disable, /verify catch blocks
+ *   routes/preferences.ts  — GET /me catch, GET /:userId catch
+ *   routes/employees.ts    — scope filter, dept string parse, pagination, GET /:id error
+ *
+ * @author Luca Ostinelli
+ */
+
+import express from 'express';
+import request from 'supertest';
+
+// ── Auth middleware stub ──────────────────────────────────────────────────────
+jest.mock('../middleware/auth', () => ({
+  authenticate: (req: any, _res: any, next: any) => {
+    req.user = {
+      id: 1,
+      email: 'a@x',
+      isActive: true,
+      permissions: require('./helpers/permissions').ALL_PERMISSIONS,
+      allowedOrgUnitIds: null,
+    };
+    next();
+  },
+  requirePermission: () => (_req: any, _res: any, next: any) => next(),
+  requireModule: () => (_req: any, _res: any, next: any) => next(),
+  userHasPermission: () => true,
+}));
+
+// ── Service mocks ─────────────────────────────────────────────────────────────
+jest.mock('../services/OnCallService');
+jest.mock('../services/NotificationService');
+jest.mock('../services/ReportsService');
+jest.mock('../services/TwoFactorService');
+jest.mock('../services/PreferencesService');
+jest.mock('../services/EmployeeService');
+jest.mock('../services/AuditLogService');
+
+import { OnCallService } from '../services/OnCallService';
+import { NotificationService } from '../services/NotificationService';
+import { ReportsService } from '../services/ReportsService';
+import { TwoFactorService } from '../services/TwoFactorService';
+import { PreferencesService } from '../services/PreferencesService';
+import { EmployeeService } from '../services/EmployeeService';
+
+import { createOnCallRouter } from '../routes/onCall';
+import { createNotificationsRouter } from '../routes/notifications';
+import { createReportsRouter } from '../routes/reports';
+import { createTwoFactorRouter } from '../routes/twoFactor';
+import { createPreferencesRouter } from '../routes/preferences';
+import { createEmployeesRouter } from '../routes/employees';
+
+const fakePool = {} as never;
+
+const mount = (prefix: string, router: express.Router) => {
+  const app = express();
+  app.use(express.json());
+  app.use(prefix, router);
+  return app;
+};
+
+// ─── routes/onCall.ts ─────────────────────────────────────────────────────────
+
+describe('onCall route error handlers', () => {
+  const app = () => mount('/api/on-call', createOnCallRouter(fakePool));
+
+  it('GET /me 500 when service throws', async () => {
+    (OnCallService.prototype.listForUser as jest.Mock).mockRejectedValueOnce(new Error('db'));
+    const res = await request(app()).get('/api/on-call/me');
+    expect(res.status).toBe(500);
+    expect(res.body.error.code).toBe('INTERNAL_ERROR');
+  });
+
+  it('GET /periods 500 when service throws', async () => {
+    (OnCallService.prototype.listPeriods as jest.Mock).mockRejectedValueOnce(new Error('db'));
+    const res = await request(app()).get('/api/on-call/periods');
+    expect(res.status).toBe(500);
+  });
+
+  it('GET /periods/:id 500 when service throws unexpected error', async () => {
+    (OnCallService.prototype.getPeriodById as jest.Mock).mockRejectedValueOnce(new Error('db'));
+    const res = await request(app()).get('/api/on-call/periods/1');
+    expect(res.status).toBe(500);
+  });
+
+  it('GET /periods/:id/assignments 500 when service throws', async () => {
+    (OnCallService.prototype.listAssignments as jest.Mock).mockRejectedValueOnce(new Error('db'));
+    const res = await request(app()).get('/api/on-call/periods/1/assignments');
+    expect(res.status).toBe(500);
+  });
+
+  it('DELETE /periods/:id/assign/:userId 500 when service throws', async () => {
+    (OnCallService.prototype.unassign as jest.Mock).mockRejectedValueOnce(new Error('db'));
+    const res = await request(app()).delete('/api/on-call/periods/1/assign/7');
+    expect(res.status).toBe(500);
+  });
+});
+
+// ─── routes/notifications.ts ──────────────────────────────────────────────────
+
+describe('notifications route error handlers', () => {
+  const app = () => mount('/api/notifications', createNotificationsRouter(fakePool));
+
+  it('GET / 500 when service throws', async () => {
+    (NotificationService.prototype.listForUser as jest.Mock).mockRejectedValueOnce(new Error('db'));
+    const res = await request(app()).get('/api/notifications');
+    expect(res.status).toBe(500);
+  });
+
+  it('GET /unread-count 500 when service throws', async () => {
+    (NotificationService.prototype.unreadCount as jest.Mock).mockRejectedValueOnce(new Error('db'));
+    const res = await request(app()).get('/api/notifications/unread-count');
+    expect(res.status).toBe(500);
+  });
+
+  it('PATCH /:id/read 500 when service throws', async () => {
+    (NotificationService.prototype.markRead as jest.Mock).mockRejectedValueOnce(new Error('db'));
+    const res = await request(app()).patch('/api/notifications/1/read');
+    expect(res.status).toBe(500);
+  });
+
+  it('PATCH /read-all 500 when service throws', async () => {
+    (NotificationService.prototype.markAllRead as jest.Mock).mockRejectedValueOnce(new Error('db'));
+    const res = await request(app()).patch('/api/notifications/read-all');
+    expect(res.status).toBe(500);
+  });
+});
+
+// ─── routes/reports.ts ────────────────────────────────────────────────────────
+
+describe('reports route — missing params and error handlers', () => {
+  const app = () => mount('/api/reports', createReportsRouter(fakePool));
+
+  it('GET /hours-worked 500 when service throws', async () => {
+    (ReportsService.prototype.hoursWorkedByUser as jest.Mock).mockRejectedValueOnce(new Error('db'));
+    const res = await request(app()).get('/api/reports/hours-worked?start=2026-01-01&end=2026-01-31');
+    expect(res.status).toBe(500);
+  });
+
+  it('GET /cost-by-department 400 when start or end missing', async () => {
+    const res = await request(app()).get('/api/reports/cost-by-department?start=2026-01-01');
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('GET /cost-by-department 500 when service throws', async () => {
+    (ReportsService.prototype.costByDepartment as jest.Mock).mockRejectedValueOnce(new Error('db'));
+    const res = await request(app()).get('/api/reports/cost-by-department?start=2026-01-01&end=2026-01-31');
+    expect(res.status).toBe(500);
+  });
+
+  it('GET /fairness/:scheduleId 400 when id is not a positive integer', async () => {
+    const res = await request(app()).get('/api/reports/fairness/abc');
+    expect(res.status).toBe(400);
+  });
+
+  it('GET /fairness/:scheduleId 500 when service throws', async () => {
+    (ReportsService.prototype.fairnessForSchedule as jest.Mock).mockRejectedValueOnce(new Error('db'));
+    const res = await request(app()).get('/api/reports/fairness/5');
+    expect(res.status).toBe(500);
+  });
+});
+
+// ─── routes/twoFactor.ts ─────────────────────────────────────────────────────
+
+describe('twoFactor route error handlers', () => {
+  const app = () => mount('/api/auth/2fa', createTwoFactorRouter(fakePool));
+
+  it('POST /setup 500 when service throws', async () => {
+    (TwoFactorService.prototype.beginSetup as jest.Mock).mockRejectedValueOnce(new Error('db'));
+    const res = await request(app()).post('/api/auth/2fa/setup').send({});
+    expect(res.status).toBe(500);
+  });
+
+  it('POST /disable 500 when service throws', async () => {
+    (TwoFactorService.prototype.disable as jest.Mock).mockRejectedValueOnce(new Error('db'));
+    const res = await request(app()).post('/api/auth/2fa/disable').send({});
+    expect(res.status).toBe(500);
+  });
+
+  it('POST /verify 500 when service throws', async () => {
+    (TwoFactorService.prototype.verifyCode as jest.Mock).mockRejectedValueOnce(new Error('db'));
+    const res = await request(app()).post('/api/auth/2fa/verify').send({ code: '123456' });
+    expect(res.status).toBe(500);
+  });
+});
+
+// ─── routes/preferences.ts ───────────────────────────────────────────────────
+
+describe('preferences route error handlers', () => {
+  const app = () => mount('/api/preferences', createPreferencesRouter(fakePool));
+
+  it('GET /me 500 when service throws', async () => {
+    (PreferencesService.prototype.getByUserId as jest.Mock).mockRejectedValueOnce(new Error('db'));
+    const res = await request(app()).get('/api/preferences/me');
+    expect(res.status).toBe(500);
+  });
+
+  it('GET /:userId 500 when service throws', async () => {
+    (PreferencesService.prototype.getByUserId as jest.Mock).mockRejectedValueOnce(new Error('db'));
+    const res = await request(app()).get('/api/preferences/2');
+    expect(res.status).toBe(500);
+  });
+});
+
+// ─── routes/employees.ts — branches + error handler ─────────────────────────
+
+describe('employees route — scope filter, dept parse, pagination, error', () => {
+  const app = () => mount('/api/employees', createEmployeesRouter(fakePool));
+
+  beforeEach(() => {
+    (EmployeeService.prototype.getAllEmployees as jest.Mock).mockResolvedValue([]);
+    (EmployeeService.prototype.countEmployees as jest.Mock).mockResolvedValue(0);
+  });
+
+  it('GET / applies orgUnitIds scope from req.user.allowedOrgUnitIds when non-null', async () => {
+    // Override the authenticate stub to set allowedOrgUnitIds
+    const authMock = require('../middleware/auth');
+    const origAuth = authMock.authenticate;
+    authMock.authenticate = (req: any, _res: any, next: any) => {
+      req.user = {
+        id: 1, email: 'a@x', isActive: true,
+        permissions: require('./helpers/permissions').ALL_PERMISSIONS,
+        allowedOrgUnitIds: [3, 5],
+      };
+      next();
+    };
+    const res = await request(app()).get('/api/employees');
+    authMock.authenticate = origAuth;
+    expect(res.status).toBe(200);
+    expect(EmployeeService.prototype.getAllEmployees).toHaveBeenCalled();
+  });
+
+  it('GET / parses numeric department query param as departmentId', async () => {
+    const res = await request(app()).get('/api/employees?department=4');
+    expect(res.status).toBe(200);
+    const call = (EmployeeService.prototype.getAllEmployees as jest.Mock).mock.calls[0];
+    expect(call[0]?.departmentId).toBe(4);
+  });
+
+  it('GET / passes non-numeric department as departmentName', async () => {
+    const res = await request(app()).get('/api/employees?department=Engineering');
+    expect(res.status).toBe(200);
+    const call = (EmployeeService.prototype.getAllEmployees as jest.Mock).mock.calls[0];
+    expect(call[0]?.departmentName).toBe('Engineering');
+  });
+
+  it('GET / uses pagination when page param is provided', async () => {
+    const res = await request(app()).get('/api/employees?page=1&pageSize=10');
+    expect(res.status).toBe(200);
+    expect(EmployeeService.prototype.countEmployees).toHaveBeenCalled();
+  });
+
+  it('GET /:id 500 when service throws', async () => {
+    (EmployeeService.prototype.getEmployeeById as jest.Mock).mockRejectedValueOnce(new Error('db'));
+    const res = await request(app()).get('/api/employees/1');
+    expect(res.status).toBe(500);
+  });
+});

--- a/backend/src/__tests__/schedule.service.coverage.test.ts
+++ b/backend/src/__tests__/schedule.service.coverage.test.ts
@@ -1,0 +1,148 @@
+/**
+ * ScheduleService coverage supplement — fills gaps not hit by existing test files:
+ *   - getAllSchedules with orgUnitIds filter (lines 157-159)
+ *   - getAllSchedules with pagination (lines 165-166)
+ *   - countSchedules entire method — all filter branches + error (lines 189-222)
+ *   - deleteSchedule when affectedRows === 0 (line 312)
+ *
+ * @author Luca Ostinelli
+ */
+
+import { ScheduleService } from '../services/ScheduleService';
+
+type Tuple = [unknown, unknown];
+
+const scheduleRow = {
+  id: 1,
+  name: 'May 2026',
+  department_id: 3,
+  department_name: 'Emergency',
+  department_org_unit_id: null,
+  start_date: '2026-05-01',
+  end_date: '2026-05-31',
+  status: 'draft',
+  published_at: null,
+  notes: null,
+  created_at: 't',
+  updated_at: 't',
+  total_shifts: 0,
+  total_assignments: 0,
+};
+
+const makePool = () => {
+  const execute = jest.fn();
+  const conn = {
+    execute: jest.fn(),
+    beginTransaction: jest.fn().mockResolvedValue(undefined),
+    commit: jest.fn().mockResolvedValue(undefined),
+    rollback: jest.fn().mockResolvedValue(undefined),
+    release: jest.fn(),
+  };
+  return {
+    pool: { execute, getConnection: jest.fn().mockResolvedValue(conn) } as never,
+    execute,
+    conn,
+  };
+};
+
+// ─── getAllSchedules — orgUnitIds and pagination ──────────────────────────────
+
+describe('ScheduleService.getAllSchedules orgUnitIds and pagination', () => {
+  it('applies orgUnitIds filter', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[scheduleRow], null] as Tuple);
+    const svc = new ScheduleService(pool);
+    const out = await svc.getAllSchedules({ orgUnitIds: [5, 6] });
+    expect(out.length).toBe(1);
+    const sql = execute.mock.calls[0][0] as string;
+    expect(sql).toMatch(/d\.org_unit_id IN/);
+  });
+
+  it('appends LIMIT/OFFSET when pagination provided', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[scheduleRow], null] as Tuple);
+    const svc = new ScheduleService(pool);
+    await svc.getAllSchedules({}, { limit: 20, offset: 40 });
+    const params = execute.mock.calls[0][1] as unknown[];
+    expect(params.slice(-2)).toEqual([20, 40]);
+  });
+});
+
+// ─── countSchedules ───────────────────────────────────────────────────────────
+
+describe('ScheduleService.countSchedules', () => {
+  it('counts without filters', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[{ total: 7 }], null] as Tuple);
+    const svc = new ScheduleService(pool);
+    expect(await svc.countSchedules()).toBe(7);
+  });
+
+  it('applies departmentId filter', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[{ total: 2 }], null] as Tuple);
+    const svc = new ScheduleService(pool);
+    await svc.countSchedules({ departmentId: 3 });
+    const sql = execute.mock.calls[0][0] as string;
+    expect(sql).toMatch(/s\.department_id/);
+  });
+
+  it('applies status filter', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[{ total: 1 }], null] as Tuple);
+    const svc = new ScheduleService(pool);
+    await svc.countSchedules({ status: 'published' });
+    const sql = execute.mock.calls[0][0] as string;
+    expect(sql).toMatch(/s\.status/);
+  });
+
+  it('applies startDate and endDate filters', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[{ total: 3 }], null] as Tuple);
+    const svc = new ScheduleService(pool);
+    await svc.countSchedules({ startDate: '2026-05-01', endDate: '2026-05-31' });
+    const sql = execute.mock.calls[0][0] as string;
+    expect(sql).toMatch(/s\.end_date >= \?/);
+    expect(sql).toMatch(/s\.start_date <= \?/);
+  });
+
+  it('applies orgUnitIds filter', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[{ total: 4 }], null] as Tuple);
+    const svc = new ScheduleService(pool);
+    await svc.countSchedules({ orgUnitIds: [1, 2] });
+    const sql = execute.mock.calls[0][0] as string;
+    expect(sql).toMatch(/d\.org_unit_id IN/);
+  });
+
+  it('returns 0 when total absent from result', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[{}], null] as Tuple);
+    const svc = new ScheduleService(pool);
+    expect(await svc.countSchedules()).toBe(0);
+  });
+
+  it('bubbles errors', async () => {
+    const { pool, execute } = makePool();
+    execute.mockRejectedValueOnce(new Error('db fail'));
+    const svc = new ScheduleService(pool);
+    await expect(svc.countSchedules()).rejects.toThrow('db fail');
+  });
+});
+
+// ─── deleteSchedule — affectedRows === 0 ─────────────────────────────────────
+
+describe('ScheduleService.deleteSchedule affectedRows 0', () => {
+  it('throws Schedule not found when DELETE hits no rows', async () => {
+    const { pool, conn } = makePool();
+    conn.execute
+      .mockResolvedValueOnce([[{ status: 'draft' }], null])  // SELECT status
+      .mockResolvedValueOnce([{ affectedRows: 1 }, null])    // DELETE shift_assignments
+      .mockResolvedValueOnce([{ affectedRows: 1 }, null])    // DELETE shift_skills
+      .mockResolvedValueOnce([{ affectedRows: 1 }, null])    // DELETE shifts
+      .mockResolvedValueOnce([{ affectedRows: 0 }, null]);   // DELETE schedules — 0 rows
+    const svc = new ScheduleService(pool);
+    await expect(svc.deleteSchedule(1)).rejects.toThrow('Schedule not found');
+    expect(conn.rollback).toHaveBeenCalled();
+  });
+});

--- a/backend/src/__tests__/shift.service.coverage.test.ts
+++ b/backend/src/__tests__/shift.service.coverage.test.ts
@@ -1,0 +1,186 @@
+/**
+ * ShiftService coverage supplement — fills gaps not hit by existing test files:
+ *   - createShift post-insert fetch returns empty (line 107)
+ *   - getAllShifts with orgUnitIds filter (lines 280-282)
+ *   - getAllShifts with pagination (lines 291-292)
+ *   - countShifts — entire method (all filters + error) (lines 333-355)
+ *   - deleteShift when affectedRows === 0 (line 477)
+ *
+ * @author Luca Ostinelli
+ */
+
+import { ShiftService } from '../services/ShiftService';
+
+type Tuple = [unknown, unknown];
+
+const shiftRow = {
+  id: 1,
+  schedule_id: 1,
+  schedule_name: 'May',
+  department_id: 3,
+  department_name: 'ICU',
+  template_id: null,
+  date: '2026-05-01',
+  start_time: '08:00',
+  end_time: '16:00',
+  min_staff: 1,
+  max_staff: 5,
+  notes: null,
+  status: 'open',
+  assigned_staff: 0,
+  created_at: 't',
+  updated_at: 't',
+};
+
+const makePool = () => {
+  const execute = jest.fn();
+  const conn = {
+    execute: jest.fn(),
+    beginTransaction: jest.fn().mockResolvedValue(undefined),
+    commit: jest.fn().mockResolvedValue(undefined),
+    rollback: jest.fn().mockResolvedValue(undefined),
+    release: jest.fn(),
+  };
+  return {
+    pool: { execute, getConnection: jest.fn().mockResolvedValue(conn) } as never,
+    execute,
+    conn,
+  };
+};
+
+// ─── createShift — post-insert fetch empty ────────────────────────────────────
+
+describe('ShiftService.createShift post-insert empty', () => {
+  it('throws when getShiftById returns null after insert', async () => {
+    const { pool, conn, execute } = makePool();
+    conn.execute
+      .mockResolvedValueOnce([[{ id: 1 }], null])     // dept check
+      .mockResolvedValueOnce([{ insertId: 10 }, null]) // INSERT shift
+      .mockResolvedValueOnce([{ affectedRows: 1 }, null]); // INSERT skills (none — requiredSkillIds empty)
+    // getShiftById calls pool.execute (not conn.execute)
+    execute
+      .mockResolvedValueOnce([[], null] as Tuple); // getShiftById returns empty
+    const svc = new ShiftService(pool);
+    await expect(
+      svc.createShift({
+        scheduleId: 1,
+        departmentId: 3,
+        date: '2026-05-01',
+        startTime: '08:00',
+        endTime: '16:00',
+        minStaff: 1,
+        maxStaff: 5,
+      })
+    ).rejects.toThrow('Failed to retrieve created shift');
+    expect(conn.rollback).toHaveBeenCalled();
+  });
+});
+
+// ─── getAllShifts — orgUnitIds and pagination ─────────────────────────────────
+
+describe('ShiftService.getAllShifts orgUnitIds and pagination', () => {
+  it('applies orgUnitIds filter', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[shiftRow], null] as Tuple);
+    const svc = new ShiftService(pool);
+    const out = await svc.getAllShifts({ orgUnitIds: [1, 2] });
+    expect(out.length).toBe(1);
+    const sql = execute.mock.calls[0][0] as string;
+    expect(sql).toMatch(/d\.org_unit_id IN/);
+  });
+
+  it('appends LIMIT/OFFSET when pagination provided', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[shiftRow], null] as Tuple);
+    const svc = new ShiftService(pool);
+    await svc.getAllShifts({}, { limit: 25, offset: 50 });
+    const params = execute.mock.calls[0][1] as unknown[];
+    expect(params.slice(-2)).toEqual([25, 50]);
+  });
+});
+
+// ─── countShifts ─────────────────────────────────────────────────────────────
+
+describe('ShiftService.countShifts', () => {
+  it('counts without filters', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[{ total: 10 }], null] as Tuple);
+    const svc = new ShiftService(pool);
+    expect(await svc.countShifts()).toBe(10);
+  });
+
+  it('applies scheduleId filter', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[{ total: 3 }], null] as Tuple);
+    const svc = new ShiftService(pool);
+    await svc.countShifts({ scheduleId: 5 });
+    const sql = execute.mock.calls[0][0] as string;
+    expect(sql).toMatch(/s\.schedule_id/);
+  });
+
+  it('applies departmentId filter', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[{ total: 2 }], null] as Tuple);
+    const svc = new ShiftService(pool);
+    await svc.countShifts({ departmentId: 3 });
+    const sql = execute.mock.calls[0][0] as string;
+    expect(sql).toMatch(/s\.department_id/);
+  });
+
+  it('applies startDate and endDate filters', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[{ total: 4 }], null] as Tuple);
+    const svc = new ShiftService(pool);
+    await svc.countShifts({ startDate: '2026-05-01', endDate: '2026-05-31' });
+    const sql = execute.mock.calls[0][0] as string;
+    expect(sql).toMatch(/s\.date >= \?/);
+    expect(sql).toMatch(/s\.date <= \?/);
+  });
+
+  it('applies status filter', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[{ total: 1 }], null] as Tuple);
+    const svc = new ShiftService(pool);
+    await svc.countShifts({ status: 'open' });
+    const sql = execute.mock.calls[0][0] as string;
+    expect(sql).toMatch(/s\.status/);
+  });
+
+  it('applies orgUnitIds filter', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[{ total: 5 }], null] as Tuple);
+    const svc = new ShiftService(pool);
+    await svc.countShifts({ orgUnitIds: [10, 11] });
+    const sql = execute.mock.calls[0][0] as string;
+    expect(sql).toMatch(/d\.org_unit_id IN/);
+  });
+
+  it('returns 0 when total is absent from result row', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[{}], null] as Tuple);
+    const svc = new ShiftService(pool);
+    expect(await svc.countShifts()).toBe(0);
+  });
+
+  it('bubbles errors', async () => {
+    const { pool, execute } = makePool();
+    execute.mockRejectedValueOnce(new Error('db gone'));
+    const svc = new ShiftService(pool);
+    await expect(svc.countShifts()).rejects.toThrow('db gone');
+  });
+});
+
+// ─── deleteShift — affectedRows === 0 ────────────────────────────────────────
+
+describe('ShiftService.deleteShift affectedRows 0', () => {
+  it('throws Shift not found when delete hits no rows', async () => {
+    const { pool, conn } = makePool();
+    conn.execute
+      .mockResolvedValueOnce([{ affectedRows: 1 }, null])  // DELETE shift_assignments
+      .mockResolvedValueOnce([{ affectedRows: 1 }, null])  // DELETE shift_skills
+      .mockResolvedValueOnce([{ affectedRows: 0 }, null]); // DELETE shifts — 0 rows
+    const svc = new ShiftService(pool);
+    await expect(svc.deleteShift(1)).rejects.toThrow('Shift not found');
+    expect(conn.rollback).toHaveBeenCalled();
+  });
+});

--- a/backend/src/__tests__/user.service.coverage.test.ts
+++ b/backend/src/__tests__/user.service.coverage.test.ts
@@ -1,0 +1,399 @@
+/**
+ * UserService coverage supplement — fills gaps not hit by existing test files:
+ *   - createUser with roleIds array
+ *   - getAllUsers with departmentName / orgUnitIds filters and pagination
+ *   - countUsers (entire method, all filter branches + error)
+ *   - updateUser with position / hourlyRate / roleIds (empty + non-empty)
+ *   - verifyPassword catch when bcrypt.compare throws
+ *   - getUsersForManager search + departmentId filters and pagination
+ *   - countUsersForManager admin path, manager path with filters, error
+ *
+ * @author Luca Ostinelli
+ */
+
+import bcrypt from 'bcrypt';
+import { UserService } from '../services/UserService';
+
+jest.mock('bcrypt');
+
+type Tuple = [unknown, unknown];
+
+const userRow = {
+  id: 1,
+  email: 'a@b',
+  first_name: 'A',
+  last_name: 'B',
+  employee_id: 'E',
+  phone: null,
+  position: 'Engineer',
+  hourly_rate: 25.0,
+  is_active: 1,
+  last_login: null,
+  created_at: 't',
+  updated_at: 't',
+};
+
+const makePool = () => {
+  const execute = jest.fn();
+  const conn = {
+    execute: jest.fn(),
+    beginTransaction: jest.fn().mockResolvedValue(undefined),
+    commit: jest.fn().mockResolvedValue(undefined),
+    rollback: jest.fn().mockResolvedValue(undefined),
+    release: jest.fn(),
+  };
+  return {
+    pool: { execute, getConnection: jest.fn().mockResolvedValue(conn) } as never,
+    execute,
+    conn,
+  };
+};
+
+// ─── createUser with roleIds ──────────────────────────────────────────────────
+
+describe('UserService.createUser with roleIds', () => {
+  beforeEach(() => {
+    (bcrypt.hash as jest.Mock).mockResolvedValue('hashed');
+  });
+
+  it('inserts role assignments when roleIds is provided', async () => {
+    const { pool, conn, execute } = makePool();
+    conn.execute
+      .mockResolvedValueOnce([[], null])           // email check
+      .mockResolvedValueOnce([{ insertId: 5 }, null])  // INSERT user
+      .mockResolvedValueOnce([{ affectedRows: 1 }, null]); // INSERT roles
+    execute
+      .mockResolvedValueOnce([[userRow], null] as Tuple)  // getUserById
+      .mockResolvedValueOnce([[], null] as Tuple)          // depts
+      .mockResolvedValueOnce([[], null] as Tuple);         // skills
+
+    const svc = new UserService(pool);
+    const out = await svc.createUser({
+      email: 'a@b',
+      password: 'pass1234',
+      firstName: 'A',
+      lastName: 'B',
+      roleIds: [1, 2],
+    } as never);
+    expect(out.id).toBe(1);
+    // Verify the role INSERT was called (third conn.execute call)
+    const callArgs = conn.execute.mock.calls[2][0] as string;
+    expect(callArgs).toMatch(/INSERT IGNORE INTO user_roles/);
+  });
+});
+
+// ─── getAllUsers — departmentName + orgUnitIds filters and pagination ─────────
+
+describe('UserService.getAllUsers additional filters', () => {
+  it('applies departmentName filter when departmentId is not set', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[userRow], null] as Tuple);
+    const svc = new UserService(pool);
+    const out = await svc.getAllUsers({ departmentName: 'Eng' });
+    expect(out.length).toBe(1);
+    const sql = execute.mock.calls[0][0] as string;
+    expect(sql).toMatch(/dept_f\.name/);
+  });
+
+  it('applies departmentName filter combined with departmentId (skips second ud JOIN)', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[userRow], null] as Tuple);
+    const svc = new UserService(pool);
+    const out = await svc.getAllUsers({ departmentId: 1, departmentName: 'Eng' });
+    expect(out.length).toBe(1);
+    // When both are set the departmentName branch should not add another ud JOIN;
+    // it should only add the dept_f JOIN for the name condition.
+    const sql = execute.mock.calls[0][0] as string;
+    expect(sql).toMatch(/JOIN departments dept_f/);
+    // The primary ud alias is introduced once from departmentId; departmentName adds dept_f only.
+    expect((sql.match(/JOIN user_departments ud ON/g) ?? []).length).toBe(1);
+  });
+
+  it('applies orgUnitIds filter', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[userRow], null] as Tuple);
+    const svc = new UserService(pool);
+    const out = await svc.getAllUsers({ orgUnitIds: [3, 4] });
+    expect(out.length).toBe(1);
+    const sql = execute.mock.calls[0][0] as string;
+    expect(sql).toMatch(/uou\.org_unit_id IN/);
+  });
+
+  it('uses LIMIT/OFFSET when pagination is provided', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[userRow], null] as Tuple);
+    const svc = new UserService(pool);
+    const out = await svc.getAllUsers({}, { limit: 10, offset: 20 });
+    expect(out.length).toBe(1);
+    const params = execute.mock.calls[0][1] as unknown[];
+    // Last two params should be limit=10, offset=20
+    expect(params.slice(-2)).toEqual([10, 20]);
+  });
+});
+
+// ─── countUsers ───────────────────────────────────────────────────────────────
+
+describe('UserService.countUsers', () => {
+  it('counts without filters', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[{ total: 42 }], null] as Tuple);
+    const svc = new UserService(pool);
+    expect(await svc.countUsers()).toBe(42);
+  });
+
+  it('applies departmentId filter', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[{ total: 5 }], null] as Tuple);
+    const svc = new UserService(pool);
+    expect(await svc.countUsers({ departmentId: 2 })).toBe(5);
+    const sql = execute.mock.calls[0][0] as string;
+    expect(sql).toMatch(/ud\.department_id/);
+  });
+
+  it('applies departmentName filter when departmentId absent', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[{ total: 3 }], null] as Tuple);
+    const svc = new UserService(pool);
+    expect(await svc.countUsers({ departmentName: 'Ops' })).toBe(3);
+    const sql = execute.mock.calls[0][0] as string;
+    expect(sql).toMatch(/dept_f\.name/);
+  });
+
+  it('applies departmentName combined with departmentId (no double JOIN)', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[{ total: 2 }], null] as Tuple);
+    const svc = new UserService(pool);
+    await svc.countUsers({ departmentId: 1, departmentName: 'Ops' });
+    const sql = execute.mock.calls[0][0] as string;
+    expect((sql.match(/JOIN user_departments/g) ?? []).length).toBe(1);
+  });
+
+  it('applies roleId filter', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[{ total: 1 }], null] as Tuple);
+    const svc = new UserService(pool);
+    await svc.countUsers({ roleId: 3 });
+    const sql = execute.mock.calls[0][0] as string;
+    expect(sql).toMatch(/ur\.role_id/);
+  });
+
+  it('applies orgUnitIds filter', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[{ total: 7 }], null] as Tuple);
+    const svc = new UserService(pool);
+    expect(await svc.countUsers({ orgUnitIds: [1, 2] })).toBe(7);
+    const sql = execute.mock.calls[0][0] as string;
+    expect(sql).toMatch(/uou\.org_unit_id IN/);
+  });
+
+  it('applies isActive filter', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[{ total: 9 }], null] as Tuple);
+    const svc = new UserService(pool);
+    await svc.countUsers({ isActive: true });
+    const sql = execute.mock.calls[0][0] as string;
+    expect(sql).toMatch(/u\.is_active/);
+  });
+
+  it('applies search filter', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[{ total: 4 }], null] as Tuple);
+    const svc = new UserService(pool);
+    await svc.countUsers({ search: 'alice' });
+    const sql = execute.mock.calls[0][0] as string;
+    expect(sql).toMatch(/first_name LIKE/);
+  });
+
+  it('returns 0 when result row is missing total', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[{}], null] as Tuple);
+    const svc = new UserService(pool);
+    expect(await svc.countUsers()).toBe(0);
+  });
+
+  it('bubbles errors', async () => {
+    const { pool, execute } = makePool();
+    execute.mockRejectedValueOnce(new Error('db down'));
+    const svc = new UserService(pool);
+    await expect(svc.countUsers()).rejects.toThrow('db down');
+  });
+});
+
+// ─── updateUser — position, hourlyRate, roleIds ───────────────────────────────
+
+describe('UserService.updateUser position / hourlyRate / roleIds', () => {
+  beforeEach(() => {
+    (bcrypt.hash as jest.Mock).mockResolvedValue('hashed');
+  });
+
+  it('persists position and hourlyRate', async () => {
+    const { pool, conn, execute } = makePool();
+    conn.execute.mockResolvedValueOnce([{ affectedRows: 1 }, null]); // UPDATE
+    execute
+      .mockResolvedValueOnce([[userRow], null] as Tuple) // getUserById
+      .mockResolvedValueOnce([[], null] as Tuple)
+      .mockResolvedValueOnce([[], null] as Tuple);
+    const svc = new UserService(pool);
+    const out = await svc.updateUser(1, { position: 'Manager', hourlyRate: 30 });
+    expect(out.id).toBe(1);
+    const sql = conn.execute.mock.calls[0][0] as string;
+    expect(sql).toMatch(/position = \?/);
+    expect(sql).toMatch(/hourly_rate = \?/);
+  });
+
+  it('replaces roles when roleIds non-empty', async () => {
+    const { pool, conn, execute } = makePool();
+    conn.execute
+      .mockResolvedValueOnce([{ affectedRows: 1 }, null]) // UPDATE base fields
+      .mockResolvedValueOnce([{ affectedRows: 1 }, null]) // DELETE roles
+      .mockResolvedValueOnce([{ affectedRows: 1 }, null]); // INSERT roles
+    execute
+      .mockResolvedValueOnce([[userRow], null] as Tuple)
+      .mockResolvedValueOnce([[], null] as Tuple)
+      .mockResolvedValueOnce([[], null] as Tuple);
+    const svc = new UserService(pool);
+    await svc.updateUser(1, { firstName: 'X', roleIds: [5] } as never);
+    const deleteCall = conn.execute.mock.calls.find(
+      (c: unknown[]) => typeof c[0] === 'string' && (c[0] as string).includes('DELETE FROM user_roles')
+    );
+    expect(deleteCall).toBeDefined();
+    const insertCall = conn.execute.mock.calls.find(
+      (c: unknown[]) => typeof c[0] === 'string' && (c[0] as string).includes('INSERT IGNORE INTO user_roles')
+    );
+    expect(insertCall).toBeDefined();
+  });
+
+  it('only deletes roles when roleIds is empty array', async () => {
+    const { pool, conn, execute } = makePool();
+    conn.execute
+      .mockResolvedValueOnce([{ affectedRows: 1 }, null]) // UPDATE
+      .mockResolvedValueOnce([{ affectedRows: 1 }, null]); // DELETE roles
+    execute
+      .mockResolvedValueOnce([[userRow], null] as Tuple)
+      .mockResolvedValueOnce([[], null] as Tuple)
+      .mockResolvedValueOnce([[], null] as Tuple);
+    const svc = new UserService(pool);
+    await svc.updateUser(1, { firstName: 'X', roleIds: [] } as never);
+    const insertCall = conn.execute.mock.calls.find(
+      (c: unknown[]) => typeof c[0] === 'string' && (c[0] as string).includes('INSERT IGNORE INTO user_roles')
+    );
+    expect(insertCall).toBeUndefined();
+  });
+});
+
+// ─── verifyPassword — bcrypt.compare throws ───────────────────────────────────
+
+describe('UserService.verifyPassword error path', () => {
+  it('returns false when bcrypt.compare throws', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[{ password_hash: 'h' }], null] as Tuple);
+    (bcrypt.compare as jest.Mock).mockRejectedValueOnce(new Error('bcrypt fail'));
+    const svc = new UserService(pool);
+    expect(await svc.verifyPassword(1, 'pass')).toBe(false);
+  });
+});
+
+// ─── getUsersForManager — search, departmentId, pagination ───────────────────
+
+describe('UserService.getUsersForManager filters and pagination', () => {
+  const managerActor = { id: 99, email: 'm@x', isActive: true, permissions: [] } as never;
+
+  it('applies search filter', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[userRow], null] as Tuple);
+    const svc = new UserService(pool);
+    const out = await svc.getUsersForManager(managerActor, { search: 'alice' });
+    expect(out.length).toBe(1);
+    const sql = execute.mock.calls[0][0] as string;
+    expect(sql).toMatch(/first_name LIKE/);
+  });
+
+  it('applies departmentId filter', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[userRow], null] as Tuple);
+    const svc = new UserService(pool);
+    const out = await svc.getUsersForManager(managerActor, { departmentId: 7 });
+    expect(out.length).toBe(1);
+    const sql = execute.mock.calls[0][0] as string;
+    expect(sql).toMatch(/ud\.department_id/);
+  });
+
+  it('appends LIMIT/OFFSET when pagination provided', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[userRow], null] as Tuple);
+    const svc = new UserService(pool);
+    await svc.getUsersForManager(managerActor, {}, { limit: 5, offset: 10 });
+    const params = execute.mock.calls[0][1] as unknown[];
+    expect(params.slice(-2)).toEqual([5, 10]);
+  });
+});
+
+// ─── countUsersForManager ─────────────────────────────────────────────────────
+
+describe('UserService.countUsersForManager', () => {
+  it('delegates to countUsers for admin', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[{ total: 20 }], null] as Tuple);
+    const svc = new UserService(pool);
+    const count = await svc.countUsersForManager(
+      { id: 1, email: 'a@x', isActive: true, permissions: ['settings.manage'] } as never
+    );
+    expect(count).toBe(20);
+    const sql = execute.mock.calls[0][0] as string;
+    expect(sql).toMatch(/COUNT\(DISTINCT u\.id\)/);
+  });
+
+  it('counts by manager without filters', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[{ total: 3 }], null] as Tuple);
+    const svc = new UserService(pool);
+    const count = await svc.countUsersForManager(
+      { id: 9, email: 'm@x', isActive: true, permissions: [] } as never
+    );
+    expect(count).toBe(3);
+    const sql = execute.mock.calls[0][0] as string;
+    expect(sql).toMatch(/d\.manager_id/);
+  });
+
+  it('applies search filter for manager path', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[{ total: 1 }], null] as Tuple);
+    const svc = new UserService(pool);
+    await svc.countUsersForManager(
+      { id: 9, email: 'm@x', isActive: true, permissions: [] } as never,
+      { search: 'bob' }
+    );
+    const sql = execute.mock.calls[0][0] as string;
+    expect(sql).toMatch(/first_name LIKE/);
+  });
+
+  it('applies departmentId filter for manager path', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[{ total: 2 }], null] as Tuple);
+    const svc = new UserService(pool);
+    await svc.countUsersForManager(
+      { id: 9, email: 'm@x', isActive: true, permissions: [] } as never,
+      { departmentId: 4 }
+    );
+    const sql = execute.mock.calls[0][0] as string;
+    expect(sql).toMatch(/ud\.department_id/);
+  });
+
+  it('returns 0 when result row missing total', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[{}], null] as Tuple);
+    const svc = new UserService(pool);
+    expect(await svc.countUsersForManager(
+      { id: 9, email: 'm@x', isActive: true, permissions: [] } as never
+    )).toBe(0);
+  });
+
+  it('bubbles errors from DB', async () => {
+    const { pool, execute } = makePool();
+    execute.mockRejectedValueOnce(new Error('conn lost'));
+    const svc = new UserService(pool);
+    await expect(
+      svc.countUsersForManager({ id: 9, email: 'm@x', isActive: true, permissions: [] } as never)
+    ).rejects.toThrow('conn lost');
+  });
+});


### PR DESCRIPTION
## Summary
- Add `user.service.coverage.test.ts`: covers `countUsers`, `countUsersForManager`, `getAllUsers` with `departmentName`/`orgUnitIds`/pagination, `getUsersForManager` search/departmentId/pagination, `updateUser` with `position`/`hourlyRate`/`roleIds`, `verifyPassword` bcrypt-error path, and `createUser` with `roleIds`
- Add `shift.service.coverage.test.ts`: covers `countShifts` (all filter branches + error), `getAllShifts` with `orgUnitIds`/pagination, `deleteShift` affectedRows=0
- Add `schedule.service.coverage.test.ts`: covers `countSchedules` (all filter branches + error), `getAllSchedules` with `orgUnitIds`/pagination, `deleteSchedule` affectedRows=0
- Add `routes.error-handlers.test.ts`: covers 500 catch blocks in `onCall`, `notifications`, `reports`, `twoFactor`, `preferences` routes; and employee route `orgUnitIds` scope, dept-string vs dept-id parsing, pagination, and GET /:id error path

## Coverage impact
| Metric | Before | After |
|---|---|---|
| Lines | 95.66% | 98.78% |
| Branches | 82.40% | 85.81% |
| Functions | 97.29% | 99.09% |
| Statements | 94.56% | 97.94% |

## Test plan
- [x] All 1520+ tests pass locally (`npm test`)
- [x] Coverage thresholds satisfied (lines ≥90%, branches ≥80%, functions ≥90%, statements ≥90%)
- [x] No new source code changed — tests only