### PR TITLE
fix(security): JWT httpOnly cookie, validateBody wiring, security hardening

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "bcrypt": "^6.0.0",
         "compression": "^1.7.4",
+        "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
@@ -24,6 +25,7 @@
       "devDependencies": {
         "@types/bcrypt": "^5.0.0",
         "@types/compression": "^1.7.2",
+        "@types/cookie-parser": "^1.4.10",
         "@types/cors": "^2.8.13",
         "@types/express": "^4.17.17",
         "@types/jest": "^29.5.3",
@@ -2128,6 +2130,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookie-parser": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.10.tgz",
+      "integrity": "sha512-B4xqkqfZ8Wek+rCOeRxsjMS9OgvzebEzzLYw7NHYuvzb7IdxOkI0ZHGgeEBX4PUM7QGVvNSK60T3OvWj3YfBRg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/cookiejar": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
@@ -3542,6 +3554,25 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
     },
     "node_modules/cookie-signature": {
       "version": "1.0.7",

--- a/backend/package.json
+++ b/backend/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "bcrypt": "^6.0.0",
     "compression": "^1.7.4",
+    "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
@@ -38,6 +39,7 @@
   "devDependencies": {
     "@types/bcrypt": "^5.0.0",
     "@types/compression": "^1.7.2",
+    "@types/cookie-parser": "^1.4.10",
     "@types/cors": "^2.8.13",
     "@types/express": "^4.17.17",
     "@types/jest": "^29.5.3",

--- a/backend/src/__tests__/routes.modules.test.ts
+++ b/backend/src/__tests__/routes.modules.test.ts
@@ -188,21 +188,21 @@ describe('modules router PUT /:code', () => {
     const res = await request(mountApp()).put('/api/modules/delegation').send({});
 
     expect(res.status).toBe(400);
-    expect(res.body.error.code).toBe('INVALID_INPUT');
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
   });
 
   it('returns 400 when isEnabled is not a boolean', async () => {
     const res = await request(mountApp()).put('/api/modules/delegation').send({ isEnabled: 'yes' });
 
     expect(res.status).toBe(400);
-    expect(res.body.error.code).toBe('INVALID_INPUT');
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
   });
 
   it('returns 400 when isEnabled is a number instead of boolean', async () => {
     const res = await request(mountApp()).put('/api/modules/delegation').send({ isEnabled: 1 });
 
     expect(res.status).toBe(400);
-    expect(res.body.error.code).toBe('INVALID_INPUT');
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
   });
 
   it('returns 404 when module code does not exist', async () => {

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -10,6 +10,7 @@
 
 import express from 'express';
 import cors from 'cors';
+import cookieParser from 'cookie-parser';
 import compression from 'compression';
 import morgan from 'morgan';
 import helmet from 'helmet';
@@ -76,7 +77,7 @@ export function buildApp(pool: Pool, options: BuildAppOptions = {}): express.Exp
         directives: {
           defaultSrc: ["'self'"],
           scriptSrc: ["'self'"],
-          styleSrc: ["'self'", "'unsafe-inline'"],
+          styleSrc: ["'self'"],
           imgSrc: ["'self'", 'data:'],
           connectSrc: ["'self'"],
           fontSrc: ["'self'"],
@@ -99,7 +100,10 @@ export function buildApp(pool: Pool, options: BuildAppOptions = {}): express.Exp
   app.use(
     cors({
       origin: (origin, callback) => {
-        if (!origin) return callback(null, true);
+        if (!origin) {
+          if (config.server.env !== 'production') return callback(null, true);
+          return callback(new Error('Not allowed by CORS'));
+        }
         if (config.server.env === 'development' && (origin.includes('localhost') || origin.includes('127.0.0.1'))) {
           return callback(null, true);
         }
@@ -111,6 +115,8 @@ export function buildApp(pool: Pool, options: BuildAppOptions = {}): express.Exp
       allowedHeaders: ['Content-Type', 'Authorization'],
     })
   );
+
+  app.use(cookieParser());
 
   if (!options.silent) {
     const limiter = rateLimit({

--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -70,6 +70,7 @@ export const config = {
       secure: process.env.SESSION_COOKIE_SECURE === 'true',
       httpOnly: true,
       maxAge: parseInt(process.env.SESSION_COOKIE_MAX_AGE || '86400000'), // 24 hours
+      sameSite: 'lax' as const,
     },
   },
   jwt: {
@@ -112,7 +113,7 @@ export const config = {
     maxFiles: parseInt(process.env.LOG_MAX_FILES || '5'),
   },
   security: {
-    bcryptRounds: parseInt(process.env.BCRYPT_ROUNDS || '12'),
+    bcryptRounds: Math.max(10, parseInt(process.env.BCRYPT_ROUNDS || '12')),
     rateLimitWindow: parseInt(process.env.RATE_LIMIT_WINDOW_MS || '60000'), // 1 minute
     rateLimitMax: parseInt(process.env.RATE_LIMIT_MAX_REQUESTS || '200'),
   },

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -28,10 +28,15 @@ const getModuleService = (): ModuleService => {
   return _moduleService;
 };
 
-// Extend Express Request to include user
+// In-memory JTI blacklist for server-side token revocation on logout.
+const _jtiBlacklist = new Set<string>();
+export const addToBlacklist = (jti: string): void => { _jtiBlacklist.add(jti); };
+
+// Extend Express Request to include user and token JTI
 declare module 'express-serve-static-core' {
   interface Request {
     user?: User;
+    tokenJti?: string;
   }
 }
 
@@ -41,6 +46,7 @@ declare module 'express-serve-static-core' {
 interface JWTPayload {
   userId: string;
   email: string;
+  jti?: string;
   iat?: number;
   exp?: number;
 }
@@ -60,8 +66,13 @@ export const userHasPermission = (user: User | undefined, code: string): boolean
  */
 export const authenticate = async (req: Request, res: Response, next: NextFunction) => {
   try {
+    // Accept token from httpOnly cookie first, then Authorization header.
+    const cookieToken: string | undefined = req.cookies?.token;
     const authHeader = req.headers.authorization;
-    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    const bearerToken = authHeader?.startsWith('Bearer ') ? authHeader.substring(7) : undefined;
+    const token = cookieToken || bearerToken;
+
+    if (!token) {
       return res.status(401).json({
         success: false,
         error: {
@@ -70,8 +81,6 @@ export const authenticate = async (req: Request, res: Response, next: NextFuncti
         }
       });
     }
-
-    const token = authHeader.substring(7); // Remove 'Bearer ' prefix
 
     let decodedToken: JWTPayload;
     try {
@@ -85,6 +94,18 @@ export const authenticate = async (req: Request, res: Response, next: NextFuncti
         }
       });
     }
+
+    if (decodedToken.jti && _jtiBlacklist.has(decodedToken.jti)) {
+      return res.status(401).json({
+        success: false,
+        error: {
+          code: 'TOKEN_REVOKED',
+          message: 'Token has been revoked'
+        }
+      });
+    }
+
+    if (decodedToken.jti) req.tokenJti = decodedToken.jti;
 
     const pool = database.getPool();
     const userService = new UserService(pool);

--- a/backend/src/routes/approvalWorkflows.ts
+++ b/backend/src/routes/approvalWorkflows.ts
@@ -18,7 +18,7 @@ import { Pool } from 'mysql2/promise';
 import { ApprovalEngineService } from '../services/ApprovalEngineService';
 import { authenticate, requirePermission } from '../middleware/auth';
 import { validateParams, validateBody } from '../middleware/validation';
-import { idParam, createApprovalWorkflowBody, updateApprovalWorkflowBody } from '../schemas';
+import { idParam, createApprovalWorkflowBody, updateApprovalWorkflowBody, escalateBody } from '../schemas';
 import { logger } from '../config/logger';
 
 export const createApprovalWorkflowsRouter = (pool: Pool): Router => {
@@ -26,9 +26,9 @@ export const createApprovalWorkflowsRouter = (pool: Pool): Router => {
   const engine = new ApprovalEngineService(pool);
 
   // Escalation trigger — called by cron or admin; requires approval.manage
-  router.post('/escalate', authenticate, requirePermission('approval.manage'), async (req: Request, res: Response) => {
+  router.post('/escalate', authenticate, requirePermission('approval.manage'), validateBody(escalateBody), async (_req: Request, res: Response) => {
     try {
-      const nowIso: string | undefined = req.body?.now ?? undefined;
+      const nowIso: string | undefined = res.locals.body.now ?? undefined;
       const overdue = await engine.processEscalations(nowIso);
       res.json({ success: true, data: { overdue, count: overdue.length } });
     } catch (error) {

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -13,16 +13,27 @@
  * @author Luca Ostinelli
  */
 
+import crypto from 'crypto';
 import { Router, Request, Response } from 'express';
 import { Pool } from 'mysql2/promise';
 import rateLimit from 'express-rate-limit';
 import { UserService } from '../services/UserService';
 import { RbacService } from '../services/RbacService';
-import { authenticate } from '../middleware/auth';
+import { authenticate, addToBlacklist } from '../middleware/auth';
 import jwt, { SignOptions } from 'jsonwebtoken';
 import { logger } from '../config/logger';
 
 import { config } from '../config';
+
+const isProduction = process.env.NODE_ENV === 'production';
+
+const JWT_COOKIE_NAME = 'token';
+const JWT_COOKIE_OPTIONS = {
+  httpOnly: true,
+  secure: isProduction,
+  sameSite: 'lax' as const,
+  maxAge: 24 * 60 * 60 * 1000, // 24 hours
+};
 
 export const createAuthRouter = (pool: Pool) => {
   const router = Router();
@@ -118,12 +129,14 @@ router.post('/login', loginLimiter, async (req: Request, res: Response) => {
 
     // Generate JWT token. Only the user id is embedded; permissions are
     // resolved from the database on every request by the auth middleware.
+    const jti = crypto.randomUUID();
     const token = jwt.sign(
-      { userId: user.id, email: user.email },
+      { userId: user.id, email: user.email, jti },
       config.jwt.secret,
       jwtSignOptions
     );
 
+    res.cookie(JWT_COOKIE_NAME, token, JWT_COOKIE_OPTIONS);
     res.json({
       success: true,
       data: {
@@ -202,12 +215,14 @@ router.post('/refresh', authenticate, async (req: Request, res: Response) => {
 
     const { password_hash: _password_hash, salt: _salt, ...userWithoutPassword } = user as any;
 
+    const jti = crypto.randomUUID();
     const token = jwt.sign(
-      { userId: user.id, email: user.email },
+      { userId: user.id, email: user.email, jti },
       config.jwt.secret,
       jwtSignOptions
     );
-    
+
+    res.cookie(JWT_COOKIE_NAME, token, JWT_COOKIE_OPTIONS);
     res.json({
       success: true,
       data: {
@@ -238,10 +253,11 @@ router.post('/refresh', authenticate, async (req: Request, res: Response) => {
  * @middleware authenticate
  * @returns    {Object} `{ success: true, message: "Logged out successfully" }`
  */
-router.post('/logout', authenticate, (_req: Request, res: Response) => {
-  // In JWT-based authentication, logout is primarily client-side.
-  // The client removes the token from storage.
-  // For enhanced security, implement server-side token blacklisting.
+router.post('/logout', authenticate, (req: Request, res: Response) => {
+  if (req.tokenJti) {
+    addToBlacklist(req.tokenJti);
+  }
+  res.clearCookie(JWT_COOKIE_NAME);
   res.json({
     success: true,
     message: 'Logged out successfully'

--- a/backend/src/routes/directory.ts
+++ b/backend/src/routes/directory.ts
@@ -16,6 +16,8 @@ import { Pool } from 'mysql2/promise';
 import bcrypt from 'bcrypt';
 import { Router, Request, Response } from 'express';
 import { authenticate, requirePermission } from '../middleware/auth';
+import { validateBody } from '../middleware/validation';
+import { directoryFieldsBody } from '../schemas';
 import { UserDirectoryService } from '../services/UserDirectoryService';
 import { config } from '../config';
 
@@ -41,9 +43,9 @@ export const createDirectoryRouter = (pool: Pool): Router => {
     res.json({ success: true, data: profile });
   });
 
-  router.put('/users/:id/fields', requirePermission('user.manage'), async (req: Request, res: Response) => {
+  router.put('/users/:id/fields', requirePermission('user.manage'), validateBody(directoryFieldsBody), async (req: Request, res: Response) => {
     try {
-      const fields = Array.isArray(req.body?.fields) ? req.body.fields : [];
+      const fields = res.locals.body.fields;
       await service.setFields(Number(req.params.id), fields);
       const profile = await service.getProfile(Number(req.params.id));
       res.json({ success: true, data: profile });

--- a/backend/src/routes/modules.ts
+++ b/backend/src/routes/modules.ts
@@ -11,6 +11,8 @@ import { Router, Request, Response } from 'express';
 import { Pool } from 'mysql2/promise';
 import { ModuleService } from '../services/ModuleService';
 import { authenticate, requirePermission } from '../middleware/auth';
+import { validateBody } from '../middleware/validation';
+import { moduleEnabledBody } from '../schemas';
 import { logger } from '../config/logger';
 
 export const createModulesRouter = (pool: Pool): Router => {
@@ -27,16 +29,10 @@ export const createModulesRouter = (pool: Pool): Router => {
     }
   });
 
-  router.put('/:code', authenticate, requirePermission('settings.manage'), async (req: Request, res: Response) => {
+  router.put('/:code', authenticate, requirePermission('settings.manage'), validateBody(moduleEnabledBody), async (req: Request, res: Response) => {
     try {
       const { code } = req.params;
-      const { isEnabled } = req.body;
-      if (typeof isEnabled !== 'boolean') {
-        return res.status(400).json({
-          success: false,
-          error: { code: 'INVALID_INPUT', message: 'isEnabled (boolean) is required' },
-        });
-      }
+      const { isEnabled } = res.locals.body;
       const updated = await moduleService.setEnabled(code, isEnabled);
       res.json({ success: true, data: updated, message: `Module '${code}' ${isEnabled ? 'enabled' : 'disabled'}` });
     } catch (error: any) {

--- a/backend/src/routes/policies.ts
+++ b/backend/src/routes/policies.ts
@@ -23,7 +23,7 @@ import { Pool } from 'mysql2/promise';
 import { Router, Request, Response } from 'express';
 import { authenticate, requirePermission, userHasPermission } from '../middleware/auth';
 import { validateBody } from '../middleware/validation';
-import { createPolicyExceptionBody, createPolicyBody, updatePolicyBody } from '../schemas';
+import { createPolicyExceptionBody, createPolicyBody, updatePolicyBody, validateAssignmentBody, updateApprovalMatrixBody } from '../schemas';
 import { PolicyService } from '../services/PolicyService';
 import { PolicyExceptionService } from '../services/PolicyExceptionService';
 import { ApprovalMatrixService } from '../services/ApprovalMatrixService';
@@ -47,11 +47,11 @@ export const createPoliciesRouter = (pool: Pool): Router => {
 
   // ------------- Validation -------------
 
-  router.post('/validate/assignment', async (req: Request, res: Response) => {
+  router.post('/validate/assignment', validateBody(validateAssignmentBody), async (_req: Request, res: Response) => {
     try {
       const result = await validator.validateAssignment({
-        userId: Number(req.body?.userId),
-        shiftId: Number(req.body?.shiftId),
+        userId: res.locals.body.userId,
+        shiftId: res.locals.body.shiftId,
       });
       res.json({ success: true, data: result });
     } catch (err) {
@@ -72,9 +72,9 @@ export const createPoliciesRouter = (pool: Pool): Router => {
     }
   });
 
-  router.put('/approval-matrix/:changeType', requirePermission('approval.manage'), async (req: Request, res: Response) => {
+  router.put('/approval-matrix/:changeType', requirePermission('approval.manage'), validateBody(updateApprovalMatrixBody), async (req: Request, res: Response) => {
     try {
-      const updated = await matrix.update(req.params.changeType, req.body ?? {});
+      const updated = await matrix.update(req.params.changeType, res.locals.body);
       res.json({ success: true, data: updated });
     } catch (err) {
       const msg = (err as Error).message;

--- a/backend/src/routes/preferences.ts
+++ b/backend/src/routes/preferences.ts
@@ -12,6 +12,8 @@
 import { Pool } from 'mysql2/promise';
 import { Router, Request, Response } from 'express';
 import { authenticate, requirePermission } from '../middleware/auth';
+import { validateParams, validateBody } from '../middleware/validation';
+import { userIdParam, upsertPreferencesBody } from '../schemas';
 import { PreferencesService } from '../services/PreferencesService';
 import { logger } from '../config/logger';
 
@@ -35,18 +37,18 @@ export const createPreferencesRouter = (pool: Pool): Router => {
     }
   });
 
-  router.put('/me', async (req: Request, res: Response) => {
+  router.put('/me', validateBody(upsertPreferencesBody), async (_req: Request, res: Response) => {
     try {
-      const data = await service.upsert(req.user!.id, req.body || {});
+      const data = await service.upsert(_req.user!.id, res.locals.body);
       res.json({ success: true, data });
     } catch (err) {
       respondError(res, 400, 'VALIDATION_ERROR', (err as Error).message);
     }
   });
 
-  router.get('/:userId', requirePermission('preferences.manage'), async (req: Request, res: Response) => {
+  router.get('/:userId', requirePermission('preferences.manage'), validateParams(userIdParam), async (_req: Request, res: Response) => {
     try {
-      const userId = Number(req.params.userId);
+      const userId = res.locals.params.userId;
       const data = await service.getByUserId(userId);
       res.json({ success: true, data });
     } catch (err) {
@@ -55,10 +57,10 @@ export const createPreferencesRouter = (pool: Pool): Router => {
     }
   });
 
-  router.put('/:userId', requirePermission('preferences.manage'), async (req: Request, res: Response) => {
+  router.put('/:userId', requirePermission('preferences.manage'), validateParams(userIdParam), validateBody(upsertPreferencesBody), async (_req: Request, res: Response) => {
     try {
-      const userId = Number(req.params.userId);
-      const data = await service.upsert(userId, req.body || {});
+      const userId = res.locals.params.userId;
+      const data = await service.upsert(userId, res.locals.body);
       res.json({ success: true, data });
     } catch (err) {
       respondError(res, 400, 'VALIDATION_ERROR', (err as Error).message);

--- a/backend/src/routes/settings.ts
+++ b/backend/src/routes/settings.ts
@@ -17,7 +17,8 @@ import { Router } from 'express';
 import { Pool } from 'mysql2/promise';
 import { SystemSettingsService } from '../services/SystemSettingsService';
 import { authenticate, userHasPermission } from '../middleware/auth';
-import { UpdateSystemSettingRequest } from '../types';
+import { validateBody } from '../middleware/validation';
+import { updateCurrencyBody, updateTimePeriodBody, updateSettingValueBody } from '../schemas';
 import { logger } from '../config/logger';
 
 export const createSystemSettingsRouter = (pool: Pool) => {
@@ -79,7 +80,7 @@ export const createSystemSettingsRouter = (pool: Pool) => {
   });
 
   // Update currency (admin only)
-  router.put('/currency', authenticate, async (req, res) => {
+  router.put('/currency', authenticate, validateBody(updateCurrencyBody), async (req, res) => {
     try {
       const user = req.user!;
 
@@ -90,14 +91,7 @@ export const createSystemSettingsRouter = (pool: Pool) => {
         });
       }
 
-      const { currency } = req.body;
-
-      if (!['EUR', 'USD'].includes(currency)) {
-        return res.status(400).json({
-          success: false,
-          error: { code: 'INVALID_INPUT', message: 'Currency must be EUR or USD' }
-        });
-      }
+      const { currency } = res.locals.body;
 
       await settingsService.setCurrency(currency);
 
@@ -133,7 +127,7 @@ export const createSystemSettingsRouter = (pool: Pool) => {
   });
 
   // Update time period (admin only)
-  router.put('/time-period', authenticate, async (req, res) => {
+  router.put('/time-period', authenticate, validateBody(updateTimePeriodBody), async (req, res) => {
     try {
       const user = req.user!;
 
@@ -144,14 +138,7 @@ export const createSystemSettingsRouter = (pool: Pool) => {
         });
       }
 
-      const { timePeriod } = req.body;
-
-      if (!['daily', 'weekly', 'monthly', 'yearly'].includes(timePeriod)) {
-        return res.status(400).json({
-          success: false,
-          error: { code: 'INVALID_INPUT', message: 'Time period must be daily, weekly, monthly, or yearly' }
-        });
-      }
+      const { timePeriod } = res.locals.body;
 
       await settingsService.setTimePeriod(timePeriod);
 
@@ -196,7 +183,7 @@ export const createSystemSettingsRouter = (pool: Pool) => {
   });
 
   // Update setting value (admin only)
-  router.put('/:category/:key', authenticate, async (req, res) => {
+  router.put('/:category/:key', authenticate, validateBody(updateSettingValueBody), async (req, res) => {
     try {
       const user = req.user!;
 
@@ -209,14 +196,7 @@ export const createSystemSettingsRouter = (pool: Pool) => {
       }
 
       const { category, key } = req.params;
-      const { value }: UpdateSystemSettingRequest = req.body;
-
-      if (!value && value !== '') {
-        return res.status(400).json({
-          success: false,
-          error: { code: 'INVALID_INPUT', message: 'Setting value is required' }
-        });
-      }
+      const { value } = res.locals.body;
 
       // Validate specific settings
       if (category === 'general' && key === 'currency') {

--- a/backend/src/routes/twoFactor.ts
+++ b/backend/src/routes/twoFactor.ts
@@ -12,6 +12,8 @@
 import { Pool } from 'mysql2/promise';
 import { Router, Request, Response } from 'express';
 import { authenticate } from '../middleware/auth';
+import { validateBody } from '../middleware/validation';
+import { twoFactorCodeBody } from '../schemas';
 import { TwoFactorService } from '../services/TwoFactorService';
 import { logger } from '../config/logger';
 
@@ -35,10 +37,10 @@ export const createTwoFactorRouter = (pool: Pool): Router => {
     }
   });
 
-  router.post('/enable', async (req: Request, res: Response) => {
+  router.post('/enable', validateBody(twoFactorCodeBody), async (_req: Request, res: Response) => {
     try {
-      const code = (req.body?.code as string | undefined) ?? '';
-      const data = await service.confirmEnable(req.user!.id, code);
+      const code = res.locals.body.code as string;
+      const data = await service.confirmEnable(_req.user!.id, code);
       res.json({ success: true, data });
     } catch (err) {
       respondError(res, 400, 'TOTP_ENABLE_FAILED', (err as Error).message);
@@ -55,10 +57,10 @@ export const createTwoFactorRouter = (pool: Pool): Router => {
     }
   });
 
-  router.post('/verify', async (req: Request, res: Response) => {
+  router.post('/verify', validateBody(twoFactorCodeBody), async (_req: Request, res: Response) => {
     try {
-      const code = (req.body?.code as string | undefined) ?? '';
-      const ok = await service.verifyCode(req.user!.id, code);
+      const code = res.locals.body.code as string;
+      const ok = await service.verifyCode(_req.user!.id, code);
       res.json({ success: true, data: { valid: ok } });
     } catch (err) {
       logger.error('2fa verify error:', err);

--- a/backend/src/schemas/index.ts
+++ b/backend/src/schemas/index.ts
@@ -283,3 +283,56 @@ export const updatePolicyBody = z.object({
   description: z.string().nullable().optional(),
   isActive: z.boolean().optional(),
 });
+
+export const escalateBody = z.object({
+  now: z.string().optional(),
+});
+
+export const twoFactorCodeBody = z.object({
+  code: z.string().min(1, 'code is required'),
+});
+
+export const upsertPreferencesBody = z.object({
+  maxHoursPerWeek: z.number().positive().optional(),
+  minHoursPerWeek: z.number().nonnegative().optional(),
+  maxConsecutiveDays: z.number().int().min(1).max(14).optional(),
+  preferredShifts: z.array(z.number().int().positive()).optional(),
+  avoidShifts: z.array(z.number().int().positive()).optional(),
+  notes: z.string().nullable().optional(),
+});
+
+export const moduleEnabledBody = z.object({
+  isEnabled: z.boolean(),
+});
+
+export const directoryFieldsBody = z.object({
+  fields: z.array(z.object({
+    key: z.string().min(1),
+    value: z.unknown(),
+  })),
+});
+
+export const validateAssignmentBody = z.object({
+  userId: z.number().int().positive(),
+  shiftId: z.number().int().positive(),
+});
+
+export const updateApprovalMatrixBody = z.object({
+  approverScope: z.enum(['policy_owner', 'unit_manager', 'unit_manager_chain', 'company_role', 'company_user']).optional(),
+  approverRoleId: z.number().int().positive().nullable().optional(),
+  approverUserId: z.number().int().positive().nullable().optional(),
+  autoApproveForOwner: z.boolean().optional(),
+  description: z.string().nullable().optional(),
+});
+
+export const updateCurrencyBody = z.object({
+  currency: z.enum(['EUR', 'USD']),
+});
+
+export const updateTimePeriodBody = z.object({
+  timePeriod: z.enum(['daily', 'weekly', 'monthly', 'yearly']),
+});
+
+export const updateSettingValueBody = z.object({
+  value: z.string(),
+});

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -388,7 +388,3 @@ export interface SystemSetting {
   createdAt: Date;
   updatedAt: Date;
 }
-
-export interface UpdateSystemSettingRequest {
-  value: string;
-}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,7 +20,7 @@
  * @author Luca Ostinelli
  */
 
-import React from 'react';
+import React, { lazy, Suspense } from 'react';
 import { Routes, Route, Navigate } from 'react-router-dom';
 
 // Layout Components
@@ -29,16 +29,8 @@ import ProtectedRoute from './components/Auth/ProtectedRoute';
 import PermissionRoute from './components/Auth/PermissionRoute';
 import ErrorBoundary from './components/ErrorBoundary';
 
-// Page Components
+// Eagerly loaded — these are tiny and always needed at first render
 import Login from './pages/Auth/Login';
-import Dashboard from './pages/Dashboard/Dashboard';
-import Employees from './pages/Employees/Employees';
-import Shifts from './pages/Shifts/Shifts';
-import Schedule from './pages/Schedule/Schedule';
-import Reports from './pages/Reports/Reports';
-import Settings from './pages/Settings/Settings';
-import OrgManagement from './pages/Org/OrgManagement';
-import Policies from './pages/Policies/Policies';
 
 // Contexts
 import { AuthProvider } from './contexts/AuthContext';
@@ -47,6 +39,16 @@ import { I18nProvider } from './i18n/I18nContext';
 
 // Chrome
 import DemoBanner from './components/DemoBanner';
+
+// Lazily loaded page components — split into separate chunks
+const Dashboard = lazy(() => import('./pages/Dashboard/Dashboard'));
+const Employees = lazy(() => import('./pages/Employees/Employees'));
+const Shifts = lazy(() => import('./pages/Shifts/Shifts'));
+const Schedule = lazy(() => import('./pages/Schedule/Schedule'));
+const Reports = lazy(() => import('./pages/Reports/Reports'));
+const Settings = lazy(() => import('./pages/Settings/Settings'));
+const OrgManagement = lazy(() => import('./pages/Org/OrgManagement'));
+const Policies = lazy(() => import('./pages/Policies/Policies'));
 
 /**
  * Main Application Component
@@ -73,6 +75,7 @@ const App: React.FC = () => {
       <AuthProvider>
         <DemoBanner />
         <ErrorBoundary>
+        <Suspense fallback={null}>
         <Routes>
         {/* Public Routes - Accessible without authentication */}
         <Route path="/login" element={<Login />} />
@@ -128,6 +131,7 @@ const App: React.FC = () => {
           {/* Catch-all route - Redirect unknown paths to dashboard */}
           <Route path="*" element={<Navigate to="/dashboard" replace />} />
         </Routes>
+        </Suspense>
         </ErrorBoundary>
       </AuthProvider>
       </I18nProvider>

--- a/frontend/src/components/Layout/Sidebar.tsx
+++ b/frontend/src/components/Layout/Sidebar.tsx
@@ -116,21 +116,23 @@ const Sidebar: React.FC<SidebarProps> = ({ collapsed }) => {
         {!collapsed && 'Staff Scheduler'}
       </div>
       
-      <ul className="sidebar-nav">
-        {filteredMenuItems.map((item) => (
-          <li key={item.path} className="sidebar-nav-item">
-            <NavLink
-              to={item.path}
-              className={({ isActive }) =>
-                `sidebar-nav-link ${isActive ? 'active' : ''}`
-              }
-            >
-              <i className={item.icon}></i>
-              {!collapsed && item.label}
-            </NavLink>
-          </li>
-        ))}
-      </ul>
+      <nav aria-label="Main navigation">
+        <ul className="sidebar-nav">
+          {filteredMenuItems.map((item) => (
+            <li key={item.path} className="sidebar-nav-item">
+              <NavLink
+                to={item.path}
+                className={({ isActive }) =>
+                  `sidebar-nav-link ${isActive ? 'active' : ''}`
+                }
+              >
+                <i className={item.icon}></i>
+                {!collapsed && item.label}
+              </NavLink>
+            </li>
+          ))}
+        </ul>
+      </nav>
 
       <div className="mt-auto p-3 border-top">
         {user && (

--- a/frontend/src/contexts/AuthContext.test.tsx
+++ b/frontend/src/contexts/AuthContext.test.tsx
@@ -1,12 +1,10 @@
 /**
  * AuthContext unit tests covering:
  *   - useAuth must throw outside provider
- *   - bootstrap with no token marks loading=false / unauth
- *   - bootstrap with token + verify success → authenticated
- *   - bootstrap with token + verify failure → token cleared
+ *   - bootstrap via verifyToken (cookie-based, no localStorage)
  *   - login success / failure
  *   - refresh success / failure
- *   - logout clears the token
+ *   - logout calls server and clears state
  */
 
 import React from 'react';
@@ -23,7 +21,6 @@ const wrapper = ({ children }: { children: React.ReactNode }) => (
 );
 
 beforeEach(() => {
-  localStorage.clear();
   jest.clearAllMocks();
 });
 
@@ -40,14 +37,14 @@ describe('useAuth', () => {
 });
 
 describe('AuthProvider bootstrap', () => {
-  it('finishes loading=false when no token', async () => {
+  it('finishes loading=false when verify fails', async () => {
+    mockedAuthService.verifyToken.mockRejectedValue(new Error('no session'));
     const { result } = renderHook(() => useAuth(), { wrapper });
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     expect(result.current.isAuthenticated).toBe(false);
   });
 
   it('authenticates when verify succeeds', async () => {
-    localStorage.setItem('token', 't');
     mockedAuthService.verifyToken.mockResolvedValue({
       success: true,
       data: { id: 1, email: 'a@x', firstName: 'A', lastName: 'B', role: 'admin' } as never,
@@ -56,25 +53,24 @@ describe('AuthProvider bootstrap', () => {
     await waitFor(() => expect(result.current.isAuthenticated).toBe(true));
   });
 
-  it('clears token when verify fails', async () => {
-    localStorage.setItem('token', 't');
+  it('sets loading=false when verify returns success:false', async () => {
     mockedAuthService.verifyToken.mockResolvedValue({ success: false } as never);
     const { result } = renderHook(() => useAuth(), { wrapper });
     await waitFor(() => expect(result.current.isLoading).toBe(false));
-    expect(localStorage.getItem('token')).toBeNull();
+    expect(result.current.isAuthenticated).toBe(false);
   });
 
-  it('clears token when verify rejects', async () => {
-    localStorage.setItem('token', 't');
+  it('sets loading=false when verify rejects', async () => {
     mockedAuthService.verifyToken.mockRejectedValue(new Error('boom'));
     const { result } = renderHook(() => useAuth(), { wrapper });
     await waitFor(() => expect(result.current.isLoading).toBe(false));
-    expect(localStorage.getItem('token')).toBeNull();
+    expect(result.current.isAuthenticated).toBe(false);
   });
 });
 
 describe('AuthProvider actions', () => {
-  it('login success persists token + sets user', async () => {
+  it('login success sets user and isAuthenticated', async () => {
+    mockedAuthService.verifyToken.mockRejectedValue(new Error('no session'));
     mockedAuthService.login.mockResolvedValue({
       success: true,
       data: {
@@ -87,11 +83,12 @@ describe('AuthProvider actions', () => {
     await act(async () => {
       await result.current.login({ email: 'a@x', password: 'pw' } as never);
     });
-    expect(localStorage.getItem('token')).toBe('t');
     expect(result.current.isAuthenticated).toBe(true);
+    expect(result.current.user?.email).toBe('a@x');
   });
 
   it('login failure dispatches LOGIN_FAILURE', async () => {
+    mockedAuthService.verifyToken.mockRejectedValue(new Error('no session'));
     mockedAuthService.login.mockResolvedValue({ success: false, error: { message: 'no' } } as never);
     const { result } = renderHook(() => useAuth(), { wrapper });
     await waitFor(() => expect(result.current.isLoading).toBe(false));
@@ -106,30 +103,19 @@ describe('AuthProvider actions', () => {
     expect(result.current.isAuthenticated).toBe(false);
   });
 
-  it('logout removes token + sets unauthenticated', async () => {
-    localStorage.setItem('token', 't');
+  it('logout calls authService.logout and sets unauthenticated', async () => {
     mockedAuthService.verifyToken.mockResolvedValue({
       success: true,
       data: { id: 1, email: 'a@x', firstName: 'A', lastName: 'B', role: 'admin' } as never,
     });
+    mockedAuthService.logout.mockResolvedValue();
     const { result } = renderHook(() => useAuth(), { wrapper });
     await waitFor(() => expect(result.current.isAuthenticated).toBe(true));
     act(() => result.current.logout());
-    expect(localStorage.getItem('token')).toBeNull();
     expect(result.current.isAuthenticated).toBe(false);
   });
 
-  it('refreshToken without a stored token logs out', async () => {
-    const { result } = renderHook(() => useAuth(), { wrapper });
-    await waitFor(() => expect(result.current.isLoading).toBe(false));
-    await act(async () => {
-      await result.current.refreshToken();
-    });
-    expect(result.current.isAuthenticated).toBe(false);
-  });
-
-  it('refreshToken happy path swaps the token', async () => {
-    localStorage.setItem('token', 'old');
+  it('refreshToken happy path updates state', async () => {
     mockedAuthService.verifyToken.mockResolvedValue({
       success: true,
       data: { id: 1, email: 'a@x', firstName: 'A', lastName: 'B', role: 'admin' } as never,
@@ -146,10 +132,26 @@ describe('AuthProvider actions', () => {
     await act(async () => {
       await result.current.refreshToken();
     });
-    expect(localStorage.getItem('token')).toBe('new');
+    expect(result.current.isAuthenticated).toBe(true);
+  });
+
+  it('refreshToken failure logs out', async () => {
+    mockedAuthService.verifyToken.mockResolvedValue({
+      success: true,
+      data: { id: 1, email: 'a@x', firstName: 'A', lastName: 'B', role: 'admin' } as never,
+    });
+    mockedAuthService.logout.mockResolvedValue();
+    mockedAuthService.refreshToken.mockResolvedValue({ success: false } as never);
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(result.current.isAuthenticated).toBe(true));
+    await act(async () => {
+      await result.current.refreshToken();
+    });
+    expect(result.current.isAuthenticated).toBe(false);
   });
 
   it('keeps callback identities stable across renders', async () => {
+    mockedAuthService.verifyToken.mockRejectedValue(new Error('no session'));
     const { result, rerender } = renderHook(() => useAuth(), { wrapper });
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     const first = {
@@ -161,20 +163,5 @@ describe('AuthProvider actions', () => {
     expect(result.current.login).toBe(first.login);
     expect(result.current.logout).toBe(first.logout);
     expect(result.current.refreshToken).toBe(first.refreshToken);
-  });
-
-  it('refreshToken failure logs out', async () => {
-    localStorage.setItem('token', 'old');
-    mockedAuthService.verifyToken.mockResolvedValue({
-      success: true,
-      data: { id: 1, email: 'a@x', firstName: 'A', lastName: 'B', role: 'admin' } as never,
-    });
-    mockedAuthService.refreshToken.mockResolvedValue({ success: false } as never);
-    const { result } = renderHook(() => useAuth(), { wrapper });
-    await waitFor(() => expect(result.current.isAuthenticated).toBe(true));
-    await act(async () => {
-      await result.current.refreshToken();
-    });
-    expect(result.current.isAuthenticated).toBe(false);
   });
 });

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,22 +1,10 @@
 /**
  * Authentication Context Provider
- * 
+ *
  * Manages application-wide authentication state using React Context API.
- * Provides authentication methods and user state to all child components.
- * 
- * Features:
- * - JWT token management with localStorage persistence
- * - Automatic token verification on app startup
- * - Login/logout functionality
- * - Token refresh capabilities
- * - Error handling for authentication failures
- * - Loading states for better UX
- * 
- * Security:
- * - Automatic token cleanup on logout
- * - Token verification with backend
- * - Secure token storage practices
- * 
+ * JWT tokens are stored exclusively in httpOnly cookies set by the server;
+ * no token is persisted in localStorage or sessionStorage.
+ *
  * @author Luca Ostinelli
  */
 
@@ -24,12 +12,6 @@ import React, { createContext, useContext, useReducer, useEffect, useCallback, u
 import { User, LoginRequest, LoginResponse, ApiResponse } from '../types';
 import * as authService from '../services/authService';
 
-/**
- * Authentication State Interface
- * 
- * Defines the structure of authentication state managed by the context.
- * Excludes sensitive user data like password hashes.
- */
 interface AuthState {
   user: Omit<User, 'passwordHash' | 'salt'> | null;
   token: string | null;
@@ -38,32 +20,14 @@ interface AuthState {
   error: string | null;
 }
 
-/**
- * Authentication Context Interface
- * 
- * Extends AuthState with methods for authentication actions.
- * Provides the complete API for authentication management.
- */
 interface AuthContextType extends AuthState {
   login: (credentials: LoginRequest) => Promise<void>;
   logout: () => void;
   refreshToken: () => Promise<void>;
 }
 
-/**
- * Create Authentication Context
- * 
- * Creates the React context for authentication state management.
- * Initially undefined to ensure proper error handling.
- */
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
-/**
- * Authentication Action Types
- * 
- * Defines all possible actions for the authentication reducer.
- * Uses discriminated unions for type safety.
- */
 type AuthAction =
   | { type: 'LOGIN_START' }
   | { type: 'LOGIN_SUCCESS'; payload: { user: Omit<User, 'passwordHash' | 'salt'>; token: string } }
@@ -72,24 +36,10 @@ type AuthAction =
   | { type: 'SET_USER'; payload: Omit<User, 'passwordHash' | 'salt'> }
   | { type: 'SET_LOADING'; payload: boolean };
 
-/**
- * Authentication State Reducer
- * 
- * Manages authentication state transitions based on dispatched actions.
- * Implements immutable state updates for predictable state management.
- * 
- * @param state - Current authentication state
- * @param action - Action to process
- * @returns New authentication state
- */
 const authReducer = (state: AuthState, action: AuthAction): AuthState => {
   switch (action.type) {
     case 'LOGIN_START':
-      return {
-        ...state,
-        isLoading: true,
-        error: null,
-      };
+      return { ...state, isLoading: true, error: null };
     case 'LOGIN_SUCCESS':
       return {
         ...state,
@@ -109,23 +59,11 @@ const authReducer = (state: AuthState, action: AuthAction): AuthState => {
         error: action.payload || 'Authentication failed',
       };
     case 'LOGOUT':
-      return {
-        ...state,
-        user: null,
-        token: null,
-        isAuthenticated: false,
-        isLoading: false,
-      };
+      return { ...state, user: null, token: null, isAuthenticated: false, isLoading: false };
     case 'SET_USER':
-      return {
-        ...state,
-        user: action.payload,
-      };
+      return { ...state, user: action.payload };
     case 'SET_LOADING':
-      return {
-        ...state,
-        isLoading: action.payload,
-      };
+      return { ...state, isLoading: action.payload };
     default:
       return state;
   }
@@ -147,26 +85,18 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   const [state, dispatch] = useReducer(authReducer, initialState);
 
   useEffect(() => {
-    // Check for existing token on app load
     const initializeAuth = async () => {
-      const token = localStorage.getItem('token');
-      if (token) {
-        try {
-          const response = await authService.verifyToken(token);
-          if (response.success && response.data) {
-            dispatch({
-              type: 'LOGIN_SUCCESS',
-              payload: { user: response.data, token },
-            });
-          } else {
-            localStorage.removeItem('token');
-            dispatch({ type: 'LOGIN_FAILURE' });
-          }
-        } catch (error) {
-          localStorage.removeItem('token');
-          dispatch({ type: 'LOGIN_FAILURE' });
+      try {
+        const response = await authService.verifyToken();
+        if (response.success && response.data) {
+          dispatch({
+            type: 'LOGIN_SUCCESS',
+            payload: { user: response.data, token: '' },
+          });
+        } else {
+          dispatch({ type: 'SET_LOADING', payload: false });
         }
-      } else {
+      } catch {
         dispatch({ type: 'SET_LOADING', payload: false });
       }
     };
@@ -182,7 +112,6 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
       if (response.success && response.data) {
         const { user, token } = response.data;
-        localStorage.setItem('token', token);
         dispatch({
           type: 'LOGIN_SUCCESS',
           payload: { user, token },
@@ -197,21 +126,14 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   }, []);
 
   const logout = useCallback((): void => {
-    localStorage.removeItem('token');
+    authService.logout().catch(() => {});
     dispatch({ type: 'LOGOUT' });
   }, []);
 
   const refreshToken = useCallback(async (): Promise<void> => {
-    const token = localStorage.getItem('token');
-    if (!token) {
-      logout();
-      return;
-    }
-
     try {
-      const response = await authService.refreshToken(token);
+      const response = await authService.refreshToken();
       if (response.success && response.data) {
-        localStorage.setItem('token', response.data.token);
         dispatch({
           type: 'LOGIN_SUCCESS',
           payload: response.data,
@@ -219,7 +141,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       } else {
         logout();
       }
-    } catch (error) {
+    } catch {
       logout();
     }
   }, [logout]);

--- a/frontend/src/services/apiUtils.test.ts
+++ b/frontend/src/services/apiUtils.test.ts
@@ -37,20 +37,20 @@ describe('handleResponse', () => {
 });
 
 describe('getAuthHeaders', () => {
-  beforeEach(() => {
-    localStorage.clear();
-  });
-
   it('always sets Content-Type', () => {
-    const headers = getAuthHeaders() as Record<string, string>;
+    const init = getAuthHeaders();
+    const headers = init.headers as Record<string, string>;
     expect(headers['Content-Type']).toBe('application/json');
   });
 
-  it('attaches a Bearer token only when one is in localStorage', () => {
-    expect((getAuthHeaders() as Record<string, string>).Authorization).toBeUndefined();
+  it('includes credentials: include for cookie-based auth', () => {
+    const init = getAuthHeaders();
+    expect(init.credentials).toBe('include');
+  });
 
-    localStorage.setItem('token', 'abc.def.ghi');
-    const headers = getAuthHeaders() as Record<string, string>;
-    expect(headers.Authorization).toBe('Bearer abc.def.ghi');
+  it('does not include an Authorization header', () => {
+    const init = getAuthHeaders();
+    const headers = init.headers as Record<string, string>;
+    expect(headers['Authorization']).toBeUndefined();
   });
 });

--- a/frontend/src/services/apiUtils.ts
+++ b/frontend/src/services/apiUtils.ts
@@ -4,7 +4,7 @@
  * Provides common helpers used across all service modules:
  * - ApiError: typed error class carrying the HTTP status code
  * - handleResponse: parses fetch responses and surfaces errors uniformly
- * - getAuthHeaders: builds the Authorization + Content-Type headers from localStorage
+ * - getAuthHeaders: builds the base request init for authenticated calls
  *
  * All service files must import from here instead of defining their own copies.
  *
@@ -61,14 +61,18 @@ export const handleResponse = async <T>(response: Response): Promise<ApiResponse
 };
 
 /**
- * Builds fetch headers including the JWT bearer token if present in localStorage.
- *
- * @returns HeadersInit object with Content-Type and optional Authorization header
+ * Base headers for authenticated API requests.
+ * Used internally by getAuthHeaders.
  */
-export const getAuthHeaders = (): HeadersInit => {
-  const token = localStorage.getItem('token');
-  return {
-    'Content-Type': 'application/json',
-    ...(token && { Authorization: `Bearer ${token}` }),
-  };
+export const AUTH_HEADERS: Record<string, string> = {
+  'Content-Type': 'application/json',
 };
+
+/**
+ * Returns a RequestInit object for authenticated fetch calls.
+ * Uses credentials: 'include' so the httpOnly auth cookie is sent automatically.
+ */
+export const getAuthHeaders = (): RequestInit => ({
+  credentials: 'include',
+  headers: { ...AUTH_HEADERS },
+});

--- a/frontend/src/services/authService.ts
+++ b/frontend/src/services/authService.ts
@@ -1,89 +1,55 @@
 /**
  * Authentication Service for Staff Scheduler Frontend
- * 
+ *
  * Handles all authentication-related API calls including login, logout,
  * token management, and user profile operations.
- * 
- * Features:
- * - JWT token management with localStorage
- * - Error handling with custom ApiError
- * - Automatic header management for authenticated requests
- * - Response parsing and type safety
- * 
+ *
  * @author Luca Ostinelli
  */
 
 import { ApiResponse, LoginRequest, LoginResponse, User } from '../types';
 import { handleResponse, API_BASE_URL } from './apiUtils';
 
-
-/**
- * Authenticates user with username and password
- * @param credentials - User login credentials
- * @returns Promise resolving to login response with token and user data
- * @throws {ApiError} When authentication fails or network error occurs
- * 
- * @example
- * ```typescript
- * const result = await login({ username: 'admin', password: 'password123' });
- * localStorage.setItem('token', result.data.token);
- * ```
- */
 export const login = async (credentials: LoginRequest): Promise<ApiResponse<LoginResponse>> => {
   const response = await fetch(`${API_BASE_URL}/auth/login`, {
     method: 'POST',
+    credentials: 'include',
     headers: {
       'Content-Type': 'application/json',
     },
     body: JSON.stringify(credentials),
   });
-  
   return handleResponse<LoginResponse>(response);
 };
 
-/**
- * Verifies JWT token validity and returns user information
- * @param token - JWT token to verify
- * @returns Promise resolving to user data if token is valid
- * @throws {ApiError} When token is invalid or expired
- * 
- * @example
- * ```typescript
- * const user = await verifyToken(storedToken);
- * console.log('Current user:', user.data);
- * ```
- */
-export const verifyToken = async (token: string): Promise<ApiResponse<User>> => {
+export const verifyToken = async (): Promise<ApiResponse<User>> => {
   const response = await fetch(`${API_BASE_URL}/auth/verify`, {
     method: 'GET',
+    credentials: 'include',
     headers: {
-      'Authorization': `Bearer ${token}`,
+      'Content-Type': 'application/json',
     },
   });
-  
   return handleResponse<User>(response);
 };
 
-/**
- * Refreshes an existing JWT token
- * @param token - Current JWT token to refresh
- * @returns Promise resolving to new token and user data
- * @throws {ApiError} When token refresh fails or token is invalid
- * 
- * @example
- * ```typescript
- * const refreshed = await refreshToken(currentToken);
- * localStorage.setItem('token', refreshed.data.token);
- * ```
- */
-export const refreshToken = async (token: string): Promise<ApiResponse<LoginResponse>> => {
+export const refreshToken = async (): Promise<ApiResponse<LoginResponse>> => {
   const response = await fetch(`${API_BASE_URL}/auth/refresh`, {
     method: 'POST',
+    credentials: 'include',
     headers: {
-      'Authorization': `Bearer ${token}`,
+      'Content-Type': 'application/json',
     },
   });
-  
   return handleResponse<LoginResponse>(response);
 };
 
+export const logout = async (): Promise<void> => {
+  await fetch(`${API_BASE_URL}/auth/logout`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+};

--- a/frontend/src/services/dashboardService.ts
+++ b/frontend/src/services/dashboardService.ts
@@ -22,7 +22,7 @@ import { handleResponse, getAuthHeaders, API_BASE_URL } from './apiUtils';
 export const getDashboardStats = async (): Promise<ApiResponse<DashboardStats>> => {
   const response = await fetch(`${API_BASE_URL}/dashboard/stats`, {
     method: 'GET',
-    headers: getAuthHeaders(),
+    ...getAuthHeaders(),
   });
 
   return handleResponse<DashboardStats>(response);
@@ -32,7 +32,7 @@ export const getRecentActivity = async (limit = 5): Promise<AuditLogEntry[]> => 
   try {
     const response = await fetch(`${API_BASE_URL}/audit-logs?limit=${limit}`, {
       method: 'GET',
-      headers: getAuthHeaders(),
+      ...getAuthHeaders(),
     });
     if (!response.ok) return [];
     const body = await response.json();

--- a/frontend/src/services/departmentService.ts
+++ b/frontend/src/services/departmentService.ts
@@ -7,7 +7,7 @@
  */
 
 import { ApiResponse } from '../types';
-import { getAuthHeaders, handleResponse, API_BASE_URL } from './apiUtils';
+import { AUTH_HEADERS, handleResponse, API_BASE_URL } from './apiUtils';
 
 
 export interface Department {
@@ -20,8 +20,9 @@ export interface Department {
 
 const request = async <T>(path: string, init: RequestInit = {}): Promise<ApiResponse<T>> => {
   const res = await fetch(`${API_BASE_URL}${path}`, {
+    credentials: 'include',
     ...init,
-    headers: { ...getAuthHeaders(), ...(init.headers || {}) },
+    headers: { ...AUTH_HEADERS, ...(init.headers as Record<string, string> ?? {}) },
   });
   return handleResponse<T>(res);
 };

--- a/frontend/src/services/employeeService.ts
+++ b/frontend/src/services/employeeService.ts
@@ -113,7 +113,7 @@ export const getEmployees = async (filters: EmployeeFilters = {}): Promise<ApiRe
 
   const response = await fetch(`${API_BASE_URL}/employees?${queryParams}`, {
     method: 'GET',
-    headers: getAuthHeaders(),
+    ...getAuthHeaders(),
   });
   
   return handleResponse<Employee[]>(response);
@@ -134,7 +134,7 @@ export const getEmployees = async (filters: EmployeeFilters = {}): Promise<ApiRe
 export const getEmployee = async (id: number | string): Promise<ApiResponse<Employee>> => {
   const response = await fetch(`${API_BASE_URL}/employees/${id}`, {
     method: 'GET',
-    headers: getAuthHeaders(),
+    ...getAuthHeaders(),
   });
   
   return handleResponse<Employee>(response);
@@ -161,7 +161,7 @@ export const getEmployee = async (id: number | string): Promise<ApiResponse<Empl
 export const createEmployee = async (employeeData: CreateEmployeeData): Promise<ApiResponse<Employee>> => {
   const response = await fetch(`${API_BASE_URL}/employees`, {
     method: 'POST',
-    headers: getAuthHeaders(),
+    ...getAuthHeaders(),
     body: JSON.stringify(employeeData),
   });
   
@@ -186,7 +186,7 @@ export const createEmployee = async (employeeData: CreateEmployeeData): Promise<
 export const updateEmployee = async (id: number | string, employeeData: UpdateEmployeeData): Promise<ApiResponse<Employee>> => {
   const response = await fetch(`${API_BASE_URL}/employees/${id}`, {
     method: 'PUT',
-    headers: getAuthHeaders(),
+    ...getAuthHeaders(),
     body: JSON.stringify(employeeData),
   });
   
@@ -208,7 +208,7 @@ export const updateEmployee = async (id: number | string, employeeData: UpdateEm
 export const deleteEmployee = async (id: number | string): Promise<ApiResponse<void>> => {
   const response = await fetch(`${API_BASE_URL}/employees/${id}`, {
     method: 'DELETE',
-    headers: getAuthHeaders(),
+    ...getAuthHeaders(),
   });
   
   return handleResponse<void>(response);

--- a/frontend/src/services/extraServices.test.ts
+++ b/frontend/src/services/extraServices.test.ts
@@ -289,7 +289,7 @@ describe('scheduleService extra', () => {
 
 describe('authService extra', () => {
   it('refreshToken POSTs', async () => {
-    await authService.refreshToken('jwt-token');
+    await authService.refreshToken();
     expect(lastInit().method).toBe('POST');
   });
 });

--- a/frontend/src/services/orgService.ts
+++ b/frontend/src/services/orgService.ts
@@ -4,7 +4,7 @@
  */
 
 import { ApiResponse } from '../types';
-import { getAuthHeaders, handleResponse, API_BASE_URL } from './apiUtils';
+import { AUTH_HEADERS, handleResponse, API_BASE_URL } from './apiUtils';
 
 
 export interface OrgUnit {
@@ -51,8 +51,9 @@ export interface EmployeeLoan {
 
 const request = async <T>(path: string, init: RequestInit = {}): Promise<ApiResponse<T>> => {
   const res = await fetch(`${API_BASE_URL}${path}`, {
+    credentials: 'include',
     ...init,
-    headers: { ...getAuthHeaders(), ...(init.headers || {}) },
+    headers: { ...AUTH_HEADERS, ...(init.headers as Record<string, string> ?? {}) },
   });
   return handleResponse<T>(res);
 };

--- a/frontend/src/services/policyService.ts
+++ b/frontend/src/services/policyService.ts
@@ -4,7 +4,7 @@
  */
 
 import { ApiResponse } from '../types';
-import { getAuthHeaders, handleResponse, API_BASE_URL } from './apiUtils';
+import { AUTH_HEADERS, handleResponse, API_BASE_URL } from './apiUtils';
 
 
 export type PolicyScope = 'global' | 'org_unit' | 'schedule' | 'shift_template';
@@ -69,8 +69,9 @@ interface PolicyViolation {
 
 const request = async <T>(path: string, init: RequestInit = {}): Promise<ApiResponse<T>> => {
   const res = await fetch(`${API_BASE_URL}${path}`, {
+    credentials: 'include',
     ...init,
-    headers: { ...getAuthHeaders(), ...(init.headers || {}) },
+    headers: { ...AUTH_HEADERS, ...(init.headers as Record<string, string> ?? {}) },
   });
   return handleResponse<T>(res);
 };

--- a/frontend/src/services/preferencesService.ts
+++ b/frontend/src/services/preferencesService.ts
@@ -33,7 +33,7 @@ interface UpsertPreferencesInput {
 export const getMyPreferences = async (): Promise<ApiResponse<UserPreferences>> => {
   const response = await fetch(`${API_BASE_URL}/preferences/me`, {
     method: 'GET',
-    headers: getAuthHeaders(),
+    ...getAuthHeaders(),
   });
   return handleResponse<UserPreferences>(response);
 };
@@ -43,7 +43,7 @@ export const updateMyPreferences = async (
 ): Promise<ApiResponse<UserPreferences>> => {
   const response = await fetch(`${API_BASE_URL}/preferences/me`, {
     method: 'PUT',
-    headers: getAuthHeaders(),
+    ...getAuthHeaders(),
     body: JSON.stringify(input),
   });
   return handleResponse<UserPreferences>(response);

--- a/frontend/src/services/reportsService.ts
+++ b/frontend/src/services/reportsService.ts
@@ -4,7 +4,7 @@
  */
 
 import { ApiResponse } from '../types';
-import { getAuthHeaders, handleResponse, API_BASE_URL } from './apiUtils';
+import { AUTH_HEADERS, handleResponse, API_BASE_URL } from './apiUtils';
 
 
 export interface HoursWorkedRow {
@@ -22,8 +22,9 @@ export interface CostByDepartmentRow {
 
 const request = async <T>(path: string, init: RequestInit = {}): Promise<ApiResponse<T>> => {
   const res = await fetch(`${API_BASE_URL}${path}`, {
+    credentials: 'include',
     ...init,
-    headers: { ...getAuthHeaders(), ...(init.headers || {}) },
+    headers: { ...AUTH_HEADERS, ...(init.headers as Record<string, string> ?? {}) },
   });
   return handleResponse<T>(res);
 };

--- a/frontend/src/services/scheduleService.ts
+++ b/frontend/src/services/scheduleService.ts
@@ -13,7 +13,7 @@
  */
 
 import { ApiResponse } from '../types';
-import { getAuthHeaders, handleResponse, API_BASE_URL } from './apiUtils';
+import { AUTH_HEADERS, handleResponse, API_BASE_URL } from './apiUtils';
 
 
 interface CreateScheduleParams {
@@ -38,8 +38,9 @@ const request = async <T>(
   init: RequestInit = {}
 ): Promise<ApiResponse<T>> => {
   const response = await fetch(`${API_BASE_URL}${path}`, {
+    credentials: 'include',
     ...init,
-    headers: { ...getAuthHeaders(), ...(init.headers || {}) },
+    headers: { ...AUTH_HEADERS, ...(init.headers as Record<string, string> ?? {}) },
   });
   return handleResponse<T>(response);
 };

--- a/frontend/src/services/settingsService.ts
+++ b/frontend/src/services/settingsService.ts
@@ -23,7 +23,7 @@ interface SystemSetting {
 export const getSystemSettings = async (): Promise<ApiResponse<SystemSetting[]>> => {
   const response = await fetch(`${API_BASE_URL}/settings`, {
     method: 'GET',
-    headers: getAuthHeaders(),
+    ...getAuthHeaders(),
   });
   return handleResponse<SystemSetting[]>(response);
 };
@@ -31,7 +31,7 @@ export const getSystemSettings = async (): Promise<ApiResponse<SystemSetting[]>>
 export const updateCurrency = async (currency: string): Promise<ApiResponse<{ currency: string }>> => {
   const response = await fetch(`${API_BASE_URL}/settings/currency`, {
     method: 'PUT',
-    headers: getAuthHeaders(),
+    ...getAuthHeaders(),
     body: JSON.stringify({ currency }),
   });
   return handleResponse<{ currency: string }>(response);
@@ -42,7 +42,7 @@ export const updateTimePeriod = async (
 ): Promise<ApiResponse<{ timePeriod: string }>> => {
   const response = await fetch(`${API_BASE_URL}/settings/time-period`, {
     method: 'PUT',
-    headers: getAuthHeaders(),
+    ...getAuthHeaders(),
     body: JSON.stringify({ timePeriod }),
   });
   return handleResponse<{ timePeriod: string }>(response);

--- a/frontend/src/services/shiftService.ts
+++ b/frontend/src/services/shiftService.ts
@@ -65,7 +65,7 @@ export const getShifts = async (filters: ShiftFilters = {}): Promise<ApiResponse
 
   const response = await fetch(`${API_BASE_URL}/shifts?${queryParams}`, {
     method: 'GET',
-    headers: getAuthHeaders(),
+    ...getAuthHeaders(),
   });
   
   return handleResponse<Shift[]>(response);
@@ -75,7 +75,7 @@ export const getShifts = async (filters: ShiftFilters = {}): Promise<ApiResponse
 export const createShift = async (shiftData: CreateShiftData): Promise<ApiResponse<Shift>> => {
   const response = await fetch(`${API_BASE_URL}/shifts`, {
     method: 'POST',
-    headers: getAuthHeaders(),
+    ...getAuthHeaders(),
     body: JSON.stringify(shiftData),
   });
   
@@ -85,7 +85,7 @@ export const createShift = async (shiftData: CreateShiftData): Promise<ApiRespon
 export const updateShift = async (shiftId: string | number, shiftData: UpdateShiftData): Promise<ApiResponse<Shift>> => {
   const response = await fetch(`${API_BASE_URL}/shifts/${shiftId}`, {
     method: 'PUT',
-    headers: getAuthHeaders(),
+    ...getAuthHeaders(),
     body: JSON.stringify(shiftData),
   });
   
@@ -95,7 +95,7 @@ export const updateShift = async (shiftId: string | number, shiftData: UpdateShi
 export const deleteShift = async (shiftId: string | number): Promise<ApiResponse<void>> => {
   const response = await fetch(`${API_BASE_URL}/shifts/${shiftId}`, {
     method: 'DELETE',
-    headers: getAuthHeaders(),
+    ...getAuthHeaders(),
   });
   
   return handleResponse<void>(response);

--- a/frontend/src/services/systemService.ts
+++ b/frontend/src/services/systemService.ts
@@ -20,7 +20,7 @@ export interface SystemInfo {
 export const getSystemInfo = async (): Promise<ApiResponse<SystemInfo>> => {
   const response = await fetch(`${API_BASE_URL}/system/info`, {
     method: 'GET',
-    headers: getAuthHeaders(),
+    ...getAuthHeaders(),
   });
   return handleResponse<SystemInfo>(response);
 };


### PR DESCRIPTION
## Summary

- **JWT migration**: Token now stored in httpOnly cookie set by backend on login/refresh; cleared on logout. Backend `authenticate` middleware reads from cookie or Authorization header. Frontend removes all `localStorage` token usage; all API calls use `credentials: 'include'`.
- **Token revocation**: In-memory JTI blacklist; logout blacklists the current token's JTI so it cannot be reused.
- **validateBody wired to 13 remaining mutation routes**: `POST /escalate`, `POST /2fa/enable`, `POST /2fa/verify`, `PUT /preferences/me`, `PUT /preferences/:userId`, `PUT /modules/:code`, `PUT /settings/currency`, `PUT /settings/time-period`, `PUT /settings/:category/:key`, `PUT /directory/users/:id/fields`, `POST /policies/validate/assignment`, `PUT /policies/approval-matrix/:changeType`. 10 new Zod schemas added.
- **Config hardening**: `sameSite: 'lax'` on session cookie; `bcryptRounds` minimum enforced at 10; CORS null-origin only permitted outside production; `'unsafe-inline'` removed from CSP `styleSrc`.
- **Frontend**: React.lazy code splitting for all page-level components; `<nav aria-label="Main navigation">` wrapping sidebar nav list.
- **Tests**: Updated `AuthContext.test.tsx` and `apiUtils.test.ts` for new cookie-based auth; updated modules test for `VALIDATION_ERROR` code; fixed `extraServices.test.ts` signature.

## Test plan

- [ ] All 1647 backend tests pass
- [ ] All 103 frontend tests pass
- [ ] TypeScript compiles without errors (both backend and frontend)
- [ ] CI green before merge