### PR TITLE
fix(validation): wire validateBody to remaining routes and batch SkillService N+1

### DIFF
--- a/backend/src/__tests__/routes.delegations.test.ts
+++ b/backend/src/__tests__/routes.delegations.test.ts
@@ -151,7 +151,7 @@ describe('delegations router POST /', () => {
     const res = await request(mountApp()).post('/api/delegations').send(body);
 
     expect(res.status).toBe(400);
-    expect(res.body.error.code).toBe('INVALID_INPUT');
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
   });
 
   it('returns 400 when permissionCodes is missing', async () => {
@@ -161,7 +161,7 @@ describe('delegations router POST /', () => {
     });
 
     expect(res.status).toBe(400);
-    expect(res.body.error.code).toBe('INVALID_INPUT');
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
   });
 
   it('returns 400 when permissionCodes is an empty array', async () => {
@@ -171,7 +171,7 @@ describe('delegations router POST /', () => {
     });
 
     expect(res.status).toBe(400);
-    expect(res.body.error.code).toBe('INVALID_INPUT');
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
   });
 
   it('returns 400 when permissionCodes is not an array', async () => {
@@ -181,7 +181,7 @@ describe('delegations router POST /', () => {
     });
 
     expect(res.status).toBe(400);
-    expect(res.body.error.code).toBe('INVALID_INPUT');
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
   });
 
   it('returns 400 when expiresAt is missing', async () => {
@@ -191,7 +191,7 @@ describe('delegations router POST /', () => {
     });
 
     expect(res.status).toBe(400);
-    expect(res.body.error.code).toBe('INVALID_INPUT');
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
   });
 
   it('returns 422 when service throws escalation error', async () => {

--- a/backend/src/__tests__/routes.expanded.test.ts
+++ b/backend/src/__tests__/routes.expanded.test.ts
@@ -953,7 +953,7 @@ describe('departments router (extended)', () => {
 
   it('POST / 403/400/201/500', async () => {
     currentUser = { id: 5, role: 'employee', email: 'e@x' };
-    let res = await request(app()).post('/api/departments').send({});
+    let res = await request(app()).post('/api/departments').send({ name: 'X' });
     expect(res.status).toBe(403);
 
     currentUser = { id: 1, role: 'admin', email: 'a@x' };

--- a/backend/src/__tests__/skill.service.test.ts
+++ b/backend/src/__tests__/skill.service.test.ts
@@ -131,10 +131,8 @@ describe('SkillService.assignSkillsToUser', () => {
     conn.execute
       .mockResolvedValueOnce([[{ id: 7 }], null]) // user exists
       .mockResolvedValueOnce([{ affectedRows: 3 }, null]) // DELETE
-      .mockResolvedValueOnce([[{ id: 1 }], null]) // skill 1 valid
-      .mockResolvedValueOnce([{ affectedRows: 1 }, null]) // INSERT 1
-      .mockResolvedValueOnce([[{ id: 2 }], null]) // skill 2 valid
-      .mockResolvedValueOnce([{ affectedRows: 1 }, null]); // INSERT 2
+      .mockResolvedValueOnce([[{ id: 1 }, { id: 2 }], null]) // batch skill validation
+      .mockResolvedValueOnce([{ affectedRows: 2 }, null]); // batch INSERT
     const service = new SkillService(pool);
     const ok = await service.assignSkillsToUser(7, [1, 2]);
     expect(ok).toBe(true);

--- a/backend/src/routes/delegations.ts
+++ b/backend/src/routes/delegations.ts
@@ -12,8 +12,8 @@ import { Router, Request, Response } from 'express';
 import { Pool } from 'mysql2/promise';
 import { DelegationService } from '../services/DelegationService';
 import { authenticate } from '../middleware/auth';
-import { validateParams } from '../middleware/validation';
-import { idParam } from '../schemas';
+import { validateParams, validateBody } from '../middleware/validation';
+import { idParam, createDelegationBody } from '../schemas';
 import { logger } from '../config/logger';
 
 export const createDelegationsRouter = (pool: Pool): Router => {
@@ -21,17 +21,10 @@ export const createDelegationsRouter = (pool: Pool): Router => {
   const delegationService = new DelegationService(pool);
 
   // Create a delegation
-  router.post('/', authenticate, async (req: Request, res: Response) => {
+  router.post('/', authenticate, validateBody(createDelegationBody), async (req: Request, res: Response) => {
     try {
       const actor = req.user!;
-      const { delegateeId, permissionCodes, expiresAt, scopeOrgUnitId } = req.body;
-
-      if (!delegateeId || !Array.isArray(permissionCodes) || permissionCodes.length === 0 || !expiresAt) {
-        return res.status(400).json({
-          success: false,
-          error: { code: 'INVALID_INPUT', message: 'delegateeId, permissionCodes (non-empty array), and expiresAt are required' },
-        });
-      }
+      const { delegateeId, permissionCodes, expiresAt, scopeOrgUnitId } = res.locals.body;
 
       const delegation = await delegationService.createDelegation(
         actor.id,

--- a/backend/src/routes/departments.ts
+++ b/backend/src/routes/departments.ts
@@ -8,6 +8,7 @@ import {
   idParam,
   idAndUserIdParam,
   createDepartmentBody,
+  updateDepartmentBody,
   addUserToDepartmentBody,
 } from '../schemas';
 import { UpdateDepartmentRequest } from '../types';
@@ -77,7 +78,7 @@ export const createDepartmentsRouter = (pool: Pool) => {
   });
 
   // Create new department
-  router.post('/', authenticate, async (req, res) => {
+  router.post('/', authenticate, validateBody(createDepartmentBody), async (req, res) => {
     try {
       const user = req.user!;
 
@@ -88,19 +89,7 @@ export const createDepartmentsRouter = (pool: Pool) => {
         });
       }
 
-      const parseResult = createDepartmentBody.safeParse(req.body);
-      if (!parseResult.success) {
-        return res.status(400).json({
-          success: false,
-          error: {
-            code: 'VALIDATION_ERROR',
-            message: 'Invalid request body',
-            details: parseResult.error.issues.map(e => ({ field: e.path.join('.') || 'value', message: e.message })),
-          },
-        });
-      }
-
-      const departmentData = parseResult.data;
+      const departmentData = res.locals.body;
 
       if (departmentData.managerId) {
         const manager = await userService.getUserById(departmentData.managerId);
@@ -125,11 +114,11 @@ export const createDepartmentsRouter = (pool: Pool) => {
   });
 
   // Update department
-  router.put('/:id', authenticate, validateParams(idParam), async (req, res) => {
+  router.put('/:id', authenticate, validateParams(idParam), validateBody(updateDepartmentBody), async (req, res) => {
     try {
       const user = req.user!;
       const departmentId = res.locals.params.id;
-      const departmentData: UpdateDepartmentRequest = req.body;
+      const departmentData: UpdateDepartmentRequest = res.locals.body;
 
       if (userHasPermission(user, 'settings.manage')) {
         // Full administrators can update any department

--- a/backend/src/routes/onCall.ts
+++ b/backend/src/routes/onCall.ts
@@ -17,6 +17,8 @@
 import { Pool } from 'mysql2/promise';
 import { Router, Request, Response } from 'express';
 import { authenticate, requirePermission } from '../middleware/auth';
+import { validateParams, validateBody } from '../middleware/validation';
+import { idParam, createOnCallPeriodBody, updateOnCallPeriodBody, onCallAssignBody } from '../schemas';
 import { OnCallService } from '../services/OnCallService';
 import { logger } from '../config/logger';
 
@@ -58,18 +60,18 @@ export const createOnCallRouter = (pool: Pool): Router => {
     }
   });
 
-  router.post('/periods', requirePermission('oncall.manage'), async (req: Request, res: Response) => {
+  router.post('/periods', requirePermission('oncall.manage'), validateBody(createOnCallPeriodBody), async (_req: Request, res: Response) => {
     try {
-      const created = await service.createPeriod(req.body || {});
+      const created = await service.createPeriod(res.locals.body);
       res.status(201).json({ success: true, data: created });
     } catch (err) {
       error(res, 400, 'VALIDATION_ERROR', (err as Error).message);
     }
   });
 
-  router.get('/periods/:id', async (req: Request, res: Response) => {
+  router.get('/periods/:id', validateParams(idParam), async (_req: Request, res: Response) => {
     try {
-      const period = await service.getPeriodById(Number(req.params.id));
+      const period = await service.getPeriodById(res.locals.params.id);
       if (!period) return error(res, 404, 'NOT_FOUND', 'On-call period not found');
       res.json({ success: true, data: period });
     } catch (err) {
@@ -78,9 +80,9 @@ export const createOnCallRouter = (pool: Pool): Router => {
     }
   });
 
-  router.put('/periods/:id', requirePermission('oncall.manage'), async (req: Request, res: Response) => {
+  router.put('/periods/:id', requirePermission('oncall.manage'), validateParams(idParam), validateBody(updateOnCallPeriodBody), async (_req: Request, res: Response) => {
     try {
-      const updated = await service.updatePeriod(Number(req.params.id), req.body || {});
+      const updated = await service.updatePeriod(res.locals.params.id, res.locals.body);
       res.json({ success: true, data: updated });
     } catch (err) {
       const msg = (err as Error).message;
@@ -89,18 +91,18 @@ export const createOnCallRouter = (pool: Pool): Router => {
     }
   });
 
-  router.delete('/periods/:id', requirePermission('oncall.manage'), async (req: Request, res: Response) => {
+  router.delete('/periods/:id', requirePermission('oncall.manage'), validateParams(idParam), async (_req: Request, res: Response) => {
     try {
-      await service.deletePeriod(Number(req.params.id));
+      await service.deletePeriod(res.locals.params.id);
       res.json({ success: true });
     } catch (err) {
       error(res, 404, 'NOT_FOUND', (err as Error).message);
     }
   });
 
-  router.get('/periods/:id/assignments', async (req: Request, res: Response) => {
+  router.get('/periods/:id/assignments', validateParams(idParam), async (_req: Request, res: Response) => {
     try {
-      const data = await service.listAssignments(Number(req.params.id));
+      const data = await service.listAssignments(res.locals.params.id);
       res.json({ success: true, data });
     } catch (err) {
       logger.error('on-call assignments list error:', err);
@@ -108,13 +110,13 @@ export const createOnCallRouter = (pool: Pool): Router => {
     }
   });
 
-  router.post('/periods/:id/assign', requirePermission('oncall.manage'), async (req: Request, res: Response) => {
+  router.post('/periods/:id/assign', requirePermission('oncall.manage'), validateParams(idParam), validateBody(onCallAssignBody), async (req: Request, res: Response) => {
     try {
       const data = await service.assign(
-        Number(req.params.id),
-        Number(req.body?.userId),
+        res.locals.params.id,
+        res.locals.body.userId,
         req.user!.id,
-        req.body?.notes ?? null
+        res.locals.body.notes ?? null
       );
       res.status(201).json({ success: true, data });
     } catch (err) {

--- a/backend/src/routes/shiftSwap.ts
+++ b/backend/src/routes/shiftSwap.ts
@@ -7,6 +7,8 @@
 import { Pool } from 'mysql2/promise';
 import { Router, Request, Response } from 'express';
 import { authenticate, requirePermission, userHasPermission } from '../middleware/auth';
+import { validateBody } from '../middleware/validation';
+import { createShiftSwapBody } from '../schemas';
 import { ShiftSwapService } from '../services/ShiftSwapService';
 import { logger } from '../config/logger';
 
@@ -20,13 +22,13 @@ export const createShiftSwapRouter = (pool: Pool): Router => {
 
   router.use(authenticate);
 
-  router.post('/', async (req: Request, res: Response) => {
+  router.post('/', validateBody(createShiftSwapBody), async (req: Request, res: Response) => {
     try {
       const created = await service.create({
         requesterUserId: req.user!.id,
-        requesterAssignmentId: Number(req.body?.requesterAssignmentId),
-        targetAssignmentId: Number(req.body?.targetAssignmentId),
-        notes: req.body?.notes,
+        requesterAssignmentId: res.locals.body.requesterAssignmentId,
+        targetAssignmentId: res.locals.body.targetAssignmentId,
+        notes: res.locals.body.notes,
       });
       res.status(201).json({ success: true, data: created });
     } catch (err) {

--- a/backend/src/routes/timeOff.ts
+++ b/backend/src/routes/timeOff.ts
@@ -14,6 +14,8 @@
 import { Pool } from 'mysql2/promise';
 import { Router, Request, Response } from 'express';
 import { authenticate, requirePermission, userHasPermission } from '../middleware/auth';
+import { validateBody } from '../middleware/validation';
+import { createTimeOffBody } from '../schemas';
 import { TimeOffService } from '../services/TimeOffService';
 import { logger } from '../config/logger';
 
@@ -27,14 +29,14 @@ export const createTimeOffRouter = (pool: Pool): Router => {
 
   router.use(authenticate);
 
-  router.post('/', async (req: Request, res: Response) => {
+  router.post('/', validateBody(createTimeOffBody), async (req: Request, res: Response) => {
     try {
       const created = await service.create({
         userId: req.user!.id,
-        startDate: req.body?.startDate,
-        endDate: req.body?.endDate,
-        type: req.body?.type,
-        reason: req.body?.reason,
+        startDate: res.locals.body.startDate,
+        endDate: res.locals.body.endDate,
+        type: res.locals.body.type,
+        reason: res.locals.body.reason,
       });
       res.status(201).json({ success: true, data: created });
     } catch (err) {

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -5,7 +5,7 @@ import { RbacService } from '../services/RbacService';
 import { authenticate, userHasPermission } from '../middleware/auth';
 import { parsePagination, sendPaginated } from '../middleware/pagination';
 import { validateParams, validateBody } from '../middleware/validation';
-import { idParam, createUserBody } from '../schemas';
+import { idParam, createUserBody, updateUserBody } from '../schemas';
 import { UpdateUserRequest, User } from '../types';
 import { logger } from '../config/logger';
 
@@ -155,7 +155,7 @@ export const createUsersRouter = (pool: Pool) => {
   });
 
   // Update user
-  router.put('/:id', authenticate, validateParams(idParam), async (req, res) => {
+  router.put('/:id', authenticate, validateParams(idParam), validateBody(updateUserBody), async (req, res) => {
     try {
       const user = req.user as User;
       const userId = res.locals.params.id;

--- a/backend/src/schemas/index.ts
+++ b/backend/src/schemas/index.ts
@@ -148,3 +148,57 @@ export const updateApprovalWorkflowBody = z.object({
   description: z.string().optional(),
   steps: z.array(approvalStepBody).optional(),
 });
+
+export const updateDepartmentBody = z.object({
+  name: z.string().min(1).optional(),
+  description: z.string().optional(),
+  managerId: z.number().int().positive().optional(),
+  orgUnitId: z.number().int().positive().optional(),
+  isActive: z.boolean().optional(),
+});
+
+export const createTimeOffBody = z.object({
+  startDate: z.string().min(1, 'Start date is required'),
+  endDate: z.string().min(1, 'End date is required'),
+  type: z.enum(['vacation', 'sick', 'personal', 'other']).optional(),
+  reason: z.string().optional(),
+});
+
+export const createShiftSwapBody = z.object({
+  requesterAssignmentId: z.number().int().positive(),
+  targetAssignmentId: z.number().int().positive(),
+  notes: z.string().optional(),
+});
+
+export const createDelegationBody = z.object({
+  delegateeId: z.number().int().positive(),
+  permissionCodes: z.array(z.string()).min(1, 'At least one permission code is required'),
+  expiresAt: z.string().min(1, 'expiresAt is required'),
+  scopeOrgUnitId: z.number().int().positive().nullable().optional(),
+});
+
+export const createOnCallPeriodBody = z.object({
+  departmentId: z.number().int().positive(),
+  date: z.string().min(1, 'Date is required'),
+  startTime: z.string().min(1, 'Start time is required'),
+  endTime: z.string().min(1, 'End time is required'),
+  scheduleId: z.number().int().positive().nullable().optional(),
+  minStaff: z.number().int().nonnegative().optional(),
+  maxStaff: z.number().int().positive().optional(),
+  notes: z.string().optional(),
+});
+
+export const updateOnCallPeriodBody = z.object({
+  date: z.string().optional(),
+  startTime: z.string().optional(),
+  endTime: z.string().optional(),
+  minStaff: z.number().int().nonnegative().optional(),
+  maxStaff: z.number().int().positive().optional(),
+  notes: z.string().nullable().optional(),
+  status: z.enum(['open', 'assigned', 'cancelled']).optional(),
+});
+
+export const onCallAssignBody = z.object({
+  userId: z.number().int().positive(),
+  notes: z.string().nullable().optional(),
+});

--- a/backend/src/services/SkillService.ts
+++ b/backend/src/services/SkillService.ts
@@ -327,22 +327,23 @@ export class SkillService {
 
       // Add new skill assignments
       if (skillIds.length > 0) {
-        for (const skillId of skillIds) {
-          // Validate skill exists and is active
-          const [skillRows] = await connection.execute<RowDataPacket[]>(
-            'SELECT id FROM skills WHERE id = ? AND is_active = 1 LIMIT 1',
-            [skillId]
-          );
-
-          if (skillRows.length === 0) {
-            throw new Error(`Skill with ID ${skillId} not found or inactive`);
-          }
-
-          await connection.execute(
-            'INSERT INTO user_skills (user_id, skill_id) VALUES (?, ?)',
-            [userId, skillId]
-          );
+        const placeholders = skillIds.map(() => '?').join(', ');
+        const [validRows] = await connection.execute<RowDataPacket[]>(
+          `SELECT id FROM skills WHERE id IN (${placeholders}) AND is_active = 1`,
+          skillIds
+        );
+        const validIds = new Set((validRows as RowDataPacket[]).map((r) => r.id as number));
+        const invalid = skillIds.find((id) => !validIds.has(id));
+        if (invalid !== undefined) {
+          throw new Error(`Skill with ID ${invalid} not found or inactive`);
         }
+
+        const insertValues = skillIds.map(() => '(?, ?)').join(', ');
+        const insertParams = skillIds.flatMap((id) => [userId, id]);
+        await connection.execute(
+          `INSERT INTO user_skills (user_id, skill_id) VALUES ${insertValues}`,
+          insertParams
+        );
       }
 
       await connection.commit();
@@ -484,22 +485,23 @@ export class SkillService {
 
       // Add new skill requirements
       if (skillIds.length > 0) {
-        for (const skillId of skillIds) {
-          // Validate skill exists and is active
-          const [skillRows] = await connection.execute<RowDataPacket[]>(
-            'SELECT id FROM skills WHERE id = ? AND is_active = 1 LIMIT 1',
-            [skillId]
-          );
-
-          if (skillRows.length === 0) {
-            throw new Error(`Skill with ID ${skillId} not found or inactive`);
-          }
-
-          await connection.execute(
-            'INSERT INTO shift_skills (shift_id, skill_id) VALUES (?, ?)',
-            [shiftId, skillId]
-          );
+        const placeholders = skillIds.map(() => '?').join(', ');
+        const [validRows] = await connection.execute<RowDataPacket[]>(
+          `SELECT id FROM skills WHERE id IN (${placeholders}) AND is_active = 1`,
+          skillIds
+        );
+        const validIds = new Set((validRows as RowDataPacket[]).map((r) => r.id as number));
+        const invalid = skillIds.find((id) => !validIds.has(id));
+        if (invalid !== undefined) {
+          throw new Error(`Skill with ID ${invalid} not found or inactive`);
         }
+
+        const insertValues = skillIds.map(() => '(?, ?)').join(', ');
+        const insertParams = skillIds.flatMap((id) => [shiftId, id]);
+        await connection.execute(
+          `INSERT INTO shift_skills (shift_id, skill_id) VALUES ${insertValues}`,
+          insertParams
+        );
       }
 
       await connection.commit();


### PR DESCRIPTION
## Summary

- Wires `validateBody` Zod middleware to every POST/PUT route that lacked input validation: `users PUT /:id`, `departments POST/PUT`, `timeOff POST`, `shiftSwap POST`, `delegations POST`, `onCall POST/PUT periods`, `onCall POST assign`
- Standardises `departments POST /` from inline `safeParse` to `validateBody` middleware for consistency
- Adds `validateParams` to the on-call `GET/PUT/DELETE /periods/:id` routes (previously used raw `req.params`)
- Eliminates N+1 in `SkillService.assignSkillsToUser` and `updateShiftSkills`: replaces per-skill SELECT loop with a single `WHERE id IN (...)` batch check, then a single bulk INSERT
- Adds 7 new Zod schemas to `src/schemas/index.ts`
- Updates 3 test files to match the refactored behaviour (delegation tests now expect `VALIDATION_ERROR` instead of `INVALID_INPUT`, skill service mock updated for batch queries)

## Test plan

- [ ] All 1647 existing tests pass (`npm test` in `backend/`)
- [ ] TypeScript compiles clean (`npx tsc --noEmit`)
- [ ] Lint clean (enforced by pre-commit hook)