### PR TITLE
fix(validation): wire validateBody/res.locals.body across all mutation routes

### DIFF
--- a/backend/src/__tests__/routes.batch5.test.ts
+++ b/backend/src/__tests__/routes.batch5.test.ts
@@ -61,7 +61,6 @@ describe('employees route — POST /:id/skills missing skillId returns 400', () 
       .send({ proficiencyLevel: 3 }); // no skillId
     expect(res.status).toBe(400);
     expect(res.body.error.code).toBe('VALIDATION_ERROR');
-    expect(res.body.error.message).toMatch(/skillId and proficiencyLevel are required/);
   });
 
   it('returns 400 VALIDATION_ERROR when proficiencyLevel is absent from body', async () => {

--- a/backend/src/routes/approvalWorkflows.ts
+++ b/backend/src/routes/approvalWorkflows.ts
@@ -63,15 +63,9 @@ export const createApprovalWorkflowsRouter = (pool: Pool): Router => {
   });
 
   // Create a workflow
-  router.post('/', authenticate, requirePermission('approval.manage'), validateBody(createApprovalWorkflowBody), async (req: Request, res: Response) => {
+  router.post('/', authenticate, requirePermission('approval.manage'), validateBody(createApprovalWorkflowBody), async (_req: Request, res: Response) => {
     try {
-      const { changeType, requireAll, description, steps } = req.body;
-      if (!changeType || !Array.isArray(steps) || steps.length === 0) {
-        return res.status(400).json({
-          success: false,
-          error: { code: 'INVALID_INPUT', message: 'changeType and steps (non-empty array) are required' },
-        });
-      }
+      const { changeType, requireAll, description, steps } = res.locals.body;
       const workflow = await engine.createWorkflow({ changeType, requireAll, description, steps });
       res.status(201).json({ success: true, data: workflow, message: 'Workflow created' });
     } catch (error: any) {
@@ -84,10 +78,10 @@ export const createApprovalWorkflowsRouter = (pool: Pool): Router => {
   });
 
   // Update a workflow
-  router.put('/:id', authenticate, requirePermission('approval.manage'), validateParams(idParam), validateBody(updateApprovalWorkflowBody), async (req: Request, res: Response) => {
+  router.put('/:id', authenticate, requirePermission('approval.manage'), validateParams(idParam), validateBody(updateApprovalWorkflowBody), async (_req: Request, res: Response) => {
     try {
       const { id } = res.locals.params;
-      const workflow = await engine.updateWorkflow(id, req.body);
+      const workflow = await engine.updateWorkflow(id, res.locals.body);
       res.json({ success: true, data: workflow, message: 'Workflow updated' });
     } catch (error: any) {
       if (error.message?.includes('not found')) {

--- a/backend/src/routes/assignments.ts
+++ b/backend/src/routes/assignments.ts
@@ -88,11 +88,11 @@ router.post('/', authenticate, requirePermission('assignment.manage'), validateB
 });
 
 // Update assignment
-router.put('/:id', authenticate, requirePermission('assignment.manage'), validateParams(idParam), validateBody(updateAssignmentBody), async (req: Request, res: Response) => {
+router.put('/:id', authenticate, requirePermission('assignment.manage'), validateParams(idParam), validateBody(updateAssignmentBody), async (_req: Request, res: Response) => {
   try {
     const { id } = res.locals.params;
 
-    const assignment = await assignmentService.updateAssignment(id, req.body);
+    const assignment = await assignmentService.updateAssignment(id, res.locals.body);
     res.json({
       success: true,
       data: assignment,

--- a/backend/src/routes/employees.ts
+++ b/backend/src/routes/employees.ts
@@ -4,7 +4,7 @@ import { EmployeeService } from '../services/EmployeeService';
 import { authenticate, requirePermission } from '../middleware/auth';
 import { parsePagination, sendPaginated } from '../middleware/pagination';
 import { validateParams, validateBody } from '../middleware/validation';
-import { idParam, departmentIdParam, idAndSkillIdParam, createUserBody, updateUserBody } from '../schemas';
+import { idParam, departmentIdParam, idAndSkillIdParam, createUserBody, updateUserBody, addEmployeeSkillBody } from '../schemas';
 import { logger } from '../config/logger';
 
 export const createEmployeesRouter = (pool: Pool) => {
@@ -71,9 +71,9 @@ router.get('/:id', authenticate, validateParams(idParam), async (_req: Request, 
 });
 
 // Create new employee
-router.post('/', authenticate, requirePermission('employee.manage'), validateBody(createUserBody), async (req: Request, res: Response) => {
+router.post('/', authenticate, requirePermission('employee.manage'), validateBody(createUserBody), async (_req: Request, res: Response) => {
   try {
-    const employee = await employeeService.createEmployee(req.body);
+    const employee = await employeeService.createEmployee(res.locals.body);
 
     res.status(201).json({
       success: true,
@@ -90,11 +90,11 @@ router.post('/', authenticate, requirePermission('employee.manage'), validateBod
 });
 
 // Update employee
-router.put('/:id', authenticate, requirePermission('employee.manage'), validateParams(idParam), validateBody(updateUserBody), async (req: Request, res: Response) => {
+router.put('/:id', authenticate, requirePermission('employee.manage'), validateParams(idParam), validateBody(updateUserBody), async (_req: Request, res: Response) => {
   try {
     const { id } = res.locals.params;
 
-    const employee = await employeeService.updateEmployee(id, req.body);
+    const employee = await employeeService.updateEmployee(id, res.locals.body);
     res.json({
       success: true,
       data: employee,
@@ -169,17 +169,10 @@ router.get('/:id/skills', authenticate, validateParams(idParam), async (_req: Re
 });
 
 // Add skill to employee
-router.post('/:id/skills', authenticate, requirePermission('employee.manage'), validateParams(idParam), async (req: Request, res: Response) => {
+router.post('/:id/skills', authenticate, requirePermission('employee.manage'), validateParams(idParam), validateBody(addEmployeeSkillBody), async (_req: Request, res: Response) => {
   try {
     const { id } = res.locals.params;
-    const { skillId, proficiencyLevel } = req.body;
-
-    if (!skillId || proficiencyLevel === undefined) {
-      return res.status(400).json({
-        success: false,
-        error: { code: 'VALIDATION_ERROR', message: 'skillId and proficiencyLevel are required' }
-      });
-    }
+    const { skillId, proficiencyLevel } = res.locals.body;
 
     await employeeService.addEmployeeSkill(id, skillId, proficiencyLevel);
 

--- a/backend/src/routes/org.ts
+++ b/backend/src/routes/org.ts
@@ -23,6 +23,8 @@
 import { Pool } from 'mysql2/promise';
 import { Router, Request, Response } from 'express';
 import { authenticate, requirePermission, userHasPermission } from '../middleware/auth';
+import { validateParams, validateBody } from '../middleware/validation';
+import { idParam, createOrgUnitBody, updateOrgUnitBody, addOrgMemberBody, createLoanBody } from '../schemas';
 import { OrgUnitService } from '../services/OrgUnitService';
 import { EmployeeLoanService } from '../services/EmployeeLoanService';
 import { AuditLogService } from '../services/AuditLogService';
@@ -71,13 +73,13 @@ export const createOrgRouter = (pool: Pool): Router => {
     }
   });
 
-  router.post('/units', requirePermission('org_unit.manage'), async (req: Request, res: Response) => {
+  router.post('/units', requirePermission('org_unit.manage'), validateBody(createOrgUnitBody), async (req: Request, res: Response) => {
     try {
       const created = await units.create({
-        name: req.body?.name,
-        description: req.body?.description,
-        parentId: req.body?.parentId ?? null,
-        managerUserId: req.body?.managerUserId ?? null,
+        name: res.locals.body.name,
+        description: res.locals.body.description,
+        parentId: res.locals.body.parentId ?? null,
+        managerUserId: res.locals.body.managerUserId ?? null,
       });
       await audit.write({
         actorId: req.user!.id, action: 'org_unit.create',
@@ -90,13 +92,13 @@ export const createOrgRouter = (pool: Pool): Router => {
     }
   });
 
-  router.put('/units/:id', requirePermission('org_unit.manage'), async (req: Request, res: Response) => {
+  router.put('/units/:id', requirePermission('org_unit.manage'), validateParams(idParam), validateBody(updateOrgUnitBody), async (req: Request, res: Response) => {
     try {
-      const updated = await units.update(Number(req.params.id), req.body ?? {});
+      const updated = await units.update(res.locals.params.id, res.locals.body);
       await audit.write({
         actorId: req.user!.id, action: 'org_unit.update',
-        entityType: 'org_unit', entityId: Number(req.params.id),
-        after: req.body ?? {},
+        entityType: 'org_unit', entityId: res.locals.params.id,
+        after: res.locals.body,
       });
       res.json({ success: true, data: updated });
     } catch (err) {
@@ -132,14 +134,12 @@ export const createOrgRouter = (pool: Pool): Router => {
     }
   });
 
-  router.post('/units/:id/members', requirePermission('employee.manage'), async (req: Request, res: Response) => {
+  router.post('/units/:id/members', requirePermission('employee.manage'), validateParams(idParam), validateBody(addOrgMemberBody), async (_req: Request, res: Response) => {
     try {
-      const userId = Number(req.body?.userId);
-      if (!userId) return respondError(res, 400, 'VALIDATION_ERROR', 'userId is required');
       const created = await units.addMember(
-        userId,
-        Number(req.params.id),
-        Boolean(req.body?.isPrimary)
+        res.locals.body.userId,
+        res.locals.params.id,
+        Boolean(res.locals.body.isPrimary)
       );
       res.status(201).json({ success: true, data: created });
     } catch (err) {
@@ -195,15 +195,15 @@ export const createOrgRouter = (pool: Pool): Router => {
     }
   });
 
-  router.post('/loans', requirePermission('loan.request'), async (req: Request, res: Response) => {
+  router.post('/loans', requirePermission('loan.request'), validateBody(createLoanBody), async (req: Request, res: Response) => {
     try {
       const created = await loans.create({
-        userId: Number(req.body?.userId),
-        fromOrgUnitId: Number(req.body?.fromOrgUnitId),
-        toOrgUnitId: Number(req.body?.toOrgUnitId),
-        startDate: req.body?.startDate,
-        endDate: req.body?.endDate,
-        reason: req.body?.reason,
+        userId: res.locals.body.userId,
+        fromOrgUnitId: res.locals.body.fromOrgUnitId,
+        toOrgUnitId: res.locals.body.toOrgUnitId,
+        startDate: res.locals.body.startDate,
+        endDate: res.locals.body.endDate,
+        reason: res.locals.body.reason,
         requestedBy: req.user!.id,
       });
       res.status(201).json({ success: true, data: created });

--- a/backend/src/routes/policies.ts
+++ b/backend/src/routes/policies.ts
@@ -22,6 +22,8 @@
 import { Pool } from 'mysql2/promise';
 import { Router, Request, Response } from 'express';
 import { authenticate, requirePermission, userHasPermission } from '../middleware/auth';
+import { validateBody } from '../middleware/validation';
+import { createPolicyExceptionBody, createPolicyBody, updatePolicyBody } from '../schemas';
 import { PolicyService } from '../services/PolicyService';
 import { PolicyExceptionService } from '../services/PolicyExceptionService';
 import { ApprovalMatrixService } from '../services/ApprovalMatrixService';
@@ -104,13 +106,13 @@ export const createPoliciesRouter = (pool: Pool): Router => {
     }
   });
 
-  router.post('/exceptions', async (req: Request, res: Response) => {
+  router.post('/exceptions', validateBody(createPolicyExceptionBody), async (req: Request, res: Response) => {
     try {
       const created = await exceptions.create({
-        policyId: Number(req.body?.policyId),
-        targetType: req.body?.targetType,
-        targetId: Number(req.body?.targetId),
-        reason: req.body?.reason ?? null,
+        policyId: res.locals.body.policyId,
+        targetType: res.locals.body.targetType,
+        targetId: res.locals.body.targetId,
+        reason: res.locals.body.reason ?? null,
         requestedByUserId: req.user!.id,
       });
       res.status(201).json({ success: true, data: created });
@@ -183,14 +185,14 @@ export const createPoliciesRouter = (pool: Pool): Router => {
     }
   });
 
-  router.post('/', requirePermission('policy.manage'), async (req: Request, res: Response) => {
+  router.post('/', requirePermission('policy.manage'), validateBody(createPolicyBody), async (req: Request, res: Response) => {
     try {
       const created = await policies.create({
-        scopeType: req.body?.scopeType,
-        scopeId: req.body?.scopeId ?? null,
-        policyKey: req.body?.policyKey,
-        policyValue: req.body?.policyValue,
-        description: req.body?.description ?? null,
+        scopeType: res.locals.body.scopeType,
+        scopeId: res.locals.body.scopeId ?? null,
+        policyKey: res.locals.body.policyKey,
+        policyValue: res.locals.body.policyValue,
+        description: res.locals.body.description ?? null,
         imposedByUserId: req.user!.id,
       });
       await audit.write({
@@ -204,7 +206,7 @@ export const createPoliciesRouter = (pool: Pool): Router => {
     }
   });
 
-  router.put('/:id', requirePermission('policy.manage'), async (req: Request, res: Response) => {
+  router.put('/:id', requirePermission('policy.manage'), validateBody(updatePolicyBody), async (req: Request, res: Response) => {
     try {
       const existing = await policies.getById(Number(req.params.id));
       if (!existing) return respondError(res, 404, 'NOT_FOUND', 'Policy not found');
@@ -212,7 +214,7 @@ export const createPoliciesRouter = (pool: Pool): Router => {
       if (existing.imposedByUserId !== req.user!.id && !userHasPermission(req.user, 'settings.manage')) {
         return respondError(res, 403, 'FORBIDDEN', 'Only the policy owner or an administrator may edit this policy');
       }
-      const updated = await policies.update(Number(req.params.id), req.body ?? {});
+      const updated = await policies.update(Number(req.params.id), res.locals.body);
       await audit.write({
         actorId: req.user!.id, action: 'policy.update',
         entityType: 'policy', entityId: updated.id,

--- a/backend/src/routes/rbac.ts
+++ b/backend/src/routes/rbac.ts
@@ -23,7 +23,9 @@ import { Router, Request, Response } from 'express';
 import { Pool } from 'mysql2/promise';
 import { z } from 'zod';
 import { authenticate, requirePermission } from '../middleware/auth';
+import { validateParams, validateBody } from '../middleware/validation';
 import { RbacService } from '../services/RbacService';
+import { idParam, createRoleBody, updateRoleBody } from '../schemas';
 import { logger } from '../config/logger';
 
 const assignRoleBody = z.object({
@@ -71,12 +73,12 @@ export const createRbacRouter = (pool: Pool): { roles: Router; permissions: Rout
     }
   });
 
-  roles.post('/', async (req: Request, res: Response) => {
+  roles.post('/', validateBody(createRoleBody), async (_req: Request, res: Response) => {
     try {
       const created = await rbac.createRole({
-        name: req.body?.name,
-        description: req.body?.description,
-        permissionCodes: req.body?.permissionCodes,
+        name: res.locals.body.name,
+        description: res.locals.body.description,
+        permissionCodes: res.locals.body.permissionCodes,
       });
       res.status(201).json({ success: true, data: created });
     } catch (err) {
@@ -96,12 +98,12 @@ export const createRbacRouter = (pool: Pool): { roles: Router; permissions: Rout
     }
   });
 
-  roles.put('/:id', async (req: Request, res: Response) => {
+  roles.put('/:id', validateParams(idParam), validateBody(updateRoleBody), async (_req: Request, res: Response) => {
     try {
-      const updated = await rbac.updateRole(Number(req.params.id), {
-        name: req.body?.name,
-        description: req.body?.description,
-        permissionCodes: req.body?.permissionCodes,
+      const updated = await rbac.updateRole(res.locals.params.id, {
+        name: res.locals.body.name,
+        description: res.locals.body.description,
+        permissionCodes: res.locals.body.permissionCodes,
       });
       res.json({ success: true, data: updated });
     } catch (err) {

--- a/backend/src/routes/schedules.ts
+++ b/backend/src/routes/schedules.ts
@@ -139,11 +139,11 @@ router.post('/', authenticate, requirePermission('schedule.manage'), validateBod
 });
 
 // Update schedule
-router.put('/:id', authenticate, requirePermission('schedule.manage'), validateParams(idParam), validateBody(updateScheduleBody), async (req: Request, res: Response) => {
+router.put('/:id', authenticate, requirePermission('schedule.manage'), validateParams(idParam), validateBody(updateScheduleBody), async (_req: Request, res: Response) => {
   try {
     const { id } = res.locals.params;
 
-    const schedule = await scheduleService.updateSchedule(id, req.body);
+    const schedule = await scheduleService.updateSchedule(id, res.locals.body);
     res.json({
       success: true,
       data: schedule,

--- a/backend/src/routes/shifts.ts
+++ b/backend/src/routes/shifts.ts
@@ -24,6 +24,7 @@ import {
   scheduleIdParam,
   departmentIdParam,
   createShiftBody,
+  updateShiftBody,
   createShiftTemplateBody,
   updateShiftTemplateBody,
 } from '../schemas';
@@ -73,9 +74,9 @@ router.get('/templates/:id', authenticate, validateParams(idParam), async (_req:
 });
 
 // Create new shift template
-router.post('/templates', authenticate, requirePermission('shift.manage'), validateBody(createShiftTemplateBody), async (req: Request, res: Response) => {
+router.post('/templates', authenticate, requirePermission('shift.manage'), validateBody(createShiftTemplateBody), async (_req: Request, res: Response) => {
   try {
-    const template = await shiftService.createShiftTemplate(req.body);
+    const template = await shiftService.createShiftTemplate(res.locals.body);
 
     res.status(201).json({
       success: true,
@@ -92,11 +93,11 @@ router.post('/templates', authenticate, requirePermission('shift.manage'), valid
 });
 
 // Update shift template
-router.put('/templates/:id', authenticate, requirePermission('shift.manage'), validateParams(idParam), validateBody(updateShiftTemplateBody), async (req: Request, res: Response) => {
+router.put('/templates/:id', authenticate, requirePermission('shift.manage'), validateParams(idParam), validateBody(updateShiftTemplateBody), async (_req: Request, res: Response) => {
   try {
     const { id } = res.locals.params;
 
-    const template = await shiftService.updateShiftTemplate(id, req.body);
+    const template = await shiftService.updateShiftTemplate(id, res.locals.body);
     if (!template) {
       return res.status(404).json({
         success: false,
@@ -225,11 +226,11 @@ router.post('/', authenticate, requirePermission('shift.manage'), validateBody(c
 });
 
 // Update shift
-router.put('/:id', authenticate, requirePermission('shift.manage'), validateParams(idParam), async (req: Request, res: Response) => {
+router.put('/:id', authenticate, requirePermission('shift.manage'), validateParams(idParam), validateBody(updateShiftBody), async (_req: Request, res: Response) => {
   try {
     const { id } = res.locals.params;
 
-    const shift = await shiftService.updateShift(id, req.body);
+    const shift = await shiftService.updateShift(id, res.locals.body);
     res.json({
       success: true,
       data: shift,

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -170,12 +170,13 @@ export const createUsersRouter = (pool: Pool) => {
         });
       }
 
-      const updateData: UpdateUserRequest = req.body;
+      const updateData: UpdateUserRequest = res.locals.body;
 
       // Self-service editors are limited to a small set of profile fields.
+      // Check raw req.body keys so Zod-stripped unknown fields are still caught.
       if (!canManageUsers) {
         const allowedFields = ['firstName', 'lastName', 'phone'];
-        const submittedFields = Object.keys(updateData);
+        const submittedFields = Object.keys(req.body ?? {});
         const invalidFields = submittedFields.filter(field => !allowedFields.includes(field));
 
         if (invalidFields.length > 0) {

--- a/backend/src/schemas/index.ts
+++ b/backend/src/schemas/index.ts
@@ -202,3 +202,84 @@ export const onCallAssignBody = z.object({
   userId: z.number().int().positive(),
   notes: z.string().nullable().optional(),
 });
+
+export const updateShiftBody = z.object({
+  date: z.string().optional(),
+  startTime: z.string().optional(),
+  endTime: z.string().optional(),
+  minStaff: z.number().int().nonnegative().optional(),
+  maxStaff: z.number().int().positive().optional(),
+  status: z.enum(['open', 'assigned', 'confirmed', 'cancelled']).optional(),
+  requiredSkillIds: z.array(z.number().int().positive()).optional(),
+  notes: z.string().nullable().optional(),
+});
+
+export const addEmployeeSkillBody = z.object({
+  skillId: z.number().int().positive(),
+  proficiencyLevel: z.number().int().min(1).max(5),
+});
+
+export const createRoleBody = z.object({
+  name: z.string().min(1, 'Name is required'),
+  description: z.string().optional(),
+  permissionCodes: z.array(z.string()).optional(),
+});
+
+export const updateRoleBody = z.object({
+  name: z.string().min(1).optional(),
+  description: z.string().optional(),
+  permissionCodes: z.array(z.string()).optional(),
+});
+
+export const createOrgUnitBody = z.object({
+  name: z.string().min(1, 'Name is required'),
+  description: z.string().optional(),
+  parentId: z.number().int().positive().nullable().optional(),
+  managerUserId: z.number().int().positive().nullable().optional(),
+});
+
+export const updateOrgUnitBody = z.object({
+  name: z.string().min(1).optional(),
+  description: z.string().nullable().optional(),
+  parentId: z.number().int().positive().nullable().optional(),
+  managerUserId: z.number().int().positive().nullable().optional(),
+  isActive: z.boolean().optional(),
+});
+
+export const addOrgMemberBody = z.object({
+  userId: z.number().int().positive(),
+  isPrimary: z.boolean().optional(),
+});
+
+export const createLoanBody = z.object({
+  userId: z.number().int().positive(),
+  fromOrgUnitId: z.number().int().positive(),
+  toOrgUnitId: z.number().int().positive(),
+  startDate: z.string().min(1, 'Start date is required'),
+  endDate: z.string().min(1, 'End date is required'),
+  reason: z.string().optional(),
+});
+
+export const createPolicyExceptionBody = z.object({
+  policyId: z.number().int().positive(),
+  targetType: z.string().min(1, 'Target type is required'),
+  targetId: z.number().int().positive(),
+  reason: z.string().nullable().optional(),
+});
+
+export const createPolicyBody = z.object({
+  scopeType: z.enum(['global', 'org_unit', 'schedule', 'shift_template']),
+  scopeId: z.number().int().positive().nullable().optional(),
+  policyKey: z.string().min(1, 'Policy key is required'),
+  policyValue: z.unknown(),
+  description: z.string().nullable().optional(),
+});
+
+export const updatePolicyBody = z.object({
+  scopeType: z.enum(['global', 'org_unit', 'schedule', 'shift_template']).optional(),
+  scopeId: z.number().int().positive().nullable().optional(),
+  policyKey: z.string().min(1).optional(),
+  policyValue: z.unknown().optional(),
+  description: z.string().nullable().optional(),
+  isActive: z.boolean().optional(),
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7882,9 +7882,9 @@
       "license": "MIT"
     },
     "node_modules/bfj": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/bfj/-/bfj-7.1.0.tgz",
-      "integrity": "sha512-I6MMLkn+anzNdCUp9hMRyui1HaNEUCco50lxbvNS4+EyXg8lN3nJ48PjPWtbH8UVS9CuMoaKE9U2V3l29DaRQw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/bfj/-/bfj-8.0.0.tgz",
+      "integrity": "sha512-6KJe4gFrZ4lhmvWcUIj37yFAs36mi2FZXuTkw6udZ/QsX/znFypW4SatqcLA5K5T4BAWgJZD73UFEJJQxuJjoA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7895,7 +7895,7 @@
         "tryer": "^1.0.1"
       },
       "engines": {
-        "node": ">= 8.0.0"
+        "node": ">= 18.0.0"
       }
     },
     "node_modules/big.js": {
@@ -22123,16 +22123,6 @@
         "node": ">= 10.13.0"
       }
     },
-    "node_modules/rollup-plugin-terser/node_modules/serialize-javascript": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
-      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
-      }
-    },
     "node_modules/run-async": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
@@ -23554,16 +23544,6 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/svgo/node_modules/nth-check": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
-      "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "~1.0.0"
       }
     },
     "node_modules/svgo/node_modules/supports-color": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -92,7 +92,12 @@
   "overrides": {
     "ajv-keywords": {
       "ajv": "^8.0.0"
-    }
+    },
+    "nth-check": "^2.1.1",
+    "serialize-javascript": "^6.0.2",
+    "underscore": "^1.13.6",
+    "bfj": "^8.0.0",
+    "jsonpath": "^1.1.1"
   },
   "proxy": "http://localhost:3001",
   "engines": {


### PR DESCRIPTION
## Summary

- Replace all `req.body` reads with `res.locals.body` in 9 route handlers that applied `validateBody` but bypassed the stripped result
- Add `validateBody` to 11 mutation routes that had no input validation (shifts, employees skills, rbac roles, org units/members/loans, policies/exceptions)
- Add 11 new Zod schemas to `backend/src/schemas/index.ts`
- Remove dead unreachable manual-validation block in `approvalWorkflows.ts` POST /
- Preserve raw `req.body` key inspection in `users.ts` PUT `/:id` forbidden-fields security check
- Add npm `overrides` for `nth-check`, `serialize-javascript`, `underscore`, `bfj`, `jsonpath` to resolve frontend HIGH CVEs in react-scripts build deps

## Test plan

- [ ] All 1647 backend tests pass
- [ ] TypeScript compiles with no errors (`npx tsc --noEmit`)
- [ ] Frontend CVE overrides installed (`npm install` in frontend/)