### PR TITLE
fix(review): auth cookie cleanup, table accessibility, test alignment

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -157,13 +157,13 @@ The single source of truth is [`backend/openapi/openapi.json`](./backend/openapi
 ### Authentication
 
 ```
-POST /api/auth/login       { email, password } → { token, user: { id, email, firstName, lastName, roles, permissions } }
-GET  /api/auth/verify      (Bearer token) → { user }
-POST /api/auth/refresh     (Bearer token) → { token, user }
-POST /api/auth/logout
+POST /api/auth/login       { email, password } → sets httpOnly cookie "token"; body: { user: { id, email, firstName, lastName, roles, permissions } }
+GET  /api/auth/verify      (cookie) → { user }
+POST /api/auth/refresh     (cookie) → rotates cookie; body: { user }
+POST /api/auth/logout      blacklists the JTI and clears the cookie
 ```
 
-JWT payload: `{ userId, email }` — no role. Permissions are resolved from the DB on every request.
+JWT payload: `{ userId, email, jti }` — no role. Permissions are resolved from the DB on every request. The `jti` field enables server-side revocation on logout via an in-memory blacklist with TTL-based expiry.
 
 ### Core endpoints (summary)
 
@@ -597,7 +597,7 @@ Feature requests are welcome — describe the use case, not just the solution.
 | Decision | Rationale |
 |---|---|
 | Permission-based RBAC (no hardcoded roles) | Roles are customer data. Hard-wiring `admin`/`manager`/`employee` prevents multi-tier hierarchies. `user_roles` grants are scoped and time-bound, supporting org-unit subtree access and temporary elevation. |
-| JWT carries `userId` only | Permissions change frequently; a stale role in the token would require revocation infrastructure. Resolving from DB on every request is cheaper than maintaining a token revocation store. |
+| JWT in httpOnly cookie + JTI blacklist | The cookie prevents XSS from stealing the token. The `jti` claim in each token enables server-side revocation on logout via an in-memory `Map<jti, expiresAt>` with lazy TTL expiry — lightweight and sufficient for single-instance deployments. |
 | Hard cutover (no backward-compat shim) | The 3-role ENUM was the root of every hardcoded check. A migration shim would perpetuate the pattern. The seeded bootstrap roles (Administrator/Manager/Employee) reproduce prior behaviour without any shim. |
 | `requireModule` returns 404 | A 401 leaks that the route exists. 404 is the correct response when an entire feature is absent; no information is disclosed. |
 | In-process module cache | Module state changes infrequently. A per-request DB lookup for a static flag is wasteful. Cache invalidation on `setEnabled` is a single line. |

--- a/backend/src/__tests__/auth.route.extended.test.ts
+++ b/backend/src/__tests__/auth.route.extended.test.ts
@@ -79,9 +79,12 @@ describe('POST /api/auth/refresh', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.success).toBe(true);
-    expect(typeof res.body.data.token).toBe('string');
-
-    const decoded = jwt.verify(res.body.data.token, config.jwt.secret) as { userId: number };
+    expect(res.body.data.token).toBeUndefined();
+    const cookies = res.headers['set-cookie'] as unknown as string[];
+    const tokenCookie = cookies?.find((c: string) => c.startsWith('token='));
+    expect(tokenCookie).toBeDefined();
+    const cookieToken = tokenCookie!.split(';')[0].split('=')[1];
+    const decoded = jwt.verify(cookieToken, config.jwt.secret) as { userId: number };
     expect(decoded.userId).toBe(7);
   });
 

--- a/backend/src/__tests__/auth.route.test.ts
+++ b/backend/src/__tests__/auth.route.test.ts
@@ -64,8 +64,12 @@ describe('POST /api/auth/login', () => {
     expect(res.status).toBe(200);
     expect(res.body.data.user.permissions).toContain('schedule.manage');
     expect(res.body.data.user.roles[0].roleName).toBe('Manager');
-    expect(typeof res.body.data.token).toBe('string');
-    const decoded = jwt.verify(res.body.data.token, config.jwt.secret) as { userId: number };
+    expect(res.body.data.token).toBeUndefined();
+    const cookies = res.headers['set-cookie'] as unknown as string[];
+    const tokenCookie = cookies?.find((c: string) => c.startsWith('token='));
+    expect(tokenCookie).toBeDefined();
+    const cookieToken = tokenCookie!.split(';')[0].split('=')[1];
+    const decoded = jwt.verify(cookieToken, config.jwt.secret) as { userId: number };
     expect(decoded.userId).toBe(7);
   });
 });

--- a/backend/src/__tests__/department.service.test.ts
+++ b/backend/src/__tests__/department.service.test.ts
@@ -122,9 +122,12 @@ describe('DepartmentService.deleteDepartment', () => {
 });
 
 describe('DepartmentService.assignEmployeesToDepartment', () => {
-  it('runs DELETE + INSERT pairs in a transaction', async () => {
+  it('runs batch SELECT + INSERT IGNORE in a transaction', async () => {
     const { pool, conn } = makePool();
-    conn.execute.mockResolvedValue([{ affectedRows: 1 }, null]);
+    conn.execute
+      .mockResolvedValueOnce([[{ id: 1 }], null])                  // SELECT dept
+      .mockResolvedValueOnce([[{ id: 10 }, { id: 11 }], null])     // SELECT users
+      .mockResolvedValueOnce([{ affectedRows: 2 }, null]);         // INSERT IGNORE
     const service = new DepartmentService(pool);
     await service.assignEmployeesToDepartment(1, [10, 11]);
     expect(conn.commit).toHaveBeenCalled();

--- a/backend/src/__tests__/rbac.service.extended.test.ts
+++ b/backend/src/__tests__/rbac.service.extended.test.ts
@@ -544,12 +544,11 @@ describe('RbacService.setUserRoles', () => {
     const { pool, conn } = makePool();
     conn.execute
       .mockResolvedValueOnce([{ affectedRows: 2 }, null])  // DELETE
-      .mockResolvedValueOnce([{ affectedRows: 1 }, null])  // INSERT role 10
-      .mockResolvedValueOnce([{ affectedRows: 1 }, null]); // INSERT role 11
+      .mockResolvedValueOnce([{ affectedRows: 2 }, null]); // batch INSERT IGNORE
 
     const svc = new RbacService(pool);
     await expect(svc.setUserRoles(7, [10, 11])).resolves.toBeUndefined();
-    expect(conn.execute).toHaveBeenCalledTimes(3);
+    expect(conn.execute).toHaveBeenCalledTimes(2);
     expect(conn.commit).toHaveBeenCalled();
   });
 

--- a/backend/src/__tests__/routes.batch5.test.ts
+++ b/backend/src/__tests__/routes.batch5.test.ts
@@ -83,7 +83,7 @@ describe('bulkImport route — POST /employees password too short returns 400', 
       .send({ csv: 'email,firstName,lastName,role\ntest@x.com,A,B,employee', defaultPassword: 'short' });
     expect(res.status).toBe(400);
     expect(res.body.error.code).toBe('VALIDATION_ERROR');
-    expect(res.body.error.message).toMatch(/at least 8 characters/);
+    expect(res.body.error.details[0].message).toMatch(/at least 8 characters/);
   });
 });
 

--- a/backend/src/__tests__/routes.expanded.test.ts
+++ b/backend/src/__tests__/routes.expanded.test.ts
@@ -1864,7 +1864,7 @@ describe('auth router (extended)', () => {
       password: 'pw',
     });
     expect(res.status).toBe(200);
-    expect(typeof res.body.data.token).toBe('string');
+    expect(res.headers['set-cookie']).toBeDefined();
   });
 
   it('POST /login 401 on service throw', async () => {
@@ -1884,7 +1884,7 @@ describe('auth router (extended)', () => {
   it('POST /refresh 200', async () => {
     const res = await request(app()).post('/api/auth/refresh');
     expect(res.status).toBe(200);
-    expect(typeof res.body.data.token).toBe('string');
+    expect(res.headers['set-cookie']).toBeDefined();
   });
 
   it('POST /logout 200', async () => {

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -29,14 +29,31 @@ const getModuleService = (): ModuleService => {
 };
 
 // In-memory JTI blacklist for server-side token revocation on logout.
-const _jtiBlacklist = new Set<string>();
-export const addToBlacklist = (jti: string): void => { _jtiBlacklist.add(jti); };
+// Each entry stores the expiry timestamp (ms) so expired JTIs are pruned
+// automatically on access, preventing unbounded memory growth.
+const _jtiBlacklist = new Map<string, number>();
+
+export const addToBlacklist = (jti: string, expiresAt?: number): void => {
+  const exp = expiresAt ?? Date.now() + 24 * 60 * 60 * 1000; // default: 24 h
+  _jtiBlacklist.set(jti, exp);
+};
+
+const _isBlacklisted = (jti: string): boolean => {
+  const exp = _jtiBlacklist.get(jti);
+  if (exp === undefined) return false;
+  if (Date.now() > exp) {
+    _jtiBlacklist.delete(jti); // prune expired entry on access
+    return false;
+  }
+  return true;
+};
 
 // Extend Express Request to include user and token JTI
 declare module 'express-serve-static-core' {
   interface Request {
     user?: User;
     tokenJti?: string;
+    tokenExp?: number; // ms timestamp of token expiry, used to set blacklist TTL
   }
 }
 
@@ -95,7 +112,7 @@ export const authenticate = async (req: Request, res: Response, next: NextFuncti
       });
     }
 
-    if (decodedToken.jti && _jtiBlacklist.has(decodedToken.jti)) {
+    if (decodedToken.jti && _isBlacklisted(decodedToken.jti)) {
       return res.status(401).json({
         success: false,
         error: {
@@ -105,7 +122,10 @@ export const authenticate = async (req: Request, res: Response, next: NextFuncti
       });
     }
 
-    if (decodedToken.jti) req.tokenJti = decodedToken.jti;
+    if (decodedToken.jti) {
+      req.tokenJti = decodedToken.jti;
+      if (decodedToken.exp) req.tokenExp = decodedToken.exp * 1000; // convert JWT seconds to ms
+    }
 
     const pool = database.getPool();
     const userService = new UserService(pool);

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -20,12 +20,14 @@ import rateLimit from 'express-rate-limit';
 import { UserService } from '../services/UserService';
 import { RbacService } from '../services/RbacService';
 import { authenticate, addToBlacklist } from '../middleware/auth';
+import { validateBody } from '../middleware/validation';
+import { loginBody } from '../schemas';
 import jwt, { SignOptions } from 'jsonwebtoken';
 import { logger } from '../config/logger';
 
 import { config } from '../config';
 
-const isProduction = process.env.NODE_ENV === 'production';
+const isProduction = config.server.env === 'production';
 
 const JWT_COOKIE_NAME = 'token';
 const JWT_COOKIE_OPTIONS = {
@@ -53,7 +55,7 @@ export const createAuthRouter = (pool: Pool) => {
    * The limiter is intentionally lenient under `NODE_ENV === 'test'` so the
    * integration suites can call `/login` repeatedly without hitting 429.
    */
-  const isTestEnv = process.env.NODE_ENV === 'test';
+  const isTestEnv = config.server.env === 'test';
   const loginLimiter = rateLimit({
     windowMs: 15 * 60 * 1000, // 15 minutes
     max: isTestEnv ? 1000 : 10,
@@ -93,20 +95,9 @@ export const createAuthRouter = (pool: Pool) => {
  *   }
  * }
  */
-router.post('/login', loginLimiter, async (req: Request, res: Response) => {
+router.post('/login', loginLimiter, validateBody(loginBody), async (_req: Request, res: Response) => {
   try {
-    const { email, password } = req.body;
-
-    // Input validation
-    if (!email || !password) {
-      return res.status(400).json({
-        success: false,
-        error: {
-          code: 'VALIDATION_ERROR',
-          message: 'Email and password are required'
-        }
-      });
-    }
+    const { email, password } = res.locals.body as { email: string; password: string };
 
     // Authenticate user and generate token
     const user = await userService.validatePassword(email, password);
@@ -140,7 +131,6 @@ router.post('/login', loginLimiter, async (req: Request, res: Response) => {
     res.json({
       success: true,
       data: {
-        token,
         user: {
           id: user.id,
           email: user.email,
@@ -227,7 +217,6 @@ router.post('/refresh', authenticate, async (req: Request, res: Response) => {
       success: true,
       data: {
         user: userWithoutPassword,
-        token
       }
     });
   } catch (error) {
@@ -255,7 +244,7 @@ router.post('/refresh', authenticate, async (req: Request, res: Response) => {
  */
 router.post('/logout', authenticate, (req: Request, res: Response) => {
   if (req.tokenJti) {
-    addToBlacklist(req.tokenJti);
+    addToBlacklist(req.tokenJti, req.tokenExp);
   }
   res.clearCookie(JWT_COOKIE_NAME);
   res.json({

--- a/backend/src/routes/bulkImport.ts
+++ b/backend/src/routes/bulkImport.ts
@@ -13,6 +13,8 @@
 import { Pool } from 'mysql2/promise';
 import { Router, Request, Response } from 'express';
 import { authenticate, requirePermission } from '../middleware/auth';
+import { validateBody } from '../middleware/validation';
+import { bulkImportEmployeesBody, bulkImportShiftsBody } from '../schemas';
 import { BulkImportService } from '../services/BulkImportService';
 
 const respondError = (res: Response, status: number, code: string, message: string): void => {
@@ -25,20 +27,10 @@ export const createBulkImportRouter = (pool: Pool): Router => {
 
   router.use(authenticate, requirePermission('employee.manage'));
 
-  router.post('/employees', async (req: Request, res: Response) => {
-    const csv = req.body?.csv as string | undefined;
-    const password = req.body?.defaultPassword as string | undefined;
-    if (!csv) {
-      return respondError(res, 400, 'VALIDATION_ERROR', 'csv body is required');
-    }
-    if (!password) {
-      return respondError(res, 400, 'MISSING_FIELD', 'defaultPassword is required for bulk import');
-    }
-    if (password.length < 8) {
-      return respondError(res, 400, 'VALIDATION_ERROR', 'defaultPassword must be at least 8 characters');
-    }
+  router.post('/employees', validateBody(bulkImportEmployeesBody), async (_req: Request, res: Response) => {
+    const { csv, defaultPassword } = res.locals.body as { csv: string; defaultPassword: string };
     try {
-      const result = await service.importEmployees(csv, password);
+      const result = await service.importEmployees(csv, defaultPassword);
       const status = result.errors.length > 0 ? 400 : 200;
       res.status(status).json({ success: result.errors.length === 0, data: result });
     } catch (err) {
@@ -46,11 +38,8 @@ export const createBulkImportRouter = (pool: Pool): Router => {
     }
   });
 
-  router.post('/shifts', async (req: Request, res: Response) => {
-    const csv = req.body?.csv as string | undefined;
-    if (!csv) {
-      return respondError(res, 400, 'VALIDATION_ERROR', 'csv body is required');
-    }
+  router.post('/shifts', validateBody(bulkImportShiftsBody), async (_req: Request, res: Response) => {
+    const { csv } = res.locals.body as { csv: string };
     try {
       const result = await service.importShifts(csv);
       const status = result.errors.length > 0 ? 400 : 200;

--- a/backend/src/routes/org.ts
+++ b/backend/src/routes/org.ts
@@ -24,7 +24,7 @@ import { Pool } from 'mysql2/promise';
 import { Router, Request, Response } from 'express';
 import { authenticate, requirePermission, userHasPermission } from '../middleware/auth';
 import { validateParams, validateBody } from '../middleware/validation';
-import { idParam, createOrgUnitBody, updateOrgUnitBody, addOrgMemberBody, createLoanBody } from '../schemas';
+import { idParam, createOrgUnitBody, updateOrgUnitBody, addOrgMemberBody, createLoanBody, optionalNotesBody } from '../schemas';
 import { OrgUnitService } from '../services/OrgUnitService';
 import { EmployeeLoanService } from '../services/EmployeeLoanService';
 import { AuditLogService } from '../services/AuditLogService';
@@ -212,9 +212,9 @@ export const createOrgRouter = (pool: Pool): Router => {
     }
   });
 
-  router.post('/loans/:id/approve', requirePermission('loan.approve'), async (req: Request, res: Response) => {
+  router.post('/loans/:id/approve', requirePermission('loan.approve'), validateBody(optionalNotesBody), async (req: Request, res: Response) => {
     try {
-      const updated = await loans.approve(Number(req.params.id), req.user!.id, req.body?.notes ?? null);
+      const updated = await loans.approve(Number(req.params.id), req.user!.id, (res.locals.body.notes as string | null | undefined) ?? null);
       res.json({ success: true, data: updated });
     } catch (err) {
       const msg = (err as Error).message;
@@ -226,9 +226,9 @@ export const createOrgRouter = (pool: Pool): Router => {
     }
   });
 
-  router.post('/loans/:id/reject', requirePermission('loan.approve'), async (req: Request, res: Response) => {
+  router.post('/loans/:id/reject', requirePermission('loan.approve'), validateBody(optionalNotesBody), async (req: Request, res: Response) => {
     try {
-      const updated = await loans.reject(Number(req.params.id), req.user!.id, req.body?.notes ?? null);
+      const updated = await loans.reject(Number(req.params.id), req.user!.id, (res.locals.body.notes as string | null | undefined) ?? null);
       res.json({ success: true, data: updated });
     } catch (err) {
       const msg = (err as Error).message;

--- a/backend/src/routes/shiftSwap.ts
+++ b/backend/src/routes/shiftSwap.ts
@@ -8,7 +8,7 @@ import { Pool } from 'mysql2/promise';
 import { Router, Request, Response } from 'express';
 import { authenticate, requirePermission, userHasPermission } from '../middleware/auth';
 import { validateBody } from '../middleware/validation';
-import { createShiftSwapBody } from '../schemas';
+import { createShiftSwapBody, optionalNotesBody } from '../schemas';
 import { ShiftSwapService } from '../services/ShiftSwapService';
 import { logger } from '../config/logger';
 
@@ -70,10 +70,10 @@ export const createShiftSwapRouter = (pool: Pool): Router => {
     }
   });
 
-  router.post('/:id/approve', requirePermission('shiftswap.approve'), async (req: Request, res: Response) => {
+  router.post('/:id/approve', requirePermission('shiftswap.approve'), validateBody(optionalNotesBody), async (req: Request, res: Response) => {
     try {
       const id = Number(req.params.id);
-      const updated = await service.approve(id, req.user!.id, req.body?.notes ?? null);
+      const updated = await service.approve(id, req.user!.id, (res.locals.body.notes as string | null | undefined) ?? null);
       res.json({ success: true, data: updated });
     } catch (err) {
       const msg = (err as Error).message;
@@ -82,10 +82,10 @@ export const createShiftSwapRouter = (pool: Pool): Router => {
     }
   });
 
-  router.post('/:id/decline', requirePermission('shiftswap.approve'), async (req: Request, res: Response) => {
+  router.post('/:id/decline', requirePermission('shiftswap.approve'), validateBody(optionalNotesBody), async (req: Request, res: Response) => {
     try {
       const id = Number(req.params.id);
-      const updated = await service.decline(id, req.user!.id, req.body?.notes ?? null);
+      const updated = await service.decline(id, req.user!.id, (res.locals.body.notes as string | null | undefined) ?? null);
       res.json({ success: true, data: updated });
     } catch (err) {
       const msg = (err as Error).message;

--- a/backend/src/routes/timeOff.ts
+++ b/backend/src/routes/timeOff.ts
@@ -15,7 +15,7 @@ import { Pool } from 'mysql2/promise';
 import { Router, Request, Response } from 'express';
 import { authenticate, requirePermission, userHasPermission } from '../middleware/auth';
 import { validateBody } from '../middleware/validation';
-import { createTimeOffBody } from '../schemas';
+import { createTimeOffBody, optionalNotesBody } from '../schemas';
 import { TimeOffService } from '../services/TimeOffService';
 import { logger } from '../config/logger';
 
@@ -77,10 +77,10 @@ export const createTimeOffRouter = (pool: Pool): Router => {
     }
   });
 
-  router.post('/:id/approve', requirePermission('timeoff.approve'), async (req: Request, res: Response) => {
+  router.post('/:id/approve', requirePermission('timeoff.approve'), validateBody(optionalNotesBody), async (req: Request, res: Response) => {
     try {
       const id = Number(req.params.id);
-      const updated = await service.approve(id, req.user!.id, req.body?.notes ?? null);
+      const updated = await service.approve(id, req.user!.id, (res.locals.body.notes as string | null | undefined) ?? null);
       res.json({ success: true, data: updated });
     } catch (err) {
       const msg = (err as Error).message;
@@ -89,10 +89,10 @@ export const createTimeOffRouter = (pool: Pool): Router => {
     }
   });
 
-  router.post('/:id/reject', requirePermission('timeoff.approve'), async (req: Request, res: Response) => {
+  router.post('/:id/reject', requirePermission('timeoff.approve'), validateBody(optionalNotesBody), async (req: Request, res: Response) => {
     try {
       const id = Number(req.params.id);
-      const updated = await service.reject(id, req.user!.id, req.body?.notes ?? null);
+      const updated = await service.reject(id, req.user!.id, (res.locals.body.notes as string | null | undefined) ?? null);
       res.json({ success: true, data: updated });
     } catch (err) {
       const msg = (err as Error).message;

--- a/backend/src/schemas/index.ts
+++ b/backend/src/schemas/index.ts
@@ -336,3 +336,21 @@ export const updateTimePeriodBody = z.object({
 export const updateSettingValueBody = z.object({
   value: z.string(),
 });
+
+export const loginBody = z.object({
+  email: z.string().min(1, 'email is required'),
+  password: z.string().min(1, 'password is required'),
+});
+
+export const optionalNotesBody = z.object({
+  notes: z.string().max(2000).nullable().optional(),
+});
+
+export const bulkImportEmployeesBody = z.object({
+  csv: z.string().min(1, 'csv is required'),
+  defaultPassword: z.string().min(8, 'defaultPassword must be at least 8 characters'),
+});
+
+export const bulkImportShiftsBody = z.object({
+  csv: z.string().min(1, 'csv is required'),
+});

--- a/backend/src/services/DepartmentService.ts
+++ b/backend/src/services/DepartmentService.ts
@@ -423,31 +423,29 @@ export class DepartmentService {
         throw new Error('Department not found');
       }
 
-      // Assign each user
-      for (const userId of userIds) {
-        // Check if user exists and is active
-        const [userRows] = await connection.execute<RowDataPacket[]>(
-          'SELECT id FROM users WHERE id = ? AND is_active = 1 LIMIT 1',
-          [userId]
+      if (userIds.length === 0) {
+        await connection.commit();
+        return;
+      }
+
+      // Verify all users exist and are active in one query
+      const placeholders = userIds.map(() => '?').join(', ');
+      const [validUserRows] = await connection.execute<RowDataPacket[]>(
+        `SELECT id FROM users WHERE id IN (${placeholders}) AND is_active = 1`,
+        userIds
+      );
+      const validIds = new Set((validUserRows as RowDataPacket[]).map(r => r.id as number));
+      const skipped = userIds.filter(id => !validIds.has(id));
+      if (skipped.length > 0) logger.warn(`Skipping invalid users: ${skipped.join(', ')}`);
+
+      const toAssign = userIds.filter(id => validIds.has(id));
+      if (toAssign.length > 0) {
+        // INSERT IGNORE handles already-assigned rows without a pre-check query
+        const valPlaceholders = toAssign.map(() => '(?, ?)').join(', ');
+        await connection.execute(
+          `INSERT IGNORE INTO user_departments (user_id, department_id) VALUES ${valPlaceholders}`,
+          toAssign.flatMap(userId => [userId, departmentId])
         );
-
-        if (userRows.length === 0) {
-          logger.warn(`Skipping invalid user: ${userId}`);
-          continue;
-        }
-
-        // Check if already assigned
-        const [existing] = await connection.execute<RowDataPacket[]>(
-          'SELECT id FROM user_departments WHERE user_id = ? AND department_id = ? LIMIT 1',
-          [userId, departmentId]
-        );
-
-        if (existing.length === 0) {
-          await connection.execute(
-            'INSERT INTO user_departments (user_id, department_id) VALUES (?, ?)',
-            [userId, departmentId]
-          );
-        }
       }
 
       await connection.commit();

--- a/backend/src/services/RbacService.ts
+++ b/backend/src/services/RbacService.ts
@@ -263,10 +263,11 @@ export class RbacService {
         'DELETE FROM user_roles WHERE user_id = ? AND scope_org_unit_id IS NULL',
         [userId]
       );
-      for (const roleId of roleIds) {
+      if (roleIds.length > 0) {
+        const placeholders = roleIds.map(() => '(?, ?, NULL)').join(', ');
         await connection.execute(
-          'INSERT IGNORE INTO user_roles (user_id, role_id, scope_org_unit_id) VALUES (?, ?, NULL)',
-          [userId, roleId]
+          `INSERT IGNORE INTO user_roles (user_id, role_id, scope_org_unit_id) VALUES ${placeholders}`,
+          roleIds.flatMap(roleId => [userId, roleId])
         );
       }
       await connection.commit();

--- a/frontend/src/contexts/AuthContext.test.tsx
+++ b/frontend/src/contexts/AuthContext.test.tsx
@@ -74,7 +74,6 @@ describe('AuthProvider actions', () => {
     mockedAuthService.login.mockResolvedValue({
       success: true,
       data: {
-        token: 't',
         user: { id: 1, email: 'a@x', firstName: 'A', lastName: 'B', role: 'admin' },
       } as never,
     });
@@ -123,7 +122,6 @@ describe('AuthProvider actions', () => {
     mockedAuthService.refreshToken.mockResolvedValue({
       success: true,
       data: {
-        token: 'new',
         user: { id: 1, email: 'a@x', firstName: 'A', lastName: 'B', role: 'admin' },
       } as never,
     });

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -14,7 +14,6 @@ import * as authService from '../services/authService';
 
 interface AuthState {
   user: Omit<User, 'passwordHash' | 'salt'> | null;
-  token: string | null;
   isAuthenticated: boolean;
   isLoading: boolean;
   error: string | null;
@@ -30,7 +29,7 @@ const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 type AuthAction =
   | { type: 'LOGIN_START' }
-  | { type: 'LOGIN_SUCCESS'; payload: { user: Omit<User, 'passwordHash' | 'salt'>; token: string } }
+  | { type: 'LOGIN_SUCCESS'; payload: { user: Omit<User, 'passwordHash' | 'salt'> } }
   | { type: 'LOGIN_FAILURE'; payload?: string }
   | { type: 'LOGOUT' }
   | { type: 'SET_USER'; payload: Omit<User, 'passwordHash' | 'salt'> }
@@ -44,7 +43,6 @@ const authReducer = (state: AuthState, action: AuthAction): AuthState => {
       return {
         ...state,
         user: action.payload.user,
-        token: action.payload.token,
         isAuthenticated: true,
         isLoading: false,
         error: null,
@@ -53,13 +51,12 @@ const authReducer = (state: AuthState, action: AuthAction): AuthState => {
       return {
         ...state,
         user: null,
-        token: null,
         isAuthenticated: false,
         isLoading: false,
         error: action.payload || 'Authentication failed',
       };
     case 'LOGOUT':
-      return { ...state, user: null, token: null, isAuthenticated: false, isLoading: false };
+      return { ...state, user: null, isAuthenticated: false, isLoading: false };
     case 'SET_USER':
       return { ...state, user: action.payload };
     case 'SET_LOADING':
@@ -71,7 +68,6 @@ const authReducer = (state: AuthState, action: AuthAction): AuthState => {
 
 const initialState: AuthState = {
   user: null,
-  token: null,
   isAuthenticated: false,
   isLoading: true,
   error: null,
@@ -91,7 +87,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         if (response.success && response.data) {
           dispatch({
             type: 'LOGIN_SUCCESS',
-            payload: { user: response.data, token: '' },
+            payload: { user: response.data },
           });
         } else {
           dispatch({ type: 'SET_LOADING', payload: false });
@@ -111,10 +107,10 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       const response: ApiResponse<LoginResponse> = await authService.login(credentials);
 
       if (response.success && response.data) {
-        const { user, token } = response.data;
+        const { user } = response.data;
         dispatch({
           type: 'LOGIN_SUCCESS',
-          payload: { user, token },
+          payload: { user },
         });
       } else {
         throw new Error(response.error?.message || 'Login failed');

--- a/frontend/src/pages/Org/OrgManagement.tsx
+++ b/frontend/src/pages/Org/OrgManagement.tsx
@@ -460,11 +460,11 @@ const OrgManagement: React.FC = () => {
               <table className="table">
                 <thead>
                   <tr>
-                    <th>User</th>
-                    <th>From → To</th>
-                    <th>Range</th>
-                    <th>Status</th>
-                    <th className="text-end">Actions</th>
+                    <th scope="col">User</th>
+                    <th scope="col">From → To</th>
+                    <th scope="col">Range</th>
+                    <th scope="col">Status</th>
+                    <th scope="col" className="text-end">Actions</th>
                   </tr>
                 </thead>
                 <tbody>

--- a/frontend/src/pages/Schedule/Schedule.tsx
+++ b/frontend/src/pages/Schedule/Schedule.tsx
@@ -418,9 +418,9 @@ const Schedule: React.FC = () => {
               <table className="table table-bordered mb-0">
                 <thead>
                   <tr>
-                    <th style={{ width: '200px' }}>Shift</th>
+                    <th scope="col" style={{ width: '200px' }}>Shift</th>
                     {weekDates.map((date) => (
-                      <th key={date.toISOString()} className="text-center">
+                      <th scope="col" key={date.toISOString()} className="text-center">
                         {formatDate(date)}
                       </th>
                     ))}

--- a/frontend/src/pages/orgManagement/MemberList.tsx
+++ b/frontend/src/pages/orgManagement/MemberList.tsx
@@ -103,10 +103,10 @@ const MemberList: React.FC<Props> = ({
             <table className="table">
               <thead>
                 <tr>
-                  <th>User</th>
-                  <th>Primary</th>
-                  <th>Assigned</th>
-                  <th className="text-end">Actions</th>
+                  <th scope="col">User</th>
+                  <th scope="col">Primary</th>
+                  <th scope="col">Assigned</th>
+                  <th scope="col" className="text-end">Actions</th>
                 </tr>
               </thead>
               <tbody>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -53,7 +53,6 @@ export interface User {
 
 export interface LoginResponse {
   user: Omit<User, 'passwordHash' | 'salt'>;
-  token: string;
 }
 
 // Employee (with matrix organization support)


### PR DESCRIPTION
## Summary

- Remove JWT token from login/refresh response bodies; auth is now exclusively via httpOnly cookie — tests updated to verify `Set-Cookie` header
- Remove dead `token` field from `AuthState`, `LOGIN_SUCCESS` payload, and `LoginResponse` type in frontend
- Add TTL-based JTI blacklist expiry in auth middleware; update `DOCUMENTATION.md` to reflect cookie-only auth and JTI revocation
- Add `scope="col"` to `<th>` elements in `Schedule`, `OrgManagement`, and `MemberList` for WCAG 2.1 AA compliance
- Wire `validateBody(optionalNotesBody)` to timeOff/shiftSwap/org approve+reject routes
- Wire Zod `validateBody` schemas to bulkImport routes (employees + shifts)
- Batch `RbacService.setUserRoles` with single `INSERT IGNORE`; fix test to expect 2 execute calls instead of 3
- Batch `DepartmentService.assignEmployeesToDepartment` with `SELECT ... IN (...)` + `INSERT IGNORE`; fix test mocks accordingly
- Fix test assertions: `Set-Cookie` header check, `details[0].message` for Zod validation errors

## Test plan

- [x] `npm test` in backend: 1647 tests passing
- [x] `npm test` in frontend: 103 tests passing
- [x] `npx tsc --noEmit` clean on both backend and frontend