### PR TITLE
fix(review): stale docs, missing validateBody in policies, accessibility scope

### DIFF
--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -9,7 +9,7 @@
  * - Environment variable loading with defaults
  * - Type-safe configuration objects
  * - Database connection settings
- * - JWT and session management config
+ * - JWT configuration
  * - Logging configuration
  * - Server and security settings
  * 
@@ -60,18 +60,6 @@ export const config = {
     connectionLimit: parseInt(process.env.DB_POOL_LIMIT || '30'),
     queueLimit:      parseInt(process.env.DB_QUEUE_LIMIT || '100'),
     connectTimeout:  10_000,
-  },
-  session: {
-    secret: requireSecret('SESSION_SECRET', 'SESSION_SECRET'),
-    name: process.env.SESSION_NAME || 'staff_scheduler_session',
-    resave: false,
-    saveUninitialized: false,
-    cookie: {
-      secure: process.env.SESSION_COOKIE_SECURE === 'true',
-      httpOnly: true,
-      maxAge: parseInt(process.env.SESSION_COOKIE_MAX_AGE || '86400000'), // 24 hours
-      sameSite: 'lax' as const,
-    },
   },
   jwt: {
     secret: requireSecret('JWT_SECRET', 'JWT_SECRET'),

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -80,8 +80,8 @@ export const createAuthRouter = (pool: Pool) => {
  * @route POST /api/auth/login
  * @body  {string} email    User's email
  * @body  {string} password User's password
- * @returns {Object} `{ success, data: { token, user } }` on success;
- *                   `{ success:false, error:{ code, message } }` otherwise.
+ * @returns Sets an httpOnly "token" cookie and returns `{ success, data: { user } }`.
+ *          The JWT is never exposed in the response body.
  *
  * @example Request
  * { "email": "admin@example.com", "password": "<password>" }
@@ -90,8 +90,7 @@ export const createAuthRouter = (pool: Pool) => {
  * {
  *   "success": true,
  *   "data": {
- *     "token": "<jwt>",
- *     "user": { "id": 1, "email": "admin@example.com", "role": "admin" }
+ *     "user": { "id": 1, "email": "admin@example.com", "roles": [...], "permissions": [...] }
  *   }
  * }
  */
@@ -234,9 +233,9 @@ router.post('/refresh', authenticate, async (req: Request, res: Response) => {
 /**
  * User logout endpoint.
  *
- * With JWT auth this is informational: the client drops the token from
- * storage. A real server-side blacklist would require persistence and is
- * out of scope here (see security backlog item `B001`).
+ * Blacklists the token's JTI so it is rejected on subsequent requests, then
+ * clears the httpOnly cookie. The in-memory blacklist uses TTL-based expiry
+ * (keyed to the token's own exp claim) so entries prune themselves automatically.
  *
  * @route      POST /api/auth/logout
  * @middleware authenticate

--- a/backend/src/routes/policies.ts
+++ b/backend/src/routes/policies.ts
@@ -23,7 +23,7 @@ import { Pool } from 'mysql2/promise';
 import { Router, Request, Response } from 'express';
 import { authenticate, requirePermission, userHasPermission } from '../middleware/auth';
 import { validateBody } from '../middleware/validation';
-import { createPolicyExceptionBody, createPolicyBody, updatePolicyBody, validateAssignmentBody, updateApprovalMatrixBody } from '../schemas';
+import { createPolicyExceptionBody, createPolicyBody, updatePolicyBody, validateAssignmentBody, updateApprovalMatrixBody, optionalNotesBody } from '../schemas';
 import { PolicyService } from '../services/PolicyService';
 import { PolicyExceptionService } from '../services/PolicyExceptionService';
 import { ApprovalMatrixService } from '../services/ApprovalMatrixService';
@@ -121,12 +121,12 @@ export const createPoliciesRouter = (pool: Pool): Router => {
     }
   });
 
-  router.post('/exceptions/:id/approve', requirePermission('policy.approve'), async (req: Request, res: Response) => {
+  router.post('/exceptions/:id/approve', requirePermission('policy.approve'), validateBody(optionalNotesBody), async (req: Request, res: Response) => {
     try {
       const updated = await exceptions.approve(
         Number(req.params.id),
         req.user!.id,
-        req.body?.notes ?? null
+        (res.locals.body.notes as string | null | undefined) ?? null
       );
       res.json({ success: true, data: updated });
     } catch (err) {
@@ -136,12 +136,12 @@ export const createPoliciesRouter = (pool: Pool): Router => {
     }
   });
 
-  router.post('/exceptions/:id/reject', requirePermission('policy.approve'), async (req: Request, res: Response) => {
+  router.post('/exceptions/:id/reject', requirePermission('policy.approve'), validateBody(optionalNotesBody), async (req: Request, res: Response) => {
     try {
       const updated = await exceptions.reject(
         Number(req.params.id),
         req.user!.id,
-        req.body?.notes ?? null
+        (res.locals.body.notes as string | null | undefined) ?? null
       );
       res.json({ success: true, data: updated });
     } catch (err) {

--- a/frontend/src/pages/Employees/Employees.tsx
+++ b/frontend/src/pages/Employees/Employees.tsx
@@ -217,12 +217,12 @@ const Employees: React.FC = () => {
             <table className="table table-hover mb-0">
               <thead>
                 <tr>
-                  <th>Employee</th>
-                  <th>Department</th>
-                  <th>Position</th>
-                  <th>Hourly Rate</th>
-                  <th>Status</th>
-                  <th style={{ width: '120px' }}>Actions</th>
+                  <th scope="col">Employee</th>
+                  <th scope="col">Department</th>
+                  <th scope="col">Position</th>
+                  <th scope="col">Hourly Rate</th>
+                  <th scope="col">Status</th>
+                  <th scope="col" style={{ width: '120px' }}>Actions</th>
                 </tr>
               </thead>
               <tbody>

--- a/frontend/src/pages/Policies/ExceptionList.tsx
+++ b/frontend/src/pages/Policies/ExceptionList.tsx
@@ -104,11 +104,11 @@ const ExceptionList: React.FC<Props> = ({
         <table className="table">
           <thead>
             <tr>
-              <th>Policy</th>
-              <th>Target</th>
-              <th>Requested by</th>
-              <th>Status</th>
-              <th className="text-end">Actions</th>
+              <th scope="col">Policy</th>
+              <th scope="col">Target</th>
+              <th scope="col">Requested by</th>
+              <th scope="col">Status</th>
+              <th scope="col" className="text-end">Actions</th>
             </tr>
           </thead>
           <tbody>

--- a/frontend/src/pages/Policies/Policies.tsx
+++ b/frontend/src/pages/Policies/Policies.tsx
@@ -342,11 +342,11 @@ const Policies: React.FC = () => {
             <table className="table">
               <thead>
                 <tr>
-                  <th>Change type</th>
-                  <th>Approver scope</th>
-                  <th>Role</th>
-                  <th>User</th>
-                  <th>Auto approve</th>
+                  <th scope="col">Change type</th>
+                  <th scope="col">Approver scope</th>
+                  <th scope="col">Role</th>
+                  <th scope="col">User</th>
+                  <th scope="col">Auto approve</th>
                 </tr>
               </thead>
               <tbody>

--- a/frontend/src/pages/Policies/PolicyList.tsx
+++ b/frontend/src/pages/Policies/PolicyList.tsx
@@ -107,12 +107,12 @@ const PolicyList: React.FC<Props> = ({
         <table className="table">
           <thead>
             <tr>
-              <th>Scope</th>
-              <th>Key</th>
-              <th>Value</th>
-              <th>Owner</th>
-              <th>Status</th>
-              <th className="text-end">Actions</th>
+              <th scope="col">Scope</th>
+              <th scope="col">Key</th>
+              <th scope="col">Value</th>
+              <th scope="col">Owner</th>
+              <th scope="col">Status</th>
+              <th scope="col" className="text-end">Actions</th>
             </tr>
           </thead>
           <tbody>

--- a/frontend/src/pages/Reports/Reports.tsx
+++ b/frontend/src/pages/Reports/Reports.tsx
@@ -106,8 +106,8 @@ const Reports: React.FC = () => {
               <table className="table table-sm mb-0">
                 <thead>
                   <tr>
-                    <th>User</th>
-                    <th className="text-end">Hours</th>
+                    <th scope="col">User</th>
+                    <th scope="col" className="text-end">Hours</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -139,9 +139,9 @@ const Reports: React.FC = () => {
               <table className="table table-sm mb-0">
                 <thead>
                   <tr>
-                    <th>Department</th>
-                    <th className="text-end">Hours</th>
-                    <th className="text-end">Cost</th>
+                    <th scope="col">Department</th>
+                    <th scope="col" className="text-end">Hours</th>
+                    <th scope="col" className="text-end">Cost</th>
                   </tr>
                 </thead>
                 <tbody>

--- a/frontend/src/pages/orgManagement/OrgTree.tsx
+++ b/frontend/src/pages/orgManagement/OrgTree.tsx
@@ -132,10 +132,10 @@ const OrgTree: React.FC<Props> = ({
         <table className="table table-hover">
           <thead>
             <tr>
-              <th>Unit</th>
-              <th>Manager</th>
-              <th>Status</th>
-              <th className="text-end">Actions</th>
+              <th scope="col">Unit</th>
+              <th scope="col">Manager</th>
+              <th scope="col">Status</th>
+              <th scope="col" className="text-end">Actions</th>
             </tr>
           </thead>
           <tbody>


### PR DESCRIPTION
## Summary

- Update login/logout JSDoc in `auth.ts` to reflect cookie-only token delivery and JTI blacklist (no longer mentions `B001` backlog item since it's implemented)
- Remove dead `config.session` block from `config/index.ts` — never referenced anywhere in source
- Wire `validateBody(optionalNotesBody)` to `policies` `/exceptions/:id/approve` and `/exceptions/:id/reject` — same unvalidated `req.body?.notes` pattern that was fixed for timeOff/shiftSwap/org
- Add `scope="col"` to all remaining `<th>` elements missing it: `Employees.tsx`, `OrgTree.tsx`, `PolicyList.tsx`, `ExceptionList.tsx`, `Policies.tsx`, `Reports.tsx`

## Test plan

- [x] `npm test` in backend: 1647 tests passing
- [x] `npm test` in frontend: 103 tests passing
- [x] `npx tsc --noEmit` clean on both backend and frontend
- [x] `npm run deadcode` returns no output