### PR TITLE
fix(review): enforce 2FA at login, CORS healthcheck fix, OpenAPI sync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Staff Scheduler is an enterprise workforce management system.
 
 - **Backend**: Node.js/Express/TypeScript REST API — runs on port **3001**
 - **Frontend**: React 18/TypeScript SPA (Create React App) — runs on port **3000**
-- **Database**: MySQL 8.0 (29 tables, schema in `backend/database/init.sql`)
+- **Database**: MySQL 8.0 (37 tables, schema in `backend/database/init.sql`)
 - **Optimizer**: Python 3.8+ with Google OR-Tools CP-SAT, invoked via `child_process` from `backend/src/optimization/ScheduleOptimizerORTools.ts`
 
 ## Commands

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -157,13 +157,15 @@ The single source of truth is [`backend/openapi/openapi.json`](./backend/openapi
 ### Authentication
 
 ```
-POST /api/auth/login       { email, password } → sets httpOnly cookie "token"; body: { user: { id, email, firstName, lastName, roles, permissions } }
+POST /api/auth/login       { email, password, totpCode? } → sets httpOnly cookie "token"; body: { user: { id, email, firstName, lastName, roles, permissions } }
 GET  /api/auth/verify      (cookie) → { user }
 POST /api/auth/refresh     (cookie) → rotates cookie; body: { user }
 POST /api/auth/logout      blacklists the JTI and clears the cookie
 ```
 
-JWT payload: `{ userId, email, jti }` — no role. Permissions are resolved from the DB on every request. The `jti` field enables server-side revocation on logout via an in-memory blacklist with TTL-based expiry.
+JWT payload: `{ userId, email, jti }` — no role. Permissions are resolved from the DB on every request. The `jti` field enables server-side revocation on logout via an in-memory blacklist with TTL-based expiry. The cookie lifetime tracks `JWT_EXPIRES_IN` so cookie and token always expire together.
+
+**Two-factor authentication**: when an account has TOTP enabled (`POST /api/auth/2fa/setup` + `/enable`), login additionally requires `totpCode` — a current TOTP code or an unused recovery code. A password-valid login without the code answers 401 `TOTP_REQUIRED`; a wrong code answers 401 `TOTP_INVALID`. Disabling 2FA (`POST /api/auth/2fa/disable`) likewise requires a valid code.
 
 ### Core endpoints (summary)
 
@@ -200,8 +202,10 @@ JWT payload: `{ userId, email, jti }` — no role. Permissions are resolved from
 
 | Code | HTTP | Meaning |
 |---|---|---|
-| `MISSING_TOKEN` | 401 | No `Authorization` header |
+| `MISSING_TOKEN` | 401 | No `token` cookie and no `Authorization` header |
 | `INVALID_TOKEN` | 401 | JWT invalid or expired |
+| `TOTP_REQUIRED` | 401 | Account has 2FA enabled; login needs `totpCode` |
+| `TOTP_INVALID` | 401 | Wrong TOTP or recovery code |
 | `FORBIDDEN` | 403 | Permission not held |
 | `NOT_FOUND` | 404 | Resource missing or module disabled |
 | `CONFLICT` | 409 | Duplicate resource |
@@ -880,7 +884,7 @@ Features are grouped by category:
 | Per-org-unit rate limiting | Enterprise | Medium | Low | Current rate limiting applies only to the login endpoint. A per-tenant API quota is required for multi-tenant SaaS hardening. |
 | Multi-language / i18n | Enterprise | Medium | High | All UI strings are currently hardcoded in English in React components. Retrofitting i18n (react-i18next) requires extracting every string. |
 | Bulk API (batch endpoints) | Enterprise | Medium | Medium | High-volume integrations (HRIS sync, bulk assignment) require atomic batch operations. The `/api/import` CSV bulk import exists; REST batch endpoints for other resources do not. |
-| Two-factor authentication | Enterprise | Medium | Low | `TwoFactorService.ts` already exists in `backend/src/services/`. The gap is the frontend enrollment flow and enforcement policy per org unit. |
+| Two-factor authentication | Enterprise | Medium | Low | Backend enforcement at login and the frontend challenge step are implemented. The gap is the frontend enrollment flow (QR/secret display, recovery code presentation) and enforcement policy per org unit. |
 | Predictive demand forecasting | Innovative | High | High | The `forecasting` module is registered; `ScheduleOptimizationOrchestrator` handles optimization. Demand forecasting requires a separate ML pipeline ingesting historical assignment data and external signals (sales, footfall). |
 | AI auto-schedule generation (production-ready) | Innovative | High | Medium | OR-Tools CP-SAT optimizer exists; gap is coverage rules refinement, forecast-input integration, and a manager review/override UX. |
 | Shift bidding / preference-based assignment | Innovative | Medium | Medium | Employees rank desired shifts; optimizer uses preferences as soft constraints. Preference weights exist in the CP-SAT model; the employee-facing bidding UI and ranking endpoint are missing. |
@@ -903,7 +907,7 @@ Target: eliminate the most impactful bottlenecks without infrastructure changes;
 | Connection pool tuning | Set `DB_POOL_LIMIT` (controls `connectionLimit`, default 30) and `DB_QUEUE_LIMIT` (controls `queueLimit`, default 100) in `backend/.env`. Raise `DB_POOL_LIMIT` to 30–50 for Tier 2; set `DB_QUEUE_LIMIT` to reject rather than queue indefinitely. | Prevents pool exhaustion under moderate burst. Low-risk change. |
 | Fix N+1 in list endpoints | Audit `GET /employees`, `GET /shifts`, `GET /schedules` for per-row sub-queries. Replace with `JOIN` or a single `IN (...)` query. | Latency on list endpoints grows linearly with result set size without this fix. |
 | Add missing API filters | `GET /assignments`, `GET /audit-logs`, `GET /notifications` lack date-range and status filters that clients need for pagination. | Reduces over-fetching and improves frontend perceived performance. |
-| Two-factor authentication UI | Wire the existing `TwoFactorService.ts` to a frontend enrollment and challenge flow. | The backend is complete; the frontend gap prevents the feature from shipping. |
+| Two-factor authentication UI | Build the frontend enrollment flow (QR/secret display, recovery code presentation) on top of the existing `/api/auth/2fa` endpoints. | Backend enforcement and the login challenge step exist; enrollment still requires calling the API manually. |
 | Reporting dashboard UI | Build chart components (Recharts) on top of the existing `/api/reports` responses. | High visible value; backend is already complete. |
 | Outbound webhooks (basic) | Add a `webhook_subscriptions` table and a delivery worker that POSTs to registered URLs on key events (schedule published, assignment confirmed). Use `EventBus.ts` as the event source. | Required by integrations; unblocks enterprise evaluation. |
 

--- a/backend/openapi/openapi.json
+++ b/backend/openapi/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Staff Scheduler API",
     "version": "1.0.0",
-    "description": "Open-source workforce management REST API.\n\nAll non-public endpoints require a Bearer JWT obtained via `POST /api/v1/auth/login`.\n\nBase URLs:\n- Canonical: `http://localhost:3001/api/v1`\n- Legacy (will be removed): `http://localhost:3001/api`\n\nEvery response follows the envelope format:\n- Success: `{ \"success\": true, \"data\": <T> }`\n- Error:   `{ \"success\": false, \"error\": { \"code\": \"ERROR_CODE\", \"message\": \"...\" } }`\n\nValidation errors return `VALIDATION_ERROR` with a `details` array of field-level messages.\nRate-limit errors return HTTP 429 with code `RATE_LIMIT_EXCEEDED`.",
+    "description": "Open-source workforce management REST API.\n\nAll non-public endpoints require a JWT obtained via `POST /api/v1/auth/login`, presented either as the httpOnly `token` cookie (set automatically at login) or as `Authorization: Bearer <token>`.\n\nBase URLs:\n- Canonical: `http://localhost:3001/api/v1`\n- Legacy (will be removed): `http://localhost:3001/api`\n\nEvery response follows the envelope format:\n- Success: `{ \"success\": true, \"data\": <T> }`\n- Error:   `{ \"success\": false, \"error\": { \"code\": \"ERROR_CODE\", \"message\": \"...\" } }`\n\nValidation errors return `VALIDATION_ERROR` with a `details` array of field-level messages.\nRate-limit errors return HTTP 429 with code `RATE_LIMIT_EXCEEDED`.",
     "contact": {
       "name": "Luca Ostinelli",
       "email": "ostinelliluca2@gmail.com",
@@ -20,7 +20,7 @@
     },
     {
       "url": "http://localhost:3001/api",
-      "description": "Local development (legacy \u2014 will be removed)"
+      "description": "Local development (legacy — will be removed)"
     }
   ],
   "components": {
@@ -29,7 +29,13 @@
         "type": "http",
         "scheme": "bearer",
         "bearerFormat": "JWT",
-        "description": "JWT obtained from POST /auth/login. Pass as Authorization: Bearer <token>."
+        "description": "JWT passed as Authorization: Bearer <token>. Alternative to the httpOnly cookie for non-browser clients."
+      },
+      "cookieAuth": {
+        "type": "apiKey",
+        "in": "cookie",
+        "name": "token",
+        "description": "httpOnly JWT cookie set by POST /auth/login (primary mechanism for the web frontend)."
       }
     },
     "schemas": {
@@ -662,6 +668,9 @@
   },
   "security": [
     {
+      "cookieAuth": []
+    },
+    {
       "bearerAuth": []
     }
   ],
@@ -776,30 +785,905 @@
     }
   ],
   "paths": {
-    "/health": {
+    "/approval-workflows": {
       "get": {
         "tags": [
-          "System"
+          "Approval Workflows"
         ],
-        "summary": "Health check",
-        "description": "Returns database connectivity status. No authentication required.",
-        "security": [],
+        "summary": "List approval workflow definitions",
         "responses": {
           "200": {
-            "description": "Service healthy.",
+            "description": "Workflow list."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Approval Workflows"
+        ],
+        "summary": "Create approval workflow",
+        "description": "Defines a multi-step approval chain for a specific change type.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "name",
+                  "changeType",
+                  "steps"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "changeType": {
+                    "type": "string"
+                  },
+                  "steps": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "order": {
+                          "type": "integer"
+                        },
+                        "approverRole": {
+                          "type": "string"
+                        },
+                        "timeoutHours": {
+                          "type": "integer"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Workflow created."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/approval-workflows/escalate": {
+      "post": {
+        "tags": [
+          "Approval Workflows"
+        ],
+        "summary": "Run the escalation sweep",
+        "description": "Escalates pending approval steps past their deadline.",
+        "responses": {
+          "200": {
+            "description": "Escalation results."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/approval-workflows/{id}": {
+      "put": {
+        "tags": [
+          "Approval Workflows"
+        ],
+        "summary": "Update an approval workflow",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Workflow updated."
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Approval Workflows"
+        ],
+        "summary": "Delete an approval workflow",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Workflow deleted."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/approval-workflows/{type}": {
+      "get": {
+        "tags": [
+          "Approval Workflows"
+        ],
+        "summary": "Get workflow configuration by type",
+        "parameters": [
+          {
+            "name": "type",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/assignments": {
+      "get": {
+        "tags": [
+          "Assignments"
+        ],
+        "summary": "List assignments",
+        "parameters": [
+          {
+            "name": "shiftId",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "userId",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "scheduleId",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "departmentId",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "pending",
+                "confirmed",
+                "cancelled",
+                "completed"
+              ]
+            }
+          },
+          {
+            "name": "startDate",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "endDate",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Assignment list.",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "status": {
-                      "type": "string",
-                      "const": "ok"
+                    "success": {
+                      "type": "boolean"
                     },
-                    "database": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Assignment"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Assignments"
+        ],
+        "summary": "Create assignment",
+        "description": "Assigns an employee to a shift. Validates: capacity, conflicts, availability, skills, compliance limits, and active policies. Requires `assignment.manage`.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "shiftId",
+                  "userId"
+                ],
+                "properties": {
+                  "shiftId": {
+                    "type": "integer"
+                  },
+                  "userId": {
+                    "type": "integer"
+                  },
+                  "notes": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Assignment created with status `pending`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/Assignment"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Capacity exceeded, conflict, unavailability, or missing skills."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "409": {
+            "description": "Compliance or policy violation."
+          }
+        }
+      }
+    },
+    "/assignments/bulk": {
+      "post": {
+        "tags": [
+          "Assignments"
+        ],
+        "summary": "Bulk create assignments",
+        "description": "Creates multiple assignments in one request. Failures are logged and skipped; the response contains only successfully created assignments. Requires `assignment.manage`.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "shiftId",
+                  "userIds"
+                ],
+                "properties": {
+                  "shiftId": {
+                    "type": "integer"
+                  },
+                  "userIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created assignments."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/assignments/department/{departmentId}": {
+      "get": {
+        "tags": [
+          "Assignments"
+        ],
+        "summary": "List assignments for a department",
+        "parameters": [
+          {
+            "name": "departmentId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/assignments/shift/{shiftId}": {
+      "get": {
+        "tags": [
+          "Assignments"
+        ],
+        "summary": "List assignments for a shift",
+        "parameters": [
+          {
+            "name": "shiftId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/assignments/shift/{shiftId}/available-employees": {
+      "get": {
+        "tags": [
+          "Assignments"
+        ],
+        "summary": "Available employees for shift",
+        "description": "Returns users in the shift's department who have no conflicting assignment.",
+        "parameters": [
+          {
+            "name": "shiftId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of available employees."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/assignments/user/{userId}": {
+      "get": {
+        "tags": [
+          "Assignments"
+        ],
+        "summary": "List a user's assignments",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/assignments/{id}": {
+      "get": {
+        "tags": [
+          "Assignments"
+        ],
+        "summary": "Get assignment by ID",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Assignment object."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Assignments"
+        ],
+        "summary": "Update assignment status or notes",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "status": {
+                    "type": "string"
+                  },
+                  "notes": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Assignments"
+        ],
+        "summary": "Delete assignment",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Deleted."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/assignments/{id}/complete": {
+      "patch": {
+        "tags": [
+          "Assignments"
+        ],
+        "summary": "Complete assignment",
+        "description": "Transitions from `confirmed` to `completed`.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Completed."
+          },
+          "400": {
+            "description": "Assignment is not confirmed."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/assignments/{id}/confirm": {
+      "patch": {
+        "tags": [
+          "Assignments"
+        ],
+        "summary": "Confirm assignment",
+        "description": "Transitions from `pending` to `confirmed`.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Confirmed."
+          },
+          "400": {
+            "description": "Not in pending status."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/assignments/{id}/decline": {
+      "patch": {
+        "tags": [
+          "Assignments"
+        ],
+        "summary": "Decline assignment",
+        "description": "Transitions from `pending` or `confirmed` to `cancelled`.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Cancelled."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/audit-logs": {
+      "get": {
+        "tags": [
+          "Audit Logs"
+        ],
+        "summary": "List audit log entries",
+        "description": "Manager or admin only. Immutable log of all sensitive actions.",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "action",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "entityType",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "startDate",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "endDate",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "maximum": 500,
+              "default": 50
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Audit entries.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/AuditLogEntry"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/audit-logs/{id}": {
+      "get": {
+        "tags": [
+          "Audit Logs"
+        ],
+        "summary": "Get a single audit log entry",
+        "description": "Module `audit` must be enabled; requires `audit.read`.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/auth/2fa/disable": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Disable two-factor authentication",
+        "description": "Requires a valid current TOTP code or an unused recovery code; answers 401 `TOTP_INVALID` otherwise.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "code"
+                ],
+                "properties": {
+                  "code": {
+                    "type": "string",
+                    "description": "TOTP or recovery code."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "2FA disabled."
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/auth/2fa/enable": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Confirm and enable 2FA",
+        "description": "Verifies the 6-digit TOTP code and enables 2FA for the current user. Returns one-time recovery codes — store them safely.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "code"
+                ],
+                "properties": {
+                  "code": {
+                    "type": "string",
+                    "pattern": "^[0-9]{6}$"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "2FA enabled. Recovery codes returned."
+          },
+          "400": {
+            "description": "Invalid code or 2FA not in setup state."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/auth/2fa/setup": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Begin TOTP 2FA setup",
+        "description": "Generates a TOTP secret and returns it plus an `otpauth://` URI. The caller must confirm the code via `/auth/2fa/enable` before 2FA is active.",
+        "responses": {
+          "200": {
+            "description": "TOTP setup payload.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "secret": {
                       "type": "string"
                     },
-                    "timestamp": {
+                    "otpauthUrl": {
+                      "type": "string"
+                    },
+                    "qrCodeUrl": {
                       "type": "string"
                     }
                   }
@@ -807,23 +1691,46 @@
               }
             }
           },
-          "503": {
-            "description": "Database unreachable."
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
           }
         }
       }
     },
-    "/system/info": {
-      "get": {
+    "/auth/2fa/verify": {
+      "post": {
         "tags": [
-          "System"
+          "Auth"
         ],
-        "summary": "Runtime metadata",
-        "description": "Returns mode (production | demo | development), version, and active modules. No authentication required.",
-        "security": [],
+        "summary": "Verify a TOTP code",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "code"
+                ],
+                "properties": {
+                  "code": {
+                    "type": "string",
+                    "description": "TOTP or recovery code."
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
-            "description": "Runtime info."
+            "description": "Verification result in `data.valid`."
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
           }
         }
       }
@@ -834,7 +1741,7 @@
           "Auth"
         ],
         "summary": "Login",
-        "description": "Authenticate with email and password. Returns a signed JWT valid for the period configured in `JWT_EXPIRES_IN` (default 24 h). The token must be passed as `Authorization: Bearer <token>` on subsequent requests.",
+        "description": "Authenticate with email and password. On success the signed JWT (valid for the period configured in `JWT_EXPIRES_IN`, default 24 h) is set as an httpOnly `token` cookie; it is never returned in the response body. Subsequent requests authenticate via that cookie, or alternatively via `Authorization: Bearer <token>`. When the account has two-factor authentication enabled, `totpCode` (a TOTP or single-use recovery code) is required: the endpoint answers 401 `TOTP_REQUIRED` when it is missing and 401 `TOTP_INVALID` when it is wrong.",
         "security": [],
         "requestBody": {
           "required": true,
@@ -853,6 +1760,10 @@
                   },
                   "password": {
                     "type": "string"
+                  },
+                  "totpCode": {
+                    "type": "string",
+                    "description": "TOTP or recovery code; required only when 2FA is enabled."
                   }
                 }
               },
@@ -865,7 +1776,15 @@
         },
         "responses": {
           "200": {
-            "description": "JWT issued.",
+            "description": "Authenticated. The JWT is delivered as an httpOnly `token` cookie.",
+            "headers": {
+              "Set-Cookie": {
+                "description": "httpOnly JWT cookie, e.g. `token=<jwt>; HttpOnly; SameSite=Lax`.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -877,9 +1796,6 @@
                     "data": {
                       "type": "object",
                       "properties": {
-                        "token": {
-                          "type": "string"
-                        },
                         "user": {
                           "$ref": "#/components/schemas/User"
                         }
@@ -894,21 +1810,21 @@
             "$ref": "#/components/responses/ValidationError"
           },
           "401": {
-            "description": "Invalid credentials."
+            "description": "Invalid credentials (`LOGIN_FAILED`), missing 2FA code (`TOTP_REQUIRED`), or wrong 2FA code (`TOTP_INVALID`)."
           },
           "429": {
-            "description": "Login throttled \u2014 too many failed attempts."
+            "description": "Login throttled — too many failed attempts."
           }
         }
       }
     },
-    "/auth/verify": {
-      "get": {
+    "/auth/logout": {
+      "post": {
         "tags": [
           "Auth"
         ],
-        "summary": "Verify token",
-        "description": "Validates the incoming JWT and returns the user record (without secrets). Use this to check whether a stored token is still valid.",
+        "summary": "Logout",
+        "description": "Informational endpoint. With JWT-based auth, logout is primarily client-side: the client drops the token from storage. The server responds with success without invalidating the token server-side (no revocation store). See security backlog item B001 for token blacklisting.",
         "security": [
           {
             "bearerAuth": []
@@ -916,7 +1832,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Token valid. User record returned.",
+            "description": "Logout acknowledged.",
             "content": {
               "application/json": {
                 "schema": {
@@ -925,10 +1841,14 @@
                     "success": {
                       "type": "boolean"
                     },
-                    "data": {
-                      "$ref": "#/components/schemas/User"
+                    "message": {
+                      "type": "string"
                     }
                   }
+                },
+                "example": {
+                  "success": true,
+                  "message": "Logged out successfully"
                 }
               }
             }
@@ -984,13 +1904,13 @@
         }
       }
     },
-    "/auth/logout": {
-      "post": {
+    "/auth/verify": {
+      "get": {
         "tags": [
           "Auth"
         ],
-        "summary": "Logout",
-        "description": "Informational endpoint. With JWT-based auth, logout is primarily client-side: the client drops the token from storage. The server responds with success without invalidating the token server-side (no revocation store). See security backlog item B001 for token blacklisting.",
+        "summary": "Verify token",
+        "description": "Validates the incoming JWT and returns the user record (without secrets). Use this to check whether a stored token is still valid.",
         "security": [
           {
             "bearerAuth": []
@@ -998,7 +1918,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Logout acknowledged.",
+            "description": "Token valid. User record returned.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1007,14 +1927,10 @@
                     "success": {
                       "type": "boolean"
                     },
-                    "message": {
-                      "type": "string"
+                    "data": {
+                      "$ref": "#/components/schemas/User"
                     }
                   }
-                },
-                "example": {
-                  "success": true,
-                  "message": "Logged out successfully"
                 }
               }
             }
@@ -1025,34 +1941,117 @@
         }
       }
     },
-    "/auth/2fa/setup": {
-      "post": {
+    "/calendar/department/{id}.ics": {
+      "get": {
         "tags": [
-          "Auth"
+          "Calendar"
         ],
-        "summary": "Begin TOTP 2FA setup",
-        "description": "Generates a TOTP secret and returns it plus an `otpauth://` URI. The caller must confirm the code via `/auth/2fa/enable` before 2FA is active.",
+        "summary": "Department iCalendar feed",
+        "description": "Aggregated iCal for an entire department. Manager/admin only. Pass the manager's calendar token.",
+        "security": [],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "token",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "If-None-Match",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
-            "description": "TOTP setup payload.",
+            "description": "iCalendar text.",
             "content": {
-              "application/json": {
+              "text/calendar": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "secret": {
-                      "type": "string"
-                    },
-                    "otpauthUrl": {
-                      "type": "string"
-                    },
-                    "qrCodeUrl": {
-                      "type": "string"
-                    }
-                  }
+                  "type": "string"
                 }
               }
             }
+          },
+          "304": {
+            "description": "Not modified."
+          },
+          "401": {
+            "description": "Missing or invalid token."
+          },
+          "403": {
+            "description": "Caller is not a manager of this department."
+          }
+        }
+      }
+    },
+    "/calendar/feed.ics": {
+      "get": {
+        "tags": [
+          "Calendar"
+        ],
+        "summary": "Personal iCalendar feed",
+        "description": "Returns an iCal feed for the user identified by `token`. No JWT required — pass the token as a query parameter. Emits ETag for conditional requests. Lists colleagues working the same shift in DESCRIPTION.",
+        "security": [],
+        "parameters": [
+          {
+            "name": "token",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "If-None-Match",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "iCalendar text.",
+            "content": {
+              "text/calendar": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "304": {
+            "description": "Not modified (ETag match)."
+          },
+          "401": {
+            "description": "Missing or invalid token."
+          }
+        }
+      }
+    },
+    "/calendar/token": {
+      "post": {
+        "tags": [
+          "Calendar"
+        ],
+        "summary": "Get or create calendar feed token",
+        "description": "Returns a stable token used to authenticate the iCalendar feed URL.",
+        "responses": {
+          "200": {
+            "description": "Token."
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
@@ -1060,13 +2059,114 @@
         }
       }
     },
-    "/auth/2fa/enable": {
+    "/calendar/token/rotate": {
       "post": {
         "tags": [
-          "Auth"
+          "Calendar"
         ],
-        "summary": "Confirm and enable 2FA",
-        "description": "Verifies the 6-digit TOTP code and enables 2FA for the current user. Returns one-time recovery codes \u2014 store them safely.",
+        "summary": "Rotate the personal calendar feed token",
+        "description": "Invalidates the previous token.",
+        "responses": {
+          "200": {
+            "description": "New token in `data.token`."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/dashboard/activities": {
+      "get": {
+        "tags": [
+          "Dashboard"
+        ],
+        "summary": "Recent activity feed",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/limitQuery"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Activity list."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/dashboard/departments": {
+      "get": {
+        "tags": [
+          "Dashboard"
+        ],
+        "summary": "Department summaries for the dashboard",
+        "responses": {
+          "200": {
+            "description": "OK."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/dashboard/stats": {
+      "get": {
+        "tags": [
+          "Dashboard"
+        ],
+        "summary": "Aggregated dashboard statistics",
+        "responses": {
+          "200": {
+            "description": "Stats (total staff, shifts today, coverage, etc.)."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/dashboard/upcoming-shifts": {
+      "get": {
+        "tags": [
+          "Dashboard"
+        ],
+        "summary": "Caller's upcoming shifts",
+        "responses": {
+          "200": {
+            "description": "Shifts list."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/delegations": {
+      "get": {
+        "tags": [
+          "Delegations"
+        ],
+        "summary": "List delegations",
+        "description": "Returns delegations involving the caller (as delegator or delegate).",
+        "responses": {
+          "200": {
+            "description": "Delegation list."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Delegations"
+        ],
+        "summary": "Create delegation",
+        "description": "Grants a set of permissions to another user for a specified period.",
         "requestBody": {
           "required": true,
           "content": {
@@ -1074,12 +2174,220 @@
               "schema": {
                 "type": "object",
                 "required": [
-                  "code"
+                  "delegateUserId",
+                  "permissionKeys",
+                  "startDate",
+                  "endDate"
                 ],
                 "properties": {
-                  "code": {
+                  "delegateUserId": {
+                    "type": "integer"
+                  },
+                  "permissionKeys": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "startDate": {
                     "type": "string",
-                    "pattern": "^[0-9]{6}$"
+                    "format": "date-time"
+                  },
+                  "endDate": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "reason": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Delegation created."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/delegations/{id}": {
+      "delete": {
+        "tags": [
+          "Delegations"
+        ],
+        "summary": "Revoke a delegation",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Delegation revoked."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/departments": {
+      "get": {
+        "tags": [
+          "Departments"
+        ],
+        "summary": "List departments",
+        "parameters": [
+          {
+            "name": "isActive",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "orgUnitId",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Filter by parent org unit."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Department list.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Department"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Departments"
+        ],
+        "summary": "Create department",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "orgUnitId": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Department created."
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/departments/{id}": {
+      "get": {
+        "tags": [
+          "Departments"
+        ],
+        "summary": "Get department by ID",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Department object."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Departments"
+        ],
+        "summary": "Update department",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "isActive": {
+                    "type": "boolean"
+                  },
+                  "orgUnitId": {
+                    "type": "integer"
                   }
                 }
               }
@@ -1088,10 +2396,195 @@
         },
         "responses": {
           "200": {
-            "description": "2FA enabled. Recovery codes returned."
+            "description": "Updated."
           },
-          "400": {
-            "description": "Invalid code or 2FA not in setup state."
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Departments"
+        ],
+        "summary": "Delete department",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Deleted."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/departments/{id}/stats": {
+      "get": {
+        "tags": [
+          "Departments"
+        ],
+        "summary": "Department statistics",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Staffing stats."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/departments/{id}/users": {
+      "post": {
+        "tags": [
+          "Departments"
+        ],
+        "summary": "Add user to department",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "userId"
+                ],
+                "properties": {
+                  "userId": {
+                    "type": "integer"
+                  },
+                  "role": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "User added."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/departments/{id}/users/{userId}": {
+      "delete": {
+        "tags": [
+          "Departments"
+        ],
+        "summary": "Remove user from department",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          },
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "User removed."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/directory/import-vcard": {
+      "post": {
+        "tags": [
+          "Directory"
+        ],
+        "summary": "Bulk import from vCard",
+        "description": "Admin only. Existing emails are skipped.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "vcf": {
+                    "type": "string",
+                    "description": "Raw .vcf text."
+                  },
+                  "defaultPassword": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Inserted and skipped counts."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/directory/me": {
+      "get": {
+        "tags": [
+          "Directory"
+        ],
+        "summary": "Own directory profile",
+        "description": "Returns the caller's profile plus any custom fields.",
+        "responses": {
+          "200": {
+            "description": "Profile."
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
@@ -1099,18 +2592,4223 @@
         }
       }
     },
-    "/auth/2fa/disable": {
-      "post": {
+    "/directory/users/{id}": {
+      "get": {
         "tags": [
-          "Auth"
+          "Directory"
         ],
-        "summary": "Disable 2FA",
+        "summary": "User directory profile",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
         "responses": {
           "200": {
-            "description": "2FA disabled."
+            "description": "Profile."
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/directory/users/{id}/fields": {
+      "put": {
+        "tags": [
+          "Directory"
+        ],
+        "summary": "Bulk upsert custom fields",
+        "description": "Replaces all custom fields for a user. Manager only.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "fields"
+                ],
+                "properties": {
+                  "fields": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "required": [
+                        "key",
+                        "value"
+                      ],
+                      "properties": {
+                        "key": {
+                          "type": "string",
+                          "pattern": "^[A-Za-z0-9_-]{1,64}$"
+                        },
+                        "value": {
+                          "type": "string"
+                        },
+                        "isPublic": {
+                          "type": "boolean"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated profile."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/directory/users/{id}/fields/{key}": {
+      "delete": {
+        "tags": [
+          "Directory"
+        ],
+        "summary": "Remove a custom directory field",
+        "description": "Requires `user.manage`.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          },
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Field removed."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/directory/users/{id}/vcard": {
+      "get": {
+        "tags": [
+          "Directory"
+        ],
+        "summary": "Single-user vCard 4.0",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "vCard.",
+            "content": {
+              "text/vcard": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/directory/vcard.vcf": {
+      "get": {
+        "tags": [
+          "Directory"
+        ],
+        "summary": "Multi-user vCard archive",
+        "parameters": [
+          {
+            "name": "ids",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Comma-separated user IDs."
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "vCard archive.",
+            "content": {
+              "text/vcard": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/employees": {
+      "get": {
+        "tags": [
+          "Employees"
+        ],
+        "summary": "List employees",
+        "parameters": [
+          {
+            "name": "departmentId",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "isActive",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/pageQuery"
+          },
+          {
+            "$ref": "#/components/parameters/limitQuery"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Employee list.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Employee"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Employees"
+        ],
+        "summary": "Create employee profile",
+        "description": "Creates the employee record for an existing user. Requires `employee.manage`.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "userId"
+                ],
+                "properties": {
+                  "userId": {
+                    "type": "integer"
+                  },
+                  "employeeNumber": {
+                    "type": "string"
+                  },
+                  "position": {
+                    "type": "string"
+                  },
+                  "departmentId": {
+                    "type": "integer"
+                  },
+                  "hourlyRate": {
+                    "type": "number",
+                    "minimum": 0
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Employee created."
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/employees/department/{departmentId}": {
+      "get": {
+        "tags": [
+          "Employees"
+        ],
+        "summary": "List employees of a department",
+        "parameters": [
+          {
+            "name": "departmentId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/employees/{id}": {
+      "get": {
+        "tags": [
+          "Employees"
+        ],
+        "summary": "Get employee by ID",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Employee object."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Employees"
+        ],
+        "summary": "Update employee",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "position": {
+                    "type": "string"
+                  },
+                  "hourlyRate": {
+                    "type": "number"
+                  },
+                  "isActive": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Employees"
+        ],
+        "summary": "Delete employee profile",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Deleted."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/employees/{id}/skills": {
+      "get": {
+        "tags": [
+          "Employees"
+        ],
+        "summary": "List employee skills",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Skill list."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Employees"
+        ],
+        "summary": "Add skill to employee",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "skillId"
+                ],
+                "properties": {
+                  "skillId": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Skill added."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/employees/{id}/skills/{skillId}": {
+      "delete": {
+        "tags": [
+          "Employees"
+        ],
+        "summary": "Remove a skill from an employee",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          },
+          {
+            "name": "skillId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Skill removed."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/events/stream": {
+      "get": {
+        "tags": [
+          "System"
+        ],
+        "summary": "Server-sent events stream",
+        "description": "Long-lived `text/event-stream` connection delivering domain events.",
+        "responses": {
+          "200": {
+            "description": "SSE stream (text/event-stream)."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/health": {
+      "get": {
+        "tags": [
+          "System"
+        ],
+        "summary": "Health check",
+        "description": "Returns database connectivity status. No authentication required.",
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Service healthy.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "const": "ok"
+                    },
+                    "database": {
+                      "type": "string"
+                    },
+                    "timestamp": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Database unreachable."
+          }
+        }
+      }
+    },
+    "/health/ready": {
+      "get": {
+        "tags": [
+          "System"
+        ],
+        "summary": "Readiness probe",
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Ready."
+          },
+          "503": {
+            "description": "Dependencies unavailable."
+          }
+        }
+      }
+    },
+    "/import/employees": {
+      "post": {
+        "tags": [
+          "Import"
+        ],
+        "summary": "Bulk import employees from CSV/JSON",
+        "description": "Admin only. Idempotent by email — existing employees are updated.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "employees"
+                ],
+                "properties": {
+                  "employees": {
+                    "type": "array",
+                    "items": {
+                      "type": "object"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Import result."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/import/shifts": {
+      "post": {
+        "tags": [
+          "Import"
+        ],
+        "summary": "Bulk import shifts",
+        "description": "Admin/manager only.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "shifts"
+                ],
+                "properties": {
+                  "shifts": {
+                    "type": "array",
+                    "items": {
+                      "type": "object"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Import result."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/modules": {
+      "get": {
+        "tags": [
+          "Modules"
+        ],
+        "summary": "List feature modules and their status",
+        "responses": {
+          "200": {
+            "description": "Module list with enabled/disabled state."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/modules/{code}": {
+      "put": {
+        "tags": [
+          "Modules"
+        ],
+        "summary": "Enable or disable a feature module",
+        "description": "Requires `settings.manage`.",
+        "parameters": [
+          {
+            "name": "code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "isEnabled"
+                ],
+                "properties": {
+                  "isEnabled": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Module updated."
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/notifications": {
+      "get": {
+        "tags": [
+          "Notifications"
+        ],
+        "summary": "List own notifications",
+        "description": "Module `notifications` must be enabled (404 otherwise).",
+        "responses": {
+          "200": {
+            "description": "OK."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/notifications/read-all": {
+      "patch": {
+        "tags": [
+          "Notifications"
+        ],
+        "summary": "Mark all own notifications as read",
+        "responses": {
+          "200": {
+            "description": "All marked as read."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/notifications/unread-count": {
+      "get": {
+        "tags": [
+          "Notifications"
+        ],
+        "summary": "Count own unread notifications",
+        "description": "Module `notifications` must be enabled (404 otherwise).",
+        "responses": {
+          "200": {
+            "description": "OK."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/notifications/{id}/read": {
+      "patch": {
+        "tags": [
+          "Notifications"
+        ],
+        "summary": "Mark a notification as read",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Marked as read."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/on-call/me": {
+      "get": {
+        "tags": [
+          "On Call"
+        ],
+        "summary": "Caller's on-call schedule",
+        "parameters": [
+          {
+            "name": "start",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "end",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "On-call periods for the caller."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/on-call/periods": {
+      "get": {
+        "tags": [
+          "On Call"
+        ],
+        "summary": "List on-call periods",
+        "parameters": [
+          {
+            "name": "departmentId",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "start",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "end",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "On-call period list."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "On Call"
+        ],
+        "summary": "Create on-call period",
+        "description": "Requires manager role.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "departmentId",
+                  "date",
+                  "startTime",
+                  "endTime"
+                ],
+                "properties": {
+                  "departmentId": {
+                    "type": "integer"
+                  },
+                  "scheduleId": {
+                    "type": "integer"
+                  },
+                  "date": {
+                    "type": "string",
+                    "format": "date"
+                  },
+                  "startTime": {
+                    "type": "string"
+                  },
+                  "endTime": {
+                    "type": "string"
+                  },
+                  "minStaff": {
+                    "type": "integer",
+                    "minimum": 1
+                  },
+                  "maxStaff": {
+                    "type": "integer",
+                    "minimum": 1
+                  },
+                  "notes": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/on-call/periods/{id}": {
+      "get": {
+        "tags": [
+          "On Call"
+        ],
+        "summary": "Get an on-call period",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "On Call"
+        ],
+        "summary": "Update an on-call period",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Period updated."
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "On Call"
+        ],
+        "summary": "Delete an on-call period",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Period deleted."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/on-call/periods/{id}/assign": {
+      "post": {
+        "tags": [
+          "On Call"
+        ],
+        "summary": "Assign user to on-call period",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "userId"
+                ],
+                "properties": {
+                  "userId": {
+                    "type": "integer"
+                  },
+                  "notes": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Assigned."
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "description": "Period at max capacity."
+          }
+        }
+      }
+    },
+    "/on-call/periods/{id}/assign/{userId}": {
+      "delete": {
+        "tags": [
+          "On Call"
+        ],
+        "summary": "Remove a user from an on-call period",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          },
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Assignment removed."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/on-call/periods/{id}/assignments": {
+      "get": {
+        "tags": [
+          "On Call"
+        ],
+        "summary": "List assignments of an on-call period",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/org/loans": {
+      "get": {
+        "tags": [
+          "Org Units"
+        ],
+        "summary": "List employee loans",
+        "description": "Employee loans temporarily move a user to a different org unit.",
+        "responses": {
+          "200": {
+            "description": "Loan list."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Org Units"
+        ],
+        "summary": "Request employee loan",
+        "description": "Requires `loan.request`.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "userId",
+                  "targetOrgUnitId",
+                  "startDate",
+                  "endDate"
+                ],
+                "properties": {
+                  "userId": {
+                    "type": "integer"
+                  },
+                  "targetOrgUnitId": {
+                    "type": "integer"
+                  },
+                  "startDate": {
+                    "type": "string",
+                    "format": "date"
+                  },
+                  "endDate": {
+                    "type": "string",
+                    "format": "date"
+                  },
+                  "reason": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Loan requested."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/org/loans/{id}/approve": {
+      "post": {
+        "tags": [
+          "Org Units"
+        ],
+        "summary": "Approve an employee loan",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Loan approved."
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/org/loans/{id}/cancel": {
+      "post": {
+        "tags": [
+          "Org Units"
+        ],
+        "summary": "Cancel an employee loan",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Loan cancelled."
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/org/loans/{id}/reject": {
+      "post": {
+        "tags": [
+          "Org Units"
+        ],
+        "summary": "Reject an employee loan",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Loan rejected."
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/org/units": {
+      "get": {
+        "tags": [
+          "Org Units"
+        ],
+        "summary": "List org units (flat)",
+        "responses": {
+          "200": {
+            "description": "Flat list of org units."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Org Units"
+        ],
+        "summary": "Create org unit",
+        "description": "Requires `org_unit.manage`.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "parentId": {
+                    "type": "integer",
+                    "description": "Null for root units."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/org/units/tree": {
+      "get": {
+        "tags": [
+          "Org Units"
+        ],
+        "summary": "Org unit tree",
+        "description": "Returns the full hierarchy as a nested tree structure.",
+        "responses": {
+          "200": {
+            "description": "Tree."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/org/units/{id}": {
+      "get": {
+        "tags": [
+          "Org Units"
+        ],
+        "summary": "Get org unit by ID",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Org unit.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrgUnit"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Org Units"
+        ],
+        "summary": "Update org unit",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "parentId": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Org Units"
+        ],
+        "summary": "Delete org unit",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Deleted."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/org/units/{id}/members": {
+      "get": {
+        "tags": [
+          "Org Units"
+        ],
+        "summary": "List members of an org unit",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Org Units"
+        ],
+        "summary": "Add a member to an org unit",
+        "description": "Requires `employee.manage`.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Member added."
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/org/units/{id}/members/{userId}": {
+      "delete": {
+        "tags": [
+          "Org Units"
+        ],
+        "summary": "Remove a member from an org unit",
+        "description": "Requires `employee.manage`.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          },
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Member removed."
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/org/units/{id}/members/{userId}/primary": {
+      "patch": {
+        "tags": [
+          "Org Units"
+        ],
+        "summary": "Set a member's primary org unit",
+        "description": "Requires `employee.manage`.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          },
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Primary unit set."
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/permissions": {
+      "get": {
+        "tags": [
+          "RBAC"
+        ],
+        "summary": "List all permission keys",
+        "responses": {
+          "200": {
+            "description": "Permission list.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Permission"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/policies": {
+      "get": {
+        "tags": [
+          "Policies"
+        ],
+        "summary": "List scheduling policies",
+        "responses": {
+          "200": {
+            "description": "Policy list.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Policy"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Policies"
+        ],
+        "summary": "Create policy",
+        "description": "Requires `policy.manage`.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "key",
+                  "label",
+                  "value",
+                  "valueType"
+                ],
+                "properties": {
+                  "key": {
+                    "type": "string"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "value": {},
+                  "valueType": {
+                    "type": "string",
+                    "enum": [
+                      "integer",
+                      "float",
+                      "boolean",
+                      "string"
+                    ]
+                  },
+                  "category": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Policy created."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/policies/approval-matrix": {
+      "get": {
+        "tags": [
+          "Policies"
+        ],
+        "summary": "Get the approval matrix",
+        "responses": {
+          "200": {
+            "description": "OK."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/policies/approval-matrix/{changeType}": {
+      "put": {
+        "tags": [
+          "Policies"
+        ],
+        "summary": "Update an approval matrix row",
+        "parameters": [
+          {
+            "name": "changeType",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Matrix row updated."
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/policies/exceptions": {
+      "get": {
+        "tags": [
+          "Policies"
+        ],
+        "summary": "List policy exceptions",
+        "responses": {
+          "200": {
+            "description": "Exception list."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Policies"
+        ],
+        "summary": "Request a policy exception",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "policyId",
+                  "reason"
+                ],
+                "properties": {
+                  "policyId": {
+                    "type": "integer"
+                  },
+                  "reason": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Exception requested."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/policies/exceptions/{id}/approve": {
+      "post": {
+        "tags": [
+          "Policies"
+        ],
+        "summary": "Approve a policy exception request",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Exception approved."
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/policies/exceptions/{id}/cancel": {
+      "post": {
+        "tags": [
+          "Policies"
+        ],
+        "summary": "Cancel an own policy exception request",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Exception cancelled."
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/policies/exceptions/{id}/reject": {
+      "post": {
+        "tags": [
+          "Policies"
+        ],
+        "summary": "Reject a policy exception request",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Exception rejected."
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/policies/validate/assignment": {
+      "post": {
+        "tags": [
+          "Policies"
+        ],
+        "summary": "Validate assignment against policies",
+        "description": "Dry-runs policy checks without creating an assignment. Returns violations.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "userId",
+                  "shiftId"
+                ],
+                "properties": {
+                  "userId": {
+                    "type": "integer"
+                  },
+                  "shiftId": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Validation result with any violations."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/policies/{id}": {
+      "get": {
+        "tags": [
+          "Policies"
+        ],
+        "summary": "Get policy by ID",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Policy object."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Policies"
+        ],
+        "summary": "Update policy",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "label": {
+                    "type": "string"
+                  },
+                  "value": {},
+                  "isActive": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Policies"
+        ],
+        "summary": "Delete policy",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Deleted."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/preferences/me": {
+      "get": {
+        "tags": [
+          "Preferences"
+        ],
+        "summary": "Read own scheduling preferences",
+        "responses": {
+          "200": {
+            "description": "Preferences object."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Preferences"
+        ],
+        "summary": "Upsert own scheduling preferences",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "maxHoursPerWeek": {
+                    "type": "integer"
+                  },
+                  "minHoursPerWeek": {
+                    "type": "integer"
+                  },
+                  "maxConsecutiveDays": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 14
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/preferences/{userId}": {
+      "get": {
+        "tags": [
+          "Preferences"
+        ],
+        "summary": "Get a user's preferences",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Preferences"
+        ],
+        "summary": "Update a user's preferences",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Preferences updated."
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/reports/cost-by-department": {
+      "get": {
+        "tags": [
+          "Reports"
+        ],
+        "summary": "Labour cost by department",
+        "parameters": [
+          {
+            "name": "startDate",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "endDate",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Cost breakdown."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/reports/fairness/{scheduleId}": {
+      "get": {
+        "tags": [
+          "Reports"
+        ],
+        "summary": "Shift fairness report",
+        "description": "Measures how evenly shifts are distributed across employees in a schedule.",
+        "parameters": [
+          {
+            "name": "scheduleId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Fairness metrics."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/reports/hours-worked": {
+      "get": {
+        "tags": [
+          "Reports"
+        ],
+        "summary": "Hours worked report",
+        "parameters": [
+          {
+            "name": "startDate",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "endDate",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "departmentId",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Hours per employee."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/roles": {
+      "get": {
+        "tags": [
+          "RBAC"
+        ],
+        "summary": "List roles",
+        "responses": {
+          "200": {
+            "description": "Role list.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Role"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "RBAC"
+        ],
+        "summary": "Create role",
+        "description": "Requires admin.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "permissionKeys": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Role created."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/roles/users/{userId}": {
+      "post": {
+        "tags": [
+          "RBAC"
+        ],
+        "summary": "Grant a role to a user",
+        "description": "Requires `role.manage`.",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Role granted."
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/roles/users/{userId}/{roleId}": {
+      "delete": {
+        "tags": [
+          "RBAC"
+        ],
+        "summary": "Revoke a role from a user",
+        "description": "Requires `role.manage`.",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          },
+          {
+            "name": "roleId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Role revoked."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/roles/{id}": {
+      "get": {
+        "tags": [
+          "RBAC"
+        ],
+        "summary": "Get role by ID",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Role object."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "RBAC"
+        ],
+        "summary": "Update role",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "permissionKeys": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "RBAC"
+        ],
+        "summary": "Delete role",
+        "description": "Cannot delete built-in roles.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Deleted."
+          },
+          "400": {
+            "description": "Cannot delete a built-in role."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/schedules": {
+      "get": {
+        "tags": [
+          "Schedules"
+        ],
+        "summary": "List schedules",
+        "parameters": [
+          {
+            "name": "departmentId",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "draft",
+                "published",
+                "archived"
+              ]
+            }
+          },
+          {
+            "name": "startDate",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "endDate",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/pageQuery"
+          },
+          {
+            "$ref": "#/components/parameters/limitQuery"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Schedule list.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Schedule"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Schedules"
+        ],
+        "summary": "Create schedule",
+        "description": "Requires `schedule.manage`. Creates a draft schedule. A schedule cannot overlap with an existing draft or published schedule in the same department.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "name",
+                  "departmentId",
+                  "startDate",
+                  "endDate"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "departmentId": {
+                    "type": "integer"
+                  },
+                  "startDate": {
+                    "type": "string",
+                    "format": "date"
+                  },
+                  "endDate": {
+                    "type": "string",
+                    "format": "date"
+                  },
+                  "notes": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Schedule created."
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "409": {
+            "description": "Overlapping schedule exists for this department and date range."
+          }
+        }
+      }
+    },
+    "/schedules/department/{departmentId}": {
+      "get": {
+        "tags": [
+          "Schedules"
+        ],
+        "summary": "List schedules for a department",
+        "parameters": [
+          {
+            "name": "departmentId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/schedules/user/{userId}": {
+      "get": {
+        "tags": [
+          "Schedules"
+        ],
+        "summary": "List schedules involving a user",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/schedules/{id}": {
+      "get": {
+        "tags": [
+          "Schedules"
+        ],
+        "summary": "Get schedule by ID",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Schedule object."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Schedules"
+        ],
+        "summary": "Update schedule",
+        "description": "Updates name, dates, notes, or status. Requires `schedule.manage`. Archived schedules cannot be modified.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "startDate": {
+                    "type": "string",
+                    "format": "date"
+                  },
+                  "endDate": {
+                    "type": "string",
+                    "format": "date"
+                  },
+                  "notes": {
+                    "type": "string"
+                  },
+                  "status": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated."
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Schedules"
+        ],
+        "summary": "Delete schedule",
+        "description": "Only draft schedules can be deleted. Cascades to shifts and assignments. Requires `schedule.manage`.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Deleted."
+          },
+          "400": {
+            "description": "Schedule is not in draft status."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/schedules/{id}/archive": {
+      "patch": {
+        "tags": [
+          "Schedules"
+        ],
+        "summary": "Archive schedule",
+        "description": "Transitions status to `archived`. Requires `schedule.manage`.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Archived."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/schedules/{id}/duplicate": {
+      "post": {
+        "tags": [
+          "Schedules"
+        ],
+        "summary": "Duplicate schedule",
+        "description": "Clones the schedule and all its shifts to a new date range. Requires `schedule.manage`.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "name",
+                  "startDate",
+                  "endDate"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "startDate": {
+                    "type": "string",
+                    "format": "date"
+                  },
+                  "endDate": {
+                    "type": "string",
+                    "format": "date"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Cloned schedule."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/schedules/{id}/generate": {
+      "post": {
+        "tags": [
+          "Schedules"
+        ],
+        "summary": "Auto-generate assignments",
+        "description": "Runs the scheduling optimizer (OR-Tools if available, TypeScript fallback otherwise) and creates pending assignments for all open shifts. Requires `schedule.optimize`.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Generation result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "assignmentsCreated": {
+                      "type": "integer"
+                    },
+                    "totalShifts": {
+                      "type": "integer"
+                    },
+                    "coveragePercentage": {
+                      "type": "number"
+                    },
+                    "status": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/schedules/{id}/publish": {
+      "patch": {
+        "tags": [
+          "Schedules"
+        ],
+        "summary": "Publish schedule",
+        "description": "Transitions status from `draft` to `published`. The schedule must have at least one shift. Requires `schedule.publish`.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Published."
+          },
+          "400": {
+            "description": "No shifts or wrong status."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/schedules/{id}/shifts": {
+      "get": {
+        "tags": [
+          "Schedules"
+        ],
+        "summary": "List shifts in schedule",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Shift list with staffing counts."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/settings": {
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Get all system settings",
+        "responses": {
+          "200": {
+            "description": "Settings object."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/settings/category/{category}": {
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "List settings in a category",
+        "parameters": [
+          {
+            "name": "category",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/settings/currency": {
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Get currency setting",
+        "responses": {
+          "200": {
+            "description": "Currency code."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Update currency setting",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "currency"
+                ],
+                "properties": {
+                  "currency": {
+                    "type": "string",
+                    "pattern": "^[A-Z]{3}$"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/settings/time-period": {
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Get the time-period display setting",
+        "responses": {
+          "200": {
+            "description": "OK."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Update the time-period display setting",
+        "description": "Requires `settings.manage`.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "timePeriod"
+                ],
+                "properties": {
+                  "timePeriod": {
+                    "type": "string",
+                    "enum": [
+                      "daily",
+                      "weekly",
+                      "monthly",
+                      "yearly"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Setting updated."
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/settings/{category}/{key}": {
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Get a single setting value",
+        "parameters": [
+          {
+            "name": "category",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Update a single setting value",
+        "description": "Requires `settings.manage`.",
+        "parameters": [
+          {
+            "name": "category",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "value"
+                ],
+                "properties": {
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Setting updated."
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/settings/{category}/{key}/reset": {
+      "post": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Reset a setting to its default",
+        "description": "Requires `settings.manage`.",
+        "parameters": [
+          {
+            "name": "category",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Setting reset."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/shift-swap": {
+      "get": {
+        "tags": [
+          "Shift Swap"
+        ],
+        "summary": "List shift swap requests",
+        "responses": {
+          "200": {
+            "description": "Swap request list."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Shift Swap"
+        ],
+        "summary": "Create shift swap request",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "requesterAssignmentId",
+                  "targetAssignmentId"
+                ],
+                "properties": {
+                  "requesterAssignmentId": {
+                    "type": "integer"
+                  },
+                  "targetAssignmentId": {
+                    "type": "integer"
+                  },
+                  "notes": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Swap request created."
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/shift-swap/{id}": {
+      "get": {
+        "tags": [
+          "Shift Swap"
+        ],
+        "summary": "Get a shift swap request",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/shift-swap/{id}/approve": {
+      "post": {
+        "tags": [
+          "Shift Swap"
+        ],
+        "summary": "Approve a shift swap request",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Swap approved."
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/shift-swap/{id}/cancel": {
+      "post": {
+        "tags": [
+          "Shift Swap"
+        ],
+        "summary": "Cancel an own shift swap request",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Swap cancelled."
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/shift-swap/{id}/decline": {
+      "post": {
+        "tags": [
+          "Shift Swap"
+        ],
+        "summary": "Decline a shift swap request",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Swap declined."
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/shifts": {
+      "get": {
+        "tags": [
+          "Shifts"
+        ],
+        "summary": "List shifts",
+        "parameters": [
+          {
+            "name": "scheduleId",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "departmentId",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "date",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/pageQuery"
+          },
+          {
+            "$ref": "#/components/parameters/limitQuery"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Shift list.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Shift"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Shifts"
+        ],
+        "summary": "Create shift",
+        "description": "Requires `shift.manage`.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "scheduleId",
+                  "departmentId",
+                  "date",
+                  "startTime",
+                  "endTime"
+                ],
+                "properties": {
+                  "scheduleId": {
+                    "type": "integer"
+                  },
+                  "departmentId": {
+                    "type": "integer"
+                  },
+                  "date": {
+                    "type": "string",
+                    "format": "date"
+                  },
+                  "startTime": {
+                    "type": "string"
+                  },
+                  "endTime": {
+                    "type": "string"
+                  },
+                  "minStaff": {
+                    "type": "integer",
+                    "default": 1
+                  },
+                  "maxStaff": {
+                    "type": "integer",
+                    "default": 1
+                  },
+                  "notes": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Shift created."
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/shifts/department/{departmentId}": {
+      "get": {
+        "tags": [
+          "Shifts"
+        ],
+        "summary": "List shifts of a department",
+        "parameters": [
+          {
+            "name": "departmentId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/shifts/schedule/{scheduleId}": {
+      "get": {
+        "tags": [
+          "Shifts"
+        ],
+        "summary": "List shifts of a schedule",
+        "parameters": [
+          {
+            "name": "scheduleId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/shifts/templates": {
+      "get": {
+        "tags": [
+          "Shifts"
+        ],
+        "summary": "List shift templates",
+        "responses": {
+          "200": {
+            "description": "Template list."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Shifts"
+        ],
+        "summary": "Create shift template",
+        "description": "Requires `shift.manage`.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "name",
+                  "startTime",
+                  "endTime"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "startTime": {
+                    "type": "string"
+                  },
+                  "endTime": {
+                    "type": "string"
+                  },
+                  "minStaff": {
+                    "type": "integer"
+                  },
+                  "maxStaff": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Template created."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/shifts/templates/{id}": {
+      "get": {
+        "tags": [
+          "Shifts"
+        ],
+        "summary": "Get a shift template",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Shifts"
+        ],
+        "summary": "Update a shift template",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Template updated."
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Shifts"
+        ],
+        "summary": "Delete a shift template",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Template deleted."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/shifts/{id}": {
+      "get": {
+        "tags": [
+          "Shifts"
+        ],
+        "summary": "Get shift by ID",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Shift object."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Shifts"
+        ],
+        "summary": "Update shift",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "date": {
+                    "type": "string",
+                    "format": "date"
+                  },
+                  "startTime": {
+                    "type": "string"
+                  },
+                  "endTime": {
+                    "type": "string"
+                  },
+                  "minStaff": {
+                    "type": "integer"
+                  },
+                  "maxStaff": {
+                    "type": "integer"
+                  },
+                  "notes": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Shifts"
+        ],
+        "summary": "Delete shift",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Deleted."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/skill-gap": {
+      "get": {
+        "tags": [
+          "Skill Gap"
+        ],
+        "summary": "Skill gap analysis",
+        "parameters": [
+          {
+            "name": "departmentId",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "scheduleId",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Gaps between required and available skills."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/system/info": {
+      "get": {
+        "tags": [
+          "System"
+        ],
+        "summary": "Runtime metadata",
+        "description": "Returns mode (production | demo | development), version, and active modules. No authentication required.",
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Runtime info."
+          }
+        }
+      }
+    },
+    "/time-off": {
+      "get": {
+        "tags": [
+          "Time Off"
+        ],
+        "summary": "List time-off requests",
+        "description": "Employees see their own requests; managers see all requests in their departments.",
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "pending",
+                "approved",
+                "rejected",
+                "cancelled"
+              ]
+            }
+          },
+          {
+            "name": "userId",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/pageQuery"
+          },
+          {
+            "$ref": "#/components/parameters/limitQuery"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Time-off request list."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Time Off"
+        ],
+        "summary": "Create time-off request",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "startDate",
+                  "endDate"
+                ],
+                "properties": {
+                  "startDate": {
+                    "type": "string",
+                    "format": "date"
+                  },
+                  "endDate": {
+                    "type": "string",
+                    "format": "date"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "vacation",
+                      "sick",
+                      "personal",
+                      "other"
+                    ],
+                    "default": "other"
+                  },
+                  "reason": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Request created with status `pending`."
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/time-off/{id}": {
+      "get": {
+        "tags": [
+          "Time Off"
+        ],
+        "summary": "Get a time-off request",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/time-off/{id}/approve": {
+      "post": {
+        "tags": [
+          "Time Off"
+        ],
+        "summary": "Approve time-off request",
+        "description": "Manager action.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Approved."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/time-off/{id}/cancel": {
+      "post": {
+        "tags": [
+          "Time Off"
+        ],
+        "summary": "Cancel an own time-off request",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request cancelled."
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/time-off/{id}/reject": {
+      "post": {
+        "tags": [
+          "Time Off"
+        ],
+        "summary": "Reject time-off request",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "reason": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Rejected."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
           }
         }
       }
@@ -1356,3867 +7054,6 @@
           },
           "404": {
             "$ref": "#/components/responses/NotFound"
-          }
-        }
-      }
-    },
-    "/employees": {
-      "get": {
-        "tags": [
-          "Employees"
-        ],
-        "summary": "List employees",
-        "parameters": [
-          {
-            "name": "departmentId",
-            "in": "query",
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "name": "isActive",
-            "in": "query",
-            "schema": {
-              "type": "boolean"
-            }
-          },
-          {
-            "$ref": "#/components/parameters/pageQuery"
-          },
-          {
-            "$ref": "#/components/parameters/limitQuery"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Employee list.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "success": {
-                      "type": "boolean"
-                    },
-                    "data": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/Employee"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "Employees"
-        ],
-        "summary": "Create employee profile",
-        "description": "Creates the employee record for an existing user. Requires `employee.manage`.",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "userId"
-                ],
-                "properties": {
-                  "userId": {
-                    "type": "integer"
-                  },
-                  "employeeNumber": {
-                    "type": "string"
-                  },
-                  "position": {
-                    "type": "string"
-                  },
-                  "departmentId": {
-                    "type": "integer"
-                  },
-                  "hourlyRate": {
-                    "type": "number",
-                    "minimum": 0
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Employee created."
-          },
-          "400": {
-            "$ref": "#/components/responses/ValidationError"
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          }
-        }
-      }
-    },
-    "/employees/{id}": {
-      "get": {
-        "tags": [
-          "Employees"
-        ],
-        "summary": "Get employee by ID",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/id"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Employee object."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "404": {
-            "$ref": "#/components/responses/NotFound"
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "Employees"
-        ],
-        "summary": "Update employee",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/id"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "position": {
-                    "type": "string"
-                  },
-                  "hourlyRate": {
-                    "type": "number"
-                  },
-                  "isActive": {
-                    "type": "boolean"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Updated."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/components/responses/NotFound"
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "Employees"
-        ],
-        "summary": "Delete employee profile",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/id"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Deleted."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/components/responses/NotFound"
-          }
-        }
-      }
-    },
-    "/employees/{id}/skills": {
-      "get": {
-        "tags": [
-          "Employees"
-        ],
-        "summary": "List employee skills",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/id"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Skill list."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "404": {
-            "$ref": "#/components/responses/NotFound"
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "Employees"
-        ],
-        "summary": "Add skill to employee",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/id"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "skillId"
-                ],
-                "properties": {
-                  "skillId": {
-                    "type": "integer"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Skill added."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          }
-        }
-      }
-    },
-    "/departments": {
-      "get": {
-        "tags": [
-          "Departments"
-        ],
-        "summary": "List departments",
-        "parameters": [
-          {
-            "name": "isActive",
-            "in": "query",
-            "schema": {
-              "type": "boolean"
-            }
-          },
-          {
-            "name": "orgUnitId",
-            "in": "query",
-            "schema": {
-              "type": "integer"
-            },
-            "description": "Filter by parent org unit."
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Department list.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "success": {
-                      "type": "boolean"
-                    },
-                    "data": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/Department"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "Departments"
-        ],
-        "summary": "Create department",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "name"
-                ],
-                "properties": {
-                  "name": {
-                    "type": "string"
-                  },
-                  "description": {
-                    "type": "string"
-                  },
-                  "orgUnitId": {
-                    "type": "integer"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Department created."
-          },
-          "400": {
-            "$ref": "#/components/responses/ValidationError"
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          }
-        }
-      }
-    },
-    "/departments/{id}": {
-      "get": {
-        "tags": [
-          "Departments"
-        ],
-        "summary": "Get department by ID",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/id"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Department object."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "404": {
-            "$ref": "#/components/responses/NotFound"
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "Departments"
-        ],
-        "summary": "Update department",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/id"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string"
-                  },
-                  "description": {
-                    "type": "string"
-                  },
-                  "isActive": {
-                    "type": "boolean"
-                  },
-                  "orgUnitId": {
-                    "type": "integer"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Updated."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/components/responses/NotFound"
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "Departments"
-        ],
-        "summary": "Delete department",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/id"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Deleted."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/components/responses/NotFound"
-          }
-        }
-      }
-    },
-    "/departments/{id}/users": {
-      "post": {
-        "tags": [
-          "Departments"
-        ],
-        "summary": "Add user to department",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/id"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "userId"
-                ],
-                "properties": {
-                  "userId": {
-                    "type": "integer"
-                  },
-                  "role": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "User added."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          }
-        }
-      }
-    },
-    "/departments/{id}/users/{userId}": {
-      "delete": {
-        "tags": [
-          "Departments"
-        ],
-        "summary": "Remove user from department",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/id"
-          },
-          {
-            "name": "userId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "User removed."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          }
-        }
-      }
-    },
-    "/departments/{id}/stats": {
-      "get": {
-        "tags": [
-          "Departments"
-        ],
-        "summary": "Department statistics",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/id"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Staffing stats."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "404": {
-            "$ref": "#/components/responses/NotFound"
-          }
-        }
-      }
-    },
-    "/schedules": {
-      "get": {
-        "tags": [
-          "Schedules"
-        ],
-        "summary": "List schedules",
-        "parameters": [
-          {
-            "name": "departmentId",
-            "in": "query",
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "name": "status",
-            "in": "query",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "draft",
-                "published",
-                "archived"
-              ]
-            }
-          },
-          {
-            "name": "startDate",
-            "in": "query",
-            "schema": {
-              "type": "string",
-              "format": "date"
-            }
-          },
-          {
-            "name": "endDate",
-            "in": "query",
-            "schema": {
-              "type": "string",
-              "format": "date"
-            }
-          },
-          {
-            "$ref": "#/components/parameters/pageQuery"
-          },
-          {
-            "$ref": "#/components/parameters/limitQuery"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Schedule list.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "success": {
-                      "type": "boolean"
-                    },
-                    "data": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/Schedule"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "Schedules"
-        ],
-        "summary": "Create schedule",
-        "description": "Requires `schedule.manage`. Creates a draft schedule. A schedule cannot overlap with an existing draft or published schedule in the same department.",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "name",
-                  "departmentId",
-                  "startDate",
-                  "endDate"
-                ],
-                "properties": {
-                  "name": {
-                    "type": "string"
-                  },
-                  "departmentId": {
-                    "type": "integer"
-                  },
-                  "startDate": {
-                    "type": "string",
-                    "format": "date"
-                  },
-                  "endDate": {
-                    "type": "string",
-                    "format": "date"
-                  },
-                  "notes": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Schedule created."
-          },
-          "400": {
-            "$ref": "#/components/responses/ValidationError"
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          },
-          "409": {
-            "description": "Overlapping schedule exists for this department and date range."
-          }
-        }
-      }
-    },
-    "/schedules/{id}": {
-      "get": {
-        "tags": [
-          "Schedules"
-        ],
-        "summary": "Get schedule by ID",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/id"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Schedule object."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "404": {
-            "$ref": "#/components/responses/NotFound"
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "Schedules"
-        ],
-        "summary": "Update schedule",
-        "description": "Updates name, dates, notes, or status. Requires `schedule.manage`. Archived schedules cannot be modified.",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/id"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string"
-                  },
-                  "startDate": {
-                    "type": "string",
-                    "format": "date"
-                  },
-                  "endDate": {
-                    "type": "string",
-                    "format": "date"
-                  },
-                  "notes": {
-                    "type": "string"
-                  },
-                  "status": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Updated."
-          },
-          "400": {
-            "$ref": "#/components/responses/ValidationError"
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/components/responses/NotFound"
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "Schedules"
-        ],
-        "summary": "Delete schedule",
-        "description": "Only draft schedules can be deleted. Cascades to shifts and assignments. Requires `schedule.manage`.",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/id"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Deleted."
-          },
-          "400": {
-            "description": "Schedule is not in draft status."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/components/responses/NotFound"
-          }
-        }
-      }
-    },
-    "/schedules/{id}/shifts": {
-      "get": {
-        "tags": [
-          "Schedules"
-        ],
-        "summary": "List shifts in schedule",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/id"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Shift list with staffing counts."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "404": {
-            "$ref": "#/components/responses/NotFound"
-          }
-        }
-      }
-    },
-    "/schedules/{id}/publish": {
-      "patch": {
-        "tags": [
-          "Schedules"
-        ],
-        "summary": "Publish schedule",
-        "description": "Transitions status from `draft` to `published`. The schedule must have at least one shift. Requires `schedule.publish`.",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/id"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Published."
-          },
-          "400": {
-            "description": "No shifts or wrong status."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/components/responses/NotFound"
-          }
-        }
-      }
-    },
-    "/schedules/{id}/archive": {
-      "patch": {
-        "tags": [
-          "Schedules"
-        ],
-        "summary": "Archive schedule",
-        "description": "Transitions status to `archived`. Requires `schedule.manage`.",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/id"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Archived."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/components/responses/NotFound"
-          }
-        }
-      }
-    },
-    "/schedules/{id}/duplicate": {
-      "post": {
-        "tags": [
-          "Schedules"
-        ],
-        "summary": "Duplicate schedule",
-        "description": "Clones the schedule and all its shifts to a new date range. Requires `schedule.manage`.",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/id"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "name",
-                  "startDate",
-                  "endDate"
-                ],
-                "properties": {
-                  "name": {
-                    "type": "string"
-                  },
-                  "startDate": {
-                    "type": "string",
-                    "format": "date"
-                  },
-                  "endDate": {
-                    "type": "string",
-                    "format": "date"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Cloned schedule."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/components/responses/NotFound"
-          }
-        }
-      }
-    },
-    "/schedules/{id}/generate": {
-      "post": {
-        "tags": [
-          "Schedules"
-        ],
-        "summary": "Auto-generate assignments",
-        "description": "Runs the scheduling optimizer (OR-Tools if available, TypeScript fallback otherwise) and creates pending assignments for all open shifts. Requires `schedule.optimize`.",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/id"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Generation result.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "assignmentsCreated": {
-                      "type": "integer"
-                    },
-                    "totalShifts": {
-                      "type": "integer"
-                    },
-                    "coveragePercentage": {
-                      "type": "number"
-                    },
-                    "status": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/components/responses/NotFound"
-          }
-        }
-      }
-    },
-    "/shifts/templates": {
-      "get": {
-        "tags": [
-          "Shifts"
-        ],
-        "summary": "List shift templates",
-        "responses": {
-          "200": {
-            "description": "Template list."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "Shifts"
-        ],
-        "summary": "Create shift template",
-        "description": "Requires `shift.manage`.",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "name",
-                  "startTime",
-                  "endTime"
-                ],
-                "properties": {
-                  "name": {
-                    "type": "string"
-                  },
-                  "startTime": {
-                    "type": "string"
-                  },
-                  "endTime": {
-                    "type": "string"
-                  },
-                  "minStaff": {
-                    "type": "integer"
-                  },
-                  "maxStaff": {
-                    "type": "integer"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Template created."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          }
-        }
-      }
-    },
-    "/shifts": {
-      "get": {
-        "tags": [
-          "Shifts"
-        ],
-        "summary": "List shifts",
-        "parameters": [
-          {
-            "name": "scheduleId",
-            "in": "query",
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "name": "departmentId",
-            "in": "query",
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "name": "date",
-            "in": "query",
-            "schema": {
-              "type": "string",
-              "format": "date"
-            }
-          },
-          {
-            "$ref": "#/components/parameters/pageQuery"
-          },
-          {
-            "$ref": "#/components/parameters/limitQuery"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Shift list.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "success": {
-                      "type": "boolean"
-                    },
-                    "data": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/Shift"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "Shifts"
-        ],
-        "summary": "Create shift",
-        "description": "Requires `shift.manage`.",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "scheduleId",
-                  "departmentId",
-                  "date",
-                  "startTime",
-                  "endTime"
-                ],
-                "properties": {
-                  "scheduleId": {
-                    "type": "integer"
-                  },
-                  "departmentId": {
-                    "type": "integer"
-                  },
-                  "date": {
-                    "type": "string",
-                    "format": "date"
-                  },
-                  "startTime": {
-                    "type": "string"
-                  },
-                  "endTime": {
-                    "type": "string"
-                  },
-                  "minStaff": {
-                    "type": "integer",
-                    "default": 1
-                  },
-                  "maxStaff": {
-                    "type": "integer",
-                    "default": 1
-                  },
-                  "notes": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Shift created."
-          },
-          "400": {
-            "$ref": "#/components/responses/ValidationError"
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          }
-        }
-      }
-    },
-    "/shifts/{id}": {
-      "get": {
-        "tags": [
-          "Shifts"
-        ],
-        "summary": "Get shift by ID",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/id"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Shift object."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "404": {
-            "$ref": "#/components/responses/NotFound"
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "Shifts"
-        ],
-        "summary": "Update shift",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/id"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "date": {
-                    "type": "string",
-                    "format": "date"
-                  },
-                  "startTime": {
-                    "type": "string"
-                  },
-                  "endTime": {
-                    "type": "string"
-                  },
-                  "minStaff": {
-                    "type": "integer"
-                  },
-                  "maxStaff": {
-                    "type": "integer"
-                  },
-                  "notes": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Updated."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/components/responses/NotFound"
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "Shifts"
-        ],
-        "summary": "Delete shift",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/id"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Deleted."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/components/responses/NotFound"
-          }
-        }
-      }
-    },
-    "/assignments": {
-      "get": {
-        "tags": [
-          "Assignments"
-        ],
-        "summary": "List assignments",
-        "parameters": [
-          {
-            "name": "shiftId",
-            "in": "query",
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "name": "userId",
-            "in": "query",
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "name": "scheduleId",
-            "in": "query",
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "name": "departmentId",
-            "in": "query",
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "name": "status",
-            "in": "query",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "pending",
-                "confirmed",
-                "cancelled",
-                "completed"
-              ]
-            }
-          },
-          {
-            "name": "startDate",
-            "in": "query",
-            "schema": {
-              "type": "string",
-              "format": "date"
-            }
-          },
-          {
-            "name": "endDate",
-            "in": "query",
-            "schema": {
-              "type": "string",
-              "format": "date"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Assignment list.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "success": {
-                      "type": "boolean"
-                    },
-                    "data": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/Assignment"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "Assignments"
-        ],
-        "summary": "Create assignment",
-        "description": "Assigns an employee to a shift. Validates: capacity, conflicts, availability, skills, compliance limits, and active policies. Requires `assignment.manage`.",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "shiftId",
-                  "userId"
-                ],
-                "properties": {
-                  "shiftId": {
-                    "type": "integer"
-                  },
-                  "userId": {
-                    "type": "integer"
-                  },
-                  "notes": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Assignment created with status `pending`.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "success": {
-                      "type": "boolean"
-                    },
-                    "data": {
-                      "$ref": "#/components/schemas/Assignment"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Capacity exceeded, conflict, unavailability, or missing skills."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          },
-          "409": {
-            "description": "Compliance or policy violation."
-          }
-        }
-      }
-    },
-    "/assignments/{id}": {
-      "get": {
-        "tags": [
-          "Assignments"
-        ],
-        "summary": "Get assignment by ID",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/id"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Assignment object."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "404": {
-            "$ref": "#/components/responses/NotFound"
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "Assignments"
-        ],
-        "summary": "Update assignment status or notes",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/id"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "status": {
-                    "type": "string"
-                  },
-                  "notes": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Updated."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/components/responses/NotFound"
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "Assignments"
-        ],
-        "summary": "Delete assignment",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/id"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Deleted."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/components/responses/NotFound"
-          }
-        }
-      }
-    },
-    "/assignments/{id}/confirm": {
-      "patch": {
-        "tags": [
-          "Assignments"
-        ],
-        "summary": "Confirm assignment",
-        "description": "Transitions from `pending` to `confirmed`.",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/id"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Confirmed."
-          },
-          "400": {
-            "description": "Not in pending status."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "404": {
-            "$ref": "#/components/responses/NotFound"
-          }
-        }
-      }
-    },
-    "/assignments/{id}/decline": {
-      "patch": {
-        "tags": [
-          "Assignments"
-        ],
-        "summary": "Decline assignment",
-        "description": "Transitions from `pending` or `confirmed` to `cancelled`.",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/id"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Cancelled."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "404": {
-            "$ref": "#/components/responses/NotFound"
-          }
-        }
-      }
-    },
-    "/assignments/{id}/complete": {
-      "patch": {
-        "tags": [
-          "Assignments"
-        ],
-        "summary": "Complete assignment",
-        "description": "Transitions from `confirmed` to `completed`.",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/id"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Completed."
-          },
-          "400": {
-            "description": "Assignment is not confirmed."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "404": {
-            "$ref": "#/components/responses/NotFound"
-          }
-        }
-      }
-    },
-    "/assignments/bulk": {
-      "post": {
-        "tags": [
-          "Assignments"
-        ],
-        "summary": "Bulk create assignments",
-        "description": "Creates multiple assignments in one request. Failures are logged and skipped; the response contains only successfully created assignments. Requires `assignment.manage`.",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "shiftId",
-                  "userIds"
-                ],
-                "properties": {
-                  "shiftId": {
-                    "type": "integer"
-                  },
-                  "userIds": {
-                    "type": "array",
-                    "items": {
-                      "type": "integer"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Created assignments."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          }
-        }
-      }
-    },
-    "/assignments/shift/{shiftId}/available-employees": {
-      "get": {
-        "tags": [
-          "Assignments"
-        ],
-        "summary": "Available employees for shift",
-        "description": "Returns users in the shift's department who have no conflicting assignment.",
-        "parameters": [
-          {
-            "name": "shiftId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "List of available employees."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "404": {
-            "$ref": "#/components/responses/NotFound"
-          }
-        }
-      }
-    },
-    "/time-off": {
-      "get": {
-        "tags": [
-          "Time Off"
-        ],
-        "summary": "List time-off requests",
-        "description": "Employees see their own requests; managers see all requests in their departments.",
-        "parameters": [
-          {
-            "name": "status",
-            "in": "query",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "pending",
-                "approved",
-                "rejected",
-                "cancelled"
-              ]
-            }
-          },
-          {
-            "name": "userId",
-            "in": "query",
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "$ref": "#/components/parameters/pageQuery"
-          },
-          {
-            "$ref": "#/components/parameters/limitQuery"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Time-off request list."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "Time Off"
-        ],
-        "summary": "Create time-off request",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "startDate",
-                  "endDate"
-                ],
-                "properties": {
-                  "startDate": {
-                    "type": "string",
-                    "format": "date"
-                  },
-                  "endDate": {
-                    "type": "string",
-                    "format": "date"
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "vacation",
-                      "sick",
-                      "personal",
-                      "other"
-                    ],
-                    "default": "other"
-                  },
-                  "reason": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Request created with status `pending`."
-          },
-          "400": {
-            "$ref": "#/components/responses/ValidationError"
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          }
-        }
-      }
-    },
-    "/time-off/{id}/approve": {
-      "post": {
-        "tags": [
-          "Time Off"
-        ],
-        "summary": "Approve time-off request",
-        "description": "Manager action.",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/id"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Approved."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/components/responses/NotFound"
-          }
-        }
-      }
-    },
-    "/time-off/{id}/reject": {
-      "post": {
-        "tags": [
-          "Time Off"
-        ],
-        "summary": "Reject time-off request",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/id"
-          }
-        ],
-        "requestBody": {
-          "required": false,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "reason": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Rejected."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          }
-        }
-      }
-    },
-    "/shift-swap": {
-      "get": {
-        "tags": [
-          "Shift Swap"
-        ],
-        "summary": "List shift swap requests",
-        "responses": {
-          "200": {
-            "description": "Swap request list."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "Shift Swap"
-        ],
-        "summary": "Create shift swap request",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "requesterAssignmentId",
-                  "targetAssignmentId"
-                ],
-                "properties": {
-                  "requesterAssignmentId": {
-                    "type": "integer"
-                  },
-                  "targetAssignmentId": {
-                    "type": "integer"
-                  },
-                  "notes": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Swap request created."
-          },
-          "400": {
-            "$ref": "#/components/responses/ValidationError"
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          }
-        }
-      }
-    },
-    "/on-call/periods": {
-      "get": {
-        "tags": [
-          "On Call"
-        ],
-        "summary": "List on-call periods",
-        "parameters": [
-          {
-            "name": "departmentId",
-            "in": "query",
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "name": "status",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "start",
-            "in": "query",
-            "schema": {
-              "type": "string",
-              "format": "date"
-            }
-          },
-          {
-            "name": "end",
-            "in": "query",
-            "schema": {
-              "type": "string",
-              "format": "date"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "On-call period list."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "On Call"
-        ],
-        "summary": "Create on-call period",
-        "description": "Requires manager role.",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "departmentId",
-                  "date",
-                  "startTime",
-                  "endTime"
-                ],
-                "properties": {
-                  "departmentId": {
-                    "type": "integer"
-                  },
-                  "scheduleId": {
-                    "type": "integer"
-                  },
-                  "date": {
-                    "type": "string",
-                    "format": "date"
-                  },
-                  "startTime": {
-                    "type": "string"
-                  },
-                  "endTime": {
-                    "type": "string"
-                  },
-                  "minStaff": {
-                    "type": "integer",
-                    "minimum": 1
-                  },
-                  "maxStaff": {
-                    "type": "integer",
-                    "minimum": 1
-                  },
-                  "notes": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Created."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          }
-        }
-      }
-    },
-    "/on-call/periods/{id}/assign": {
-      "post": {
-        "tags": [
-          "On Call"
-        ],
-        "summary": "Assign user to on-call period",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/id"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "userId"
-                ],
-                "properties": {
-                  "userId": {
-                    "type": "integer"
-                  },
-                  "notes": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Assigned."
-          },
-          "404": {
-            "$ref": "#/components/responses/NotFound"
-          },
-          "409": {
-            "description": "Period at max capacity."
-          }
-        }
-      }
-    },
-    "/on-call/me": {
-      "get": {
-        "tags": [
-          "On Call"
-        ],
-        "summary": "Caller's on-call schedule",
-        "parameters": [
-          {
-            "name": "start",
-            "in": "query",
-            "schema": {
-              "type": "string",
-              "format": "date"
-            }
-          },
-          {
-            "name": "end",
-            "in": "query",
-            "schema": {
-              "type": "string",
-              "format": "date"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "On-call periods for the caller."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          }
-        }
-      }
-    },
-    "/calendar/token": {
-      "post": {
-        "tags": [
-          "Calendar"
-        ],
-        "summary": "Get or create calendar feed token",
-        "description": "Returns a stable token used to authenticate the iCalendar feed URL.",
-        "responses": {
-          "200": {
-            "description": "Token."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          }
-        }
-      }
-    },
-    "/calendar/feed.ics": {
-      "get": {
-        "tags": [
-          "Calendar"
-        ],
-        "summary": "Personal iCalendar feed",
-        "description": "Returns an iCal feed for the user identified by `token`. No JWT required \u2014 pass the token as a query parameter. Emits ETag for conditional requests. Lists colleagues working the same shift in DESCRIPTION.",
-        "security": [],
-        "parameters": [
-          {
-            "name": "token",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "If-None-Match",
-            "in": "header",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "iCalendar text.",
-            "content": {
-              "text/calendar": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "304": {
-            "description": "Not modified (ETag match)."
-          },
-          "401": {
-            "description": "Missing or invalid token."
-          }
-        }
-      }
-    },
-    "/calendar/department/{id}.ics": {
-      "get": {
-        "tags": [
-          "Calendar"
-        ],
-        "summary": "Department iCalendar feed",
-        "description": "Aggregated iCal for an entire department. Manager/admin only. Pass the manager's calendar token.",
-        "security": [],
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "name": "token",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "If-None-Match",
-            "in": "header",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "iCalendar text.",
-            "content": {
-              "text/calendar": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "304": {
-            "description": "Not modified."
-          },
-          "401": {
-            "description": "Missing or invalid token."
-          },
-          "403": {
-            "description": "Caller is not a manager of this department."
-          }
-        }
-      }
-    },
-    "/directory/me": {
-      "get": {
-        "tags": [
-          "Directory"
-        ],
-        "summary": "Own directory profile",
-        "description": "Returns the caller's profile plus any custom fields.",
-        "responses": {
-          "200": {
-            "description": "Profile."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          }
-        }
-      }
-    },
-    "/directory/users/{id}": {
-      "get": {
-        "tags": [
-          "Directory"
-        ],
-        "summary": "User directory profile",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/id"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Profile."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/components/responses/NotFound"
-          }
-        }
-      }
-    },
-    "/directory/users/{id}/fields": {
-      "put": {
-        "tags": [
-          "Directory"
-        ],
-        "summary": "Bulk upsert custom fields",
-        "description": "Replaces all custom fields for a user. Manager only.",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/id"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "fields"
-                ],
-                "properties": {
-                  "fields": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "required": [
-                        "key",
-                        "value"
-                      ],
-                      "properties": {
-                        "key": {
-                          "type": "string",
-                          "pattern": "^[A-Za-z0-9_-]{1,64}$"
-                        },
-                        "value": {
-                          "type": "string"
-                        },
-                        "isPublic": {
-                          "type": "boolean"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Updated profile."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          }
-        }
-      }
-    },
-    "/directory/users/{id}/vcard": {
-      "get": {
-        "tags": [
-          "Directory"
-        ],
-        "summary": "Single-user vCard 4.0",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/id"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "vCard.",
-            "content": {
-              "text/vcard": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "404": {
-            "$ref": "#/components/responses/NotFound"
-          }
-        }
-      }
-    },
-    "/directory/vcard.vcf": {
-      "get": {
-        "tags": [
-          "Directory"
-        ],
-        "summary": "Multi-user vCard archive",
-        "parameters": [
-          {
-            "name": "ids",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "Comma-separated user IDs."
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "vCard archive.",
-            "content": {
-              "text/vcard": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          }
-        }
-      }
-    },
-    "/directory/import-vcard": {
-      "post": {
-        "tags": [
-          "Directory"
-        ],
-        "summary": "Bulk import from vCard",
-        "description": "Admin only. Existing emails are skipped.",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "vcf": {
-                    "type": "string",
-                    "description": "Raw .vcf text."
-                  },
-                  "defaultPassword": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Inserted and skipped counts."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          }
-        }
-      }
-    },
-    "/preferences/me": {
-      "get": {
-        "tags": [
-          "Preferences"
-        ],
-        "summary": "Read own scheduling preferences",
-        "responses": {
-          "200": {
-            "description": "Preferences object."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "Preferences"
-        ],
-        "summary": "Upsert own scheduling preferences",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "maxHoursPerWeek": {
-                    "type": "integer"
-                  },
-                  "minHoursPerWeek": {
-                    "type": "integer"
-                  },
-                  "maxConsecutiveDays": {
-                    "type": "integer",
-                    "minimum": 1,
-                    "maximum": 14
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Updated."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          }
-        }
-      }
-    },
-    "/dashboard/stats": {
-      "get": {
-        "tags": [
-          "Dashboard"
-        ],
-        "summary": "Aggregated dashboard statistics",
-        "responses": {
-          "200": {
-            "description": "Stats (total staff, shifts today, coverage, etc.)."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          }
-        }
-      }
-    },
-    "/dashboard/activities": {
-      "get": {
-        "tags": [
-          "Dashboard"
-        ],
-        "summary": "Recent activity feed",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/limitQuery"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Activity list."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          }
-        }
-      }
-    },
-    "/dashboard/upcoming-shifts": {
-      "get": {
-        "tags": [
-          "Dashboard"
-        ],
-        "summary": "Caller's upcoming shifts",
-        "responses": {
-          "200": {
-            "description": "Shifts list."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          }
-        }
-      }
-    },
-    "/reports/hours-worked": {
-      "get": {
-        "tags": [
-          "Reports"
-        ],
-        "summary": "Hours worked report",
-        "parameters": [
-          {
-            "name": "startDate",
-            "in": "query",
-            "schema": {
-              "type": "string",
-              "format": "date"
-            }
-          },
-          {
-            "name": "endDate",
-            "in": "query",
-            "schema": {
-              "type": "string",
-              "format": "date"
-            }
-          },
-          {
-            "name": "departmentId",
-            "in": "query",
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Hours per employee."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          }
-        }
-      }
-    },
-    "/reports/cost-by-department": {
-      "get": {
-        "tags": [
-          "Reports"
-        ],
-        "summary": "Labour cost by department",
-        "parameters": [
-          {
-            "name": "startDate",
-            "in": "query",
-            "schema": {
-              "type": "string",
-              "format": "date"
-            }
-          },
-          {
-            "name": "endDate",
-            "in": "query",
-            "schema": {
-              "type": "string",
-              "format": "date"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Cost breakdown."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          }
-        }
-      }
-    },
-    "/reports/fairness/{scheduleId}": {
-      "get": {
-        "tags": [
-          "Reports"
-        ],
-        "summary": "Shift fairness report",
-        "description": "Measures how evenly shifts are distributed across employees in a schedule.",
-        "parameters": [
-          {
-            "name": "scheduleId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Fairness metrics."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          }
-        }
-      }
-    },
-    "/audit-logs": {
-      "get": {
-        "tags": [
-          "Audit Logs"
-        ],
-        "summary": "List audit log entries",
-        "description": "Manager or admin only. Immutable log of all sensitive actions.",
-        "parameters": [
-          {
-            "name": "userId",
-            "in": "query",
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "name": "action",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "entityType",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "startDate",
-            "in": "query",
-            "schema": {
-              "type": "string",
-              "format": "date"
-            }
-          },
-          {
-            "name": "endDate",
-            "in": "query",
-            "schema": {
-              "type": "string",
-              "format": "date"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "schema": {
-              "type": "integer",
-              "maximum": 500,
-              "default": 50
-            }
-          },
-          {
-            "name": "offset",
-            "in": "query",
-            "schema": {
-              "type": "integer",
-              "default": 0
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Audit entries.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "success": {
-                      "type": "boolean"
-                    },
-                    "data": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/AuditLogEntry"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          }
-        }
-      }
-    },
-    "/roles": {
-      "get": {
-        "tags": [
-          "RBAC"
-        ],
-        "summary": "List roles",
-        "responses": {
-          "200": {
-            "description": "Role list.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "success": {
-                      "type": "boolean"
-                    },
-                    "data": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/Role"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "RBAC"
-        ],
-        "summary": "Create role",
-        "description": "Requires admin.",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "name"
-                ],
-                "properties": {
-                  "name": {
-                    "type": "string"
-                  },
-                  "description": {
-                    "type": "string"
-                  },
-                  "permissionKeys": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Role created."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          }
-        }
-      }
-    },
-    "/roles/{id}": {
-      "get": {
-        "tags": [
-          "RBAC"
-        ],
-        "summary": "Get role by ID",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/id"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Role object."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "RBAC"
-        ],
-        "summary": "Update role",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/id"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string"
-                  },
-                  "description": {
-                    "type": "string"
-                  },
-                  "permissionKeys": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Updated."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "RBAC"
-        ],
-        "summary": "Delete role",
-        "description": "Cannot delete built-in roles.",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/id"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Deleted."
-          },
-          "400": {
-            "description": "Cannot delete a built-in role."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          }
-        }
-      }
-    },
-    "/permissions": {
-      "get": {
-        "tags": [
-          "RBAC"
-        ],
-        "summary": "List all permission keys",
-        "responses": {
-          "200": {
-            "description": "Permission list.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "success": {
-                      "type": "boolean"
-                    },
-                    "data": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/Permission"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          }
-        }
-      }
-    },
-    "/policies": {
-      "get": {
-        "tags": [
-          "Policies"
-        ],
-        "summary": "List scheduling policies",
-        "responses": {
-          "200": {
-            "description": "Policy list.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "success": {
-                      "type": "boolean"
-                    },
-                    "data": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/Policy"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "Policies"
-        ],
-        "summary": "Create policy",
-        "description": "Requires `policy.manage`.",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "key",
-                  "label",
-                  "value",
-                  "valueType"
-                ],
-                "properties": {
-                  "key": {
-                    "type": "string"
-                  },
-                  "label": {
-                    "type": "string"
-                  },
-                  "description": {
-                    "type": "string"
-                  },
-                  "value": {},
-                  "valueType": {
-                    "type": "string",
-                    "enum": [
-                      "integer",
-                      "float",
-                      "boolean",
-                      "string"
-                    ]
-                  },
-                  "category": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Policy created."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          }
-        }
-      }
-    },
-    "/policies/{id}": {
-      "get": {
-        "tags": [
-          "Policies"
-        ],
-        "summary": "Get policy by ID",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/id"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Policy object."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "Policies"
-        ],
-        "summary": "Update policy",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/id"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "label": {
-                    "type": "string"
-                  },
-                  "value": {},
-                  "isActive": {
-                    "type": "boolean"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Updated."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "Policies"
-        ],
-        "summary": "Delete policy",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/id"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Deleted."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          }
-        }
-      }
-    },
-    "/policies/validate/assignment": {
-      "post": {
-        "tags": [
-          "Policies"
-        ],
-        "summary": "Validate assignment against policies",
-        "description": "Dry-runs policy checks without creating an assignment. Returns violations.",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "userId",
-                  "shiftId"
-                ],
-                "properties": {
-                  "userId": {
-                    "type": "integer"
-                  },
-                  "shiftId": {
-                    "type": "integer"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Validation result with any violations."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          }
-        }
-      }
-    },
-    "/policies/exceptions": {
-      "get": {
-        "tags": [
-          "Policies"
-        ],
-        "summary": "List policy exceptions",
-        "responses": {
-          "200": {
-            "description": "Exception list."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "Policies"
-        ],
-        "summary": "Request a policy exception",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "policyId",
-                  "reason"
-                ],
-                "properties": {
-                  "policyId": {
-                    "type": "integer"
-                  },
-                  "reason": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Exception requested."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          }
-        }
-      }
-    },
-    "/org/units": {
-      "get": {
-        "tags": [
-          "Org Units"
-        ],
-        "summary": "List org units (flat)",
-        "responses": {
-          "200": {
-            "description": "Flat list of org units."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "Org Units"
-        ],
-        "summary": "Create org unit",
-        "description": "Requires `org_unit.manage`.",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "name"
-                ],
-                "properties": {
-                  "name": {
-                    "type": "string"
-                  },
-                  "parentId": {
-                    "type": "integer",
-                    "description": "Null for root units."
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Created."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          }
-        }
-      }
-    },
-    "/org/units/tree": {
-      "get": {
-        "tags": [
-          "Org Units"
-        ],
-        "summary": "Org unit tree",
-        "description": "Returns the full hierarchy as a nested tree structure.",
-        "responses": {
-          "200": {
-            "description": "Tree."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          }
-        }
-      }
-    },
-    "/org/units/{id}": {
-      "get": {
-        "tags": [
-          "Org Units"
-        ],
-        "summary": "Get org unit by ID",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/id"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Org unit.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OrgUnit"
-                }
-              }
-            }
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "404": {
-            "$ref": "#/components/responses/NotFound"
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "Org Units"
-        ],
-        "summary": "Update org unit",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/id"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string"
-                  },
-                  "parentId": {
-                    "type": "integer"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Updated."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "Org Units"
-        ],
-        "summary": "Delete org unit",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/id"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Deleted."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          }
-        }
-      }
-    },
-    "/org/loans": {
-      "get": {
-        "tags": [
-          "Org Units"
-        ],
-        "summary": "List employee loans",
-        "description": "Employee loans temporarily move a user to a different org unit.",
-        "responses": {
-          "200": {
-            "description": "Loan list."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "Org Units"
-        ],
-        "summary": "Request employee loan",
-        "description": "Requires `loan.request`.",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "userId",
-                  "targetOrgUnitId",
-                  "startDate",
-                  "endDate"
-                ],
-                "properties": {
-                  "userId": {
-                    "type": "integer"
-                  },
-                  "targetOrgUnitId": {
-                    "type": "integer"
-                  },
-                  "startDate": {
-                    "type": "string",
-                    "format": "date"
-                  },
-                  "endDate": {
-                    "type": "string",
-                    "format": "date"
-                  },
-                  "reason": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Loan requested."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          }
-        }
-      }
-    },
-    "/skill-gap": {
-      "get": {
-        "tags": [
-          "Skill Gap"
-        ],
-        "summary": "Skill gap analysis",
-        "parameters": [
-          {
-            "name": "departmentId",
-            "in": "query",
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "name": "scheduleId",
-            "in": "query",
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Gaps between required and available skills."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          }
-        }
-      }
-    },
-    "/settings": {
-      "get": {
-        "tags": [
-          "Settings"
-        ],
-        "summary": "Get all system settings",
-        "responses": {
-          "200": {
-            "description": "Settings object."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          }
-        }
-      }
-    },
-    "/settings/currency": {
-      "get": {
-        "tags": [
-          "Settings"
-        ],
-        "summary": "Get currency setting",
-        "responses": {
-          "200": {
-            "description": "Currency code."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "Settings"
-        ],
-        "summary": "Update currency setting",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "currency"
-                ],
-                "properties": {
-                  "currency": {
-                    "type": "string",
-                    "pattern": "^[A-Z]{3}$"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Updated."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          }
-        }
-      }
-    },
-    "/import/employees": {
-      "post": {
-        "tags": [
-          "Import"
-        ],
-        "summary": "Bulk import employees from CSV/JSON",
-        "description": "Admin only. Idempotent by email \u2014 existing employees are updated.",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "employees"
-                ],
-                "properties": {
-                  "employees": {
-                    "type": "array",
-                    "items": {
-                      "type": "object"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Import result."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          }
-        }
-      }
-    },
-    "/import/shifts": {
-      "post": {
-        "tags": [
-          "Import"
-        ],
-        "summary": "Bulk import shifts",
-        "description": "Admin/manager only.",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "shifts"
-                ],
-                "properties": {
-                  "shifts": {
-                    "type": "array",
-                    "items": {
-                      "type": "object"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Import result."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          }
-        }
-      }
-    },
-    "/modules": {
-      "get": {
-        "tags": [
-          "Modules"
-        ],
-        "summary": "List feature modules and their status",
-        "responses": {
-          "200": {
-            "description": "Module list with enabled/disabled state."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          }
-        }
-      }
-    },
-    "/modules/{name}/enable": {
-      "post": {
-        "tags": [
-          "Modules"
-        ],
-        "summary": "Enable a feature module",
-        "description": "Admin only.",
-        "parameters": [
-          {
-            "name": "name",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Module enabled."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          }
-        }
-      }
-    },
-    "/modules/{name}/disable": {
-      "post": {
-        "tags": [
-          "Modules"
-        ],
-        "summary": "Disable a feature module",
-        "description": "Admin only.",
-        "parameters": [
-          {
-            "name": "name",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Module disabled."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          }
-        }
-      }
-    },
-    "/delegations": {
-      "get": {
-        "tags": [
-          "Delegations"
-        ],
-        "summary": "List delegations",
-        "description": "Returns delegations involving the caller (as delegator or delegate).",
-        "responses": {
-          "200": {
-            "description": "Delegation list."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "Delegations"
-        ],
-        "summary": "Create delegation",
-        "description": "Grants a set of permissions to another user for a specified period.",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "delegateUserId",
-                  "permissionKeys",
-                  "startDate",
-                  "endDate"
-                ],
-                "properties": {
-                  "delegateUserId": {
-                    "type": "integer"
-                  },
-                  "permissionKeys": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "startDate": {
-                    "type": "string",
-                    "format": "date-time"
-                  },
-                  "endDate": {
-                    "type": "string",
-                    "format": "date-time"
-                  },
-                  "reason": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Delegation created."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          }
-        }
-      }
-    },
-    "/approval-workflows": {
-      "get": {
-        "tags": [
-          "Approval Workflows"
-        ],
-        "summary": "List approval workflow definitions",
-        "responses": {
-          "200": {
-            "description": "Workflow list."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "Approval Workflows"
-        ],
-        "summary": "Create approval workflow",
-        "description": "Defines a multi-step approval chain for a specific change type.",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "name",
-                  "changeType",
-                  "steps"
-                ],
-                "properties": {
-                  "name": {
-                    "type": "string"
-                  },
-                  "changeType": {
-                    "type": "string"
-                  },
-                  "steps": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "order": {
-                          "type": "integer"
-                        },
-                        "approverRole": {
-                          "type": "string"
-                        },
-                        "timeoutHours": {
-                          "type": "integer"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Workflow created."
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
           }
         }
       }

--- a/backend/src/__tests__/app.extended.test.ts
+++ b/backend/src/__tests__/app.extended.test.ts
@@ -43,6 +43,18 @@ describe('buildApp CORS callback', () => {
     // The response should simply succeed (not be rejected).
   });
 
+  it('allows requests with no origin in production (container healthchecks, curl)', async () => {
+    const original = config.server.env;
+    (config.server as any).env = 'production';
+    try {
+      const app = buildApp(fakePool, { silent: true });
+      const res = await request(app).get('/api/health');
+      expect([200, 503]).toContain(res.status);
+    } finally {
+      (config.server as any).env = original;
+    }
+  });
+
   it('allows the configured CORS_ORIGIN', async () => {
     const app = buildApp(fakePool, { silent: true });
     const res = await request(app).get('/api/health').set('Origin', config.cors.origin);
@@ -57,11 +69,14 @@ describe('buildApp CORS callback', () => {
     try {
       const app = buildApp(fakePool, { silent: true });
       const res = await request(app).get('/api/health').set('Origin', foreignOrigin);
-      // Express/cors send a 500 with 'Not allowed by CORS' when the callback
-      // passes an Error, or just omit the Allow-Origin header.
+      // Express/cors send a 500 when the callback passes an Error (the body
+      // is the masked production envelope), or just omit the Allow-Origin header.
       expect([500, 200, 503]).toContain(res.status);
       if (res.status === 500) {
-        expect(res.text).toContain('Not allowed by CORS');
+        expect(res.body).toEqual({
+          success: false,
+          error: { code: 'INTERNAL_ERROR', message: 'An internal error occurred' },
+        });
       } else {
         expect(res.headers['access-control-allow-origin']).toBeUndefined();
       }

--- a/backend/src/__tests__/auth.route.test.ts
+++ b/backend/src/__tests__/auth.route.test.ts
@@ -11,11 +11,13 @@ import request from 'supertest';
 import jwt from 'jsonwebtoken';
 import { UserService } from '../services/UserService';
 import { RbacService } from '../services/RbacService';
+import { TwoFactorService } from '../services/TwoFactorService';
 import { config } from '../config';
 import { createAuthRouter } from '../routes/auth';
 
 jest.mock('../services/UserService');
 jest.mock('../services/RbacService');
+jest.mock('../services/TwoFactorService');
 
 const buildApp = (): express.Express => {
   const app = express();
@@ -52,6 +54,7 @@ describe('POST /api/auth/login', () => {
       firstName: 'A',
       lastName: 'B',
     });
+    (TwoFactorService.prototype.isEnabled as jest.Mock) = jest.fn().mockResolvedValue(false);
     (RbacService.prototype.getEffectivePermissions as jest.Mock) = jest
       .fn()
       .mockResolvedValue(['schedule.manage', 'schedule.read']);
@@ -71,6 +74,64 @@ describe('POST /api/auth/login', () => {
     const cookieToken = tokenCookie!.split(';')[0].split('=')[1];
     const decoded = jwt.verify(cookieToken, config.jwt.secret) as { userId: number };
     expect(decoded.userId).toBe(7);
+  });
+});
+
+describe('POST /api/auth/login — two-factor enforcement', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    (UserService.prototype.validatePassword as jest.Mock) = jest.fn().mockResolvedValue({
+      id: 7,
+      email: 'a@x.com',
+      firstName: 'A',
+      lastName: 'B',
+    });
+    (RbacService.prototype.getEffectivePermissions as jest.Mock) = jest.fn().mockResolvedValue([]);
+    (RbacService.prototype.getUserRoles as jest.Mock) = jest.fn().mockResolvedValue([]);
+    (TwoFactorService.prototype.isEnabled as jest.Mock) = jest.fn().mockResolvedValue(true);
+  });
+
+  it('returns 401 TOTP_REQUIRED when 2FA is enabled and no code is supplied', async () => {
+    const res = await request(buildApp())
+      .post('/api/auth/login')
+      .send({ email: 'a@x.com', password: 'pw' });
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe('TOTP_REQUIRED');
+    expect(res.headers['set-cookie']).toBeUndefined();
+  });
+
+  it('returns 401 TOTP_INVALID when the code is wrong', async () => {
+    (TwoFactorService.prototype.verifyCode as jest.Mock) = jest.fn().mockResolvedValue(false);
+    (TwoFactorService.prototype.consumeRecoveryCode as jest.Mock) = jest
+      .fn()
+      .mockResolvedValue(false);
+    const res = await request(buildApp())
+      .post('/api/auth/login')
+      .send({ email: 'a@x.com', password: 'pw', totpCode: '000000' });
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe('TOTP_INVALID');
+    expect(res.headers['set-cookie']).toBeUndefined();
+  });
+
+  it('logs in when a valid TOTP code is supplied', async () => {
+    (TwoFactorService.prototype.verifyCode as jest.Mock) = jest.fn().mockResolvedValue(true);
+    const res = await request(buildApp())
+      .post('/api/auth/login')
+      .send({ email: 'a@x.com', password: 'pw', totpCode: '123456' });
+    expect(res.status).toBe(200);
+    const cookies = res.headers['set-cookie'] as unknown as string[];
+    expect(cookies?.some((c: string) => c.startsWith('token='))).toBe(true);
+  });
+
+  it('logs in when a valid recovery code is supplied', async () => {
+    (TwoFactorService.prototype.verifyCode as jest.Mock) = jest.fn().mockResolvedValue(false);
+    (TwoFactorService.prototype.consumeRecoveryCode as jest.Mock) = jest
+      .fn()
+      .mockResolvedValue(true);
+    const res = await request(buildApp())
+      .post('/api/auth/login')
+      .send({ email: 'a@x.com', password: 'pw', totpCode: 'RECOVERY-1234' });
+    expect(res.status).toBe(200);
   });
 });
 

--- a/backend/src/__tests__/routes.error-handlers.test.ts
+++ b/backend/src/__tests__/routes.error-handlers.test.ts
@@ -181,9 +181,24 @@ describe('twoFactor route error handlers', () => {
     expect(res.status).toBe(500);
   });
 
-  it('POST /disable 500 when service throws', async () => {
-    (TwoFactorService.prototype.disable as jest.Mock).mockRejectedValueOnce(new Error('db'));
+  it('POST /disable 400 when no code is supplied', async () => {
     const res = await request(app()).post('/api/auth/2fa/disable').send({});
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('POST /disable 401 when the code is invalid', async () => {
+    (TwoFactorService.prototype.verifyCode as jest.Mock).mockResolvedValueOnce(false);
+    (TwoFactorService.prototype.consumeRecoveryCode as jest.Mock).mockResolvedValueOnce(false);
+    const res = await request(app()).post('/api/auth/2fa/disable').send({ code: '000000' });
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe('TOTP_INVALID');
+  });
+
+  it('POST /disable 500 when service throws', async () => {
+    (TwoFactorService.prototype.verifyCode as jest.Mock).mockResolvedValueOnce(true);
+    (TwoFactorService.prototype.disable as jest.Mock).mockRejectedValueOnce(new Error('db'));
+    const res = await request(app()).post('/api/auth/2fa/disable').send({ code: '123456' });
     expect(res.status).toBe(500);
   });
 

--- a/backend/src/__tests__/routes.expanded.test.ts
+++ b/backend/src/__tests__/routes.expanded.test.ts
@@ -1795,13 +1795,19 @@ describe('directory router (extended)', () => {
     const bad = await request(app()).post('/api/directory/import-vcard').send({});
     expect(bad.status).toBe(400);
 
+    const weakPassword = await request(app())
+      .post('/api/directory/import-vcard')
+      .set('Content-Type', 'application/json')
+      .send({ vcf: 'BEGIN:VCARD\nEND:VCARD', defaultPassword: 'pw' });
+    expect(weakPassword.status).toBe(400);
+
     (UserDirectoryService.prototype.importVcf as jest.Mock) = jest
       .fn()
       .mockResolvedValue({ created: 1, updated: 0 });
     const ok = await request(app())
       .post('/api/directory/import-vcard')
       .set('Content-Type', 'application/json')
-      .send({ vcf: 'BEGIN:VCARD\nEND:VCARD', defaultPassword: 'pw' });
+      .send({ vcf: 'BEGIN:VCARD\nEND:VCARD', defaultPassword: 'initial-password-1' });
     expect(ok.status).toBe(200);
   });
 });

--- a/backend/src/__tests__/routes.feature.happy.test.ts
+++ b/backend/src/__tests__/routes.feature.happy.test.ts
@@ -268,9 +268,12 @@ describe('two-factor router', () => {
     expect(res.status).toBe(200);
   });
 
-  it('POST /disable returns ok', async () => {
+  it('POST /disable returns ok with a valid code', async () => {
+    (TwoFactorService.prototype.verifyCode as jest.Mock) = jest.fn().mockResolvedValue(true);
     (TwoFactorService.prototype.disable as jest.Mock) = jest.fn().mockResolvedValue(undefined);
-    const res = await request(mountApp('/api/auth/2fa', createTwoFactorRouter(fakePool))).post('/api/auth/2fa/disable');
+    const res = await request(mountApp('/api/auth/2fa', createTwoFactorRouter(fakePool)))
+      .post('/api/auth/2fa/disable')
+      .send({ code: '123456' });
     expect(res.status).toBe(200);
   });
 
@@ -370,7 +373,10 @@ describe('directory router', () => {
       .mockResolvedValue({ inserted: 1, skipped: [] });
     const res = await request(mountApp('/api/directory', createDirectoryRouter(fakePool)))
       .post('/api/directory/import-vcard')
-      .send({ vcf: 'BEGIN:VCARD\r\nVERSION:4.0\r\nFN:X\r\nEMAIL:x@y.com\r\nEND:VCARD\r\n' });
+      .send({
+        vcf: 'BEGIN:VCARD\r\nVERSION:4.0\r\nFN:X\r\nEMAIL:x@y.com\r\nEND:VCARD\r\n',
+        defaultPassword: 'initial-password-1',
+      });
     expect(res.status).toBe(200);
   });
 });

--- a/backend/src/__tests__/scheduleOptimizer.test.ts
+++ b/backend/src/__tests__/scheduleOptimizer.test.ts
@@ -275,6 +275,21 @@ describe('ScheduleOptimizer.evaluateCandidate (pure unit tests)', () => {
     });
     expect(opt.evaluateCandidate(emp, ctx)).toBe(false);
   });
+
+  it('returns false when an overnight shift overlaps a same-date evening shift', () => {
+    const opt = new ScheduleOptimizer();
+    // s1 runs 22:00 → 06:00 (crosses midnight); s2 runs 23:00 → 23:59 the same
+    // date. Without overnight normalization s1 appears to "end" at 06:00 and
+    // the overlap would be missed.
+    const overnight = buildShift({ id: 's1', start_time: '22:00', end_time: '06:00' });
+    const evening = buildShift({ id: 's2', start_time: '23:00', end_time: '23:59' });
+    const ctx = buildCtx({
+      shift: evening,
+      assignedShiftIds: new Set(['s1']),
+      allShifts: [overnight, evening],
+    });
+    expect(opt.evaluateCandidate(buildEmployee() as any, ctx)).toBe(false);
+  });
 });
 
 describe('ScheduleOptimizer.optimize falls back to greedy when Python is unavailable', () => {

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -100,10 +100,10 @@ export function buildApp(pool: Pool, options: BuildAppOptions = {}): express.Exp
   app.use(
     cors({
       origin: (origin, callback) => {
-        if (!origin) {
-          if (config.server.env !== 'production') return callback(null, true);
-          return callback(new Error('Not allowed by CORS'));
-        }
+        // Requests without an Origin header come from non-browser clients
+        // (curl, container healthchecks, server-to-server). CORS only guards
+        // browser cross-origin access, so these are always allowed.
+        if (!origin) return callback(null, true);
         if (config.server.env === 'development' && (origin.includes('localhost') || origin.includes('127.0.0.1'))) {
           return callback(null, true);
         }
@@ -204,7 +204,7 @@ export function buildApp(pool: Pool, options: BuildAppOptions = {}): express.Exp
         error: {
           code: err.code || 'INTERNAL_ERROR',
           message:
-            process.env.NODE_ENV === 'production' ? 'An internal error occurred' : err.message,
+            config.server.env === 'production' ? 'An internal error occurred' : err.message,
         },
       });
     }

--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -46,6 +46,25 @@ function requireProductionSecret(envVar: string, insecureDefault: string): strin
   return value;
 }
 
+/**
+ * Parses a jsonwebtoken-style duration string ("24h", "7d", "15m", "30s",
+ * or a bare number of seconds) into milliseconds. Falls back to the given
+ * default when the value is not in a recognized format, so the auth cookie
+ * lifetime always stays in lockstep with the JWT expiry.
+ */
+function parseDurationMs(value: string, fallbackMs: number): number {
+  const match = /^(\d+)\s*([smhd])?$/i.exec(value.trim());
+  if (!match) return fallbackMs;
+  const amount = parseInt(match[1], 10);
+  const unit = (match[2] ?? 's').toLowerCase();
+  const multiplier =
+    unit === 's' ? 1_000 :
+    unit === 'm' ? 60_000 :
+    unit === 'h' ? 3_600_000 :
+    86_400_000; // 'd'
+  return amount * multiplier;
+}
+
 export const config = {
   server: {
     port: parseInt(process.env.PORT || '3001'),
@@ -64,6 +83,7 @@ export const config = {
   jwt: {
     secret: requireSecret('JWT_SECRET', 'JWT_SECRET'),
     expiresIn: process.env.JWT_EXPIRES_IN || '24h',
+    expiresInMs: parseDurationMs(process.env.JWT_EXPIRES_IN || '24h', 24 * 60 * 60 * 1000),
   },
   email: {
     host: process.env.EMAIL_HOST || 'smtp.gmail.com',

--- a/backend/src/optimization/ScheduleOptimizerORTools.ts
+++ b/backend/src/optimization/ScheduleOptimizerORTools.ts
@@ -137,6 +137,10 @@ export interface CandidateContext {
 export class ScheduleOptimizer {
   private pythonScriptPath: string;
 
+  // Memoizes the id → shift index per problem instance so overlap checks are
+  // O(1) per lookup instead of scanning the full shift list every time.
+  private _shiftsByIdCache = new WeakMap<Shift[], Map<string, Shift>>();
+
   constructor() {
     // Path to Python optimizer script
     this.pythonScriptPath = join(__dirname, '../../optimization-scripts/schedule_optimizer.py');
@@ -450,6 +454,9 @@ export class ScheduleOptimizer {
    *   being staffed. The CP-SAT path handles this globally.
    * - Weekly hours are not tracked across the full schedule period; only the
    *   per-day budget is enforced here.
+   * - Overlap detection only compares shifts that share the same date. An
+   *   overnight shift is detected against same-date shifts, but not against a
+   *   next-day shift it spills into. The CP-SAT path handles this globally.
    */
   async generateGreedySchedule(problem: OptimizationProblem): Promise<ScheduleAssignment[]> {
     logger.info('Generating greedy schedule as fallback');
@@ -518,8 +525,13 @@ export class ScheduleOptimizer {
     assignedShiftIds: Set<string>,
     allShifts: Shift[]
   ): boolean {
+    let shiftsById = this._shiftsByIdCache.get(allShifts);
+    if (!shiftsById) {
+      shiftsById = new Map(allShifts.map((s) => [s.id, s]));
+      this._shiftsByIdCache.set(allShifts, shiftsById);
+    }
     for (const shiftId of assignedShiftIds) {
-      const assignedShift = allShifts.find((s) => s.id === shiftId);
+      const assignedShift = shiftsById.get(shiftId);
       if (assignedShift && assignedShift.date === shift.date) {
         // Check time overlap
         if (
@@ -539,9 +551,14 @@ export class ScheduleOptimizer {
 
   private _timesOverlap(start1: string, end1: string, start2: string, end2: string): boolean {
     const s1 = this._timeToMinutes(start1);
-    const e1 = this._timeToMinutes(end1);
+    let e1 = this._timeToMinutes(end1);
     const s2 = this._timeToMinutes(start2);
-    const e2 = this._timeToMinutes(end2);
+    let e2 = this._timeToMinutes(end2);
+
+    // Normalize overnight ranges (e.g. 22:00–06:00) so a shift crossing
+    // midnight is still detected as overlapping same-date shifts.
+    if (e1 <= s1) e1 += 24 * 60;
+    if (e2 <= s2) e2 += 24 * 60;
 
     return !(e1 <= s2 || e2 <= s1);
   }

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -19,6 +19,7 @@ import { Pool } from 'mysql2/promise';
 import rateLimit from 'express-rate-limit';
 import { UserService } from '../services/UserService';
 import { RbacService } from '../services/RbacService';
+import { TwoFactorService } from '../services/TwoFactorService';
 import { authenticate, addToBlacklist } from '../middleware/auth';
 import { validateBody } from '../middleware/validation';
 import { loginBody } from '../schemas';
@@ -34,13 +35,16 @@ const JWT_COOKIE_OPTIONS = {
   httpOnly: true,
   secure: isProduction,
   sameSite: 'lax' as const,
-  maxAge: 24 * 60 * 60 * 1000, // 24 hours
+  // Keep the cookie lifetime in lockstep with the JWT expiry so the cookie
+  // never outlives (or prematurely drops) a still-valid token.
+  maxAge: config.jwt.expiresInMs,
 };
 
 export const createAuthRouter = (pool: Pool) => {
   const router = Router();
   const userService = new UserService(pool);
   const rbacService = new RbacService(pool);
+  const twoFactorService = new TwoFactorService(pool);
 
   // Shared JWT signing options, driven by configuration rather than hardcoded.
   const jwtSignOptions: SignOptions = {
@@ -76,10 +80,14 @@ export const createAuthRouter = (pool: Pool) => {
  * User login endpoint.
  *
  * Authenticates a user with email + password credentials and returns a JWT.
+ * When the account has two-factor authentication enabled, a valid TOTP code
+ * (or single-use recovery code) must be supplied as `totpCode`; otherwise the
+ * request is rejected with `TOTP_REQUIRED` / `TOTP_INVALID`.
  *
  * @route POST /api/auth/login
- * @body  {string} email    User's email
- * @body  {string} password User's password
+ * @body  {string} email     User's email
+ * @body  {string} password  User's password
+ * @body  {string} [totpCode] TOTP or recovery code, required when 2FA is enabled
  * @returns Sets an httpOnly "token" cookie and returns `{ success, data: { user } }`.
  *          The JWT is never exposed in the response body.
  *
@@ -96,11 +104,15 @@ export const createAuthRouter = (pool: Pool) => {
  */
 router.post('/login', loginLimiter, validateBody(loginBody), async (_req: Request, res: Response) => {
   try {
-    const { email, password } = res.locals.body as { email: string; password: string };
+    const { email, password, totpCode } = res.locals.body as {
+      email: string;
+      password: string;
+      totpCode?: string;
+    };
 
     // Authenticate user and generate token
     const user = await userService.validatePassword(email, password);
-    
+
     if (!user) {
       return res.status(401).json({
         success: false,
@@ -109,6 +121,33 @@ router.post('/login', loginLimiter, validateBody(loginBody), async (_req: Reques
           message: 'Invalid email or password'
         }
       });
+    }
+
+    // Enforce two-factor authentication when the account has it enabled.
+    // The TOTP code is only checked after the password is verified so this
+    // endpoint never leaks whether 2FA is enabled for arbitrary emails.
+    if (await twoFactorService.isEnabled(user.id)) {
+      if (!totpCode) {
+        return res.status(401).json({
+          success: false,
+          error: {
+            code: 'TOTP_REQUIRED',
+            message: 'Two-factor authentication code required'
+          }
+        });
+      }
+      const totpValid =
+        (await twoFactorService.verifyCode(user.id, totpCode)) ||
+        (await twoFactorService.consumeRecoveryCode(user.id, totpCode));
+      if (!totpValid) {
+        return res.status(401).json({
+          success: false,
+          error: {
+            code: 'TOTP_INVALID',
+            message: 'Invalid two-factor authentication code'
+          }
+        });
+      }
     }
 
     // Resolve effective permissions/roles so the client can gate its UI.

--- a/backend/src/routes/directory.ts
+++ b/backend/src/routes/directory.ts
@@ -7,7 +7,7 @@
  *   DELETE /api/directory/users/:id/fields/:key  remove a custom field
  *   GET   /api/directory/users/:id/vcard    vCard for a single user
  *   GET   /api/directory/vcard.vcf?ids=…    vCard archive for a list of users
- *   POST  /api/directory/import-vcard       admin-only multipart vCard import
+ *   POST  /api/directory/import-vcard       vCard JSON import (user.manage)
  *
  * @author Luca Ostinelli
  */
@@ -17,7 +17,7 @@ import bcrypt from 'bcrypt';
 import { Router, Request, Response } from 'express';
 import { authenticate, requirePermission } from '../middleware/auth';
 import { validateBody } from '../middleware/validation';
-import { directoryFieldsBody } from '../schemas';
+import { directoryFieldsBody, importVcardBody } from '../schemas';
 import { UserDirectoryService } from '../services/UserDirectoryService';
 import { config } from '../config';
 
@@ -90,21 +90,24 @@ export const createDirectoryRouter = (pool: Pool): Router => {
       .send(vcf);
   });
 
-  router.post('/import-vcard', requirePermission('user.manage'), async (req: Request, res: Response) => {
-    try {
-      const text = typeof req.body === 'string' ? req.body : (req.body?.vcf as string | undefined);
-      if (!text) return error(res, 400, 'VALIDATION_ERROR', 'vcf body required');
-      const defaultPassword = (req.body?.defaultPassword as string | undefined) ?? 'changeme';
-      const passwordHash = await bcrypt.hash(defaultPassword, config.security.bcryptRounds);
-      const out = await service.importVcf(text, {
-        defaultPasswordHash: passwordHash,
-        createdBy: req.user!.id,
-      });
-      res.json({ success: true, data: out });
-    } catch (err) {
-      error(res, 400, 'VALIDATION_ERROR', (err as Error).message);
+  router.post(
+    '/import-vcard',
+    requirePermission('user.manage'),
+    validateBody(importVcardBody),
+    async (req: Request, res: Response) => {
+      try {
+        const { vcf, defaultPassword } = res.locals.body as { vcf: string; defaultPassword: string };
+        const passwordHash = await bcrypt.hash(defaultPassword, config.security.bcryptRounds);
+        const out = await service.importVcf(vcf, {
+          defaultPasswordHash: passwordHash,
+          createdBy: req.user!.id,
+        });
+        res.json({ success: true, data: out });
+      } catch (err) {
+        error(res, 400, 'VALIDATION_ERROR', (err as Error).message);
+      }
     }
-  });
+  );
 
   return router;
 };

--- a/backend/src/routes/org.ts
+++ b/backend/src/routes/org.ts
@@ -24,7 +24,7 @@ import { Pool } from 'mysql2/promise';
 import { Router, Request, Response } from 'express';
 import { authenticate, requirePermission, userHasPermission } from '../middleware/auth';
 import { validateParams, validateBody } from '../middleware/validation';
-import { idParam, createOrgUnitBody, updateOrgUnitBody, addOrgMemberBody, createLoanBody, optionalNotesBody } from '../schemas';
+import { idParam, idAndUserIdParam, createOrgUnitBody, updateOrgUnitBody, addOrgMemberBody, createLoanBody, optionalNotesBody } from '../schemas';
 import { OrgUnitService } from '../services/OrgUnitService';
 import { EmployeeLoanService } from '../services/EmployeeLoanService';
 import { AuditLogService } from '../services/AuditLogService';
@@ -150,9 +150,11 @@ export const createOrgRouter = (pool: Pool): Router => {
   router.patch(
     '/units/:id/members/:userId/primary',
     requirePermission('employee.manage'),
-    async (req: Request, res: Response) => {
+    validateParams(idAndUserIdParam),
+    async (_req: Request, res: Response) => {
       try {
-        await units.setPrimary(Number(req.params.userId), Number(req.params.id));
+        const { id, userId } = res.locals.params;
+        await units.setPrimary(userId, id);
         res.json({ success: true });
       } catch (err) {
         const msg = (err as Error).message;
@@ -165,9 +167,11 @@ export const createOrgRouter = (pool: Pool): Router => {
   router.delete(
     '/units/:id/members/:userId',
     requirePermission('employee.manage'),
-    async (req: Request, res: Response) => {
+    validateParams(idAndUserIdParam),
+    async (_req: Request, res: Response) => {
       try {
-        await units.removeMember(Number(req.params.userId), Number(req.params.id));
+        const { id, userId } = res.locals.params;
+        await units.removeMember(userId, id);
         res.json({ success: true });
       } catch (err) {
         respondError(res, 400, 'VALIDATION_ERROR', (err as Error).message);

--- a/backend/src/routes/twoFactor.ts
+++ b/backend/src/routes/twoFactor.ts
@@ -3,8 +3,8 @@
  *
  *   POST /api/auth/2fa/setup    start setup, returns secret + otpauth uri
  *   POST /api/auth/2fa/enable   verify code, returns recovery codes
- *   POST /api/auth/2fa/disable  turn 2FA off
- *   POST /api/auth/2fa/verify   verify a code (used by future login flow)
+ *   POST /api/auth/2fa/disable  turn 2FA off (requires a valid TOTP or recovery code)
+ *   POST /api/auth/2fa/verify   verify a code
  *
  * @author Luca Ostinelli
  */
@@ -47,9 +47,19 @@ export const createTwoFactorRouter = (pool: Pool): Router => {
     }
   });
 
-  router.post('/disable', async (req: Request, res: Response) => {
+  router.post('/disable', validateBody(twoFactorCodeBody), async (req: Request, res: Response) => {
     try {
-      await service.disable(req.user!.id);
+      const code = res.locals.body.code as string;
+      const userId = req.user!.id;
+      // Disabling 2FA weakens the account, so it demands the same proof of
+      // possession as login: a current TOTP code or an unused recovery code.
+      const valid =
+        (await service.verifyCode(userId, code)) ||
+        (await service.consumeRecoveryCode(userId, code));
+      if (!valid) {
+        return respondError(res, 401, 'TOTP_INVALID', 'Invalid two-factor authentication code');
+      }
+      await service.disable(userId);
       res.json({ success: true });
     } catch (err) {
       logger.error('2fa disable error:', err);

--- a/backend/src/schemas/index.ts
+++ b/backend/src/schemas/index.ts
@@ -340,6 +340,8 @@ export const updateSettingValueBody = z.object({
 export const loginBody = z.object({
   email: z.string().min(1, 'email is required'),
   password: z.string().min(1, 'password is required'),
+  // TOTP or recovery code; required only when the account has 2FA enabled.
+  totpCode: z.string().min(1).optional(),
 });
 
 export const optionalNotesBody = z.object({
@@ -353,4 +355,9 @@ export const bulkImportEmployeesBody = z.object({
 
 export const bulkImportShiftsBody = z.object({
   csv: z.string().min(1, 'csv is required'),
+});
+
+export const importVcardBody = z.object({
+  vcf: z.string().min(1, 'vcf is required'),
+  defaultPassword: z.string().min(8, 'defaultPassword must be at least 8 characters'),
 });

--- a/frontend/src/pages/Auth/Login.test.tsx
+++ b/frontend/src/pages/Auth/Login.test.tsx
@@ -25,6 +25,8 @@ jest.mock('../../contexts/AuthContext', () => ({
 
 // eslint-disable-next-line import/first
 import Login from './Login';
+// eslint-disable-next-line import/first
+import { ApiError } from '../../services/apiUtils';
 
 describe('<Login />', () => {
   beforeEach(() => {
@@ -64,5 +66,35 @@ describe('<Login />', () => {
     await userEvent.click(screen.getByRole('button', { name: /sign in|login|submit/i }));
     expect(await screen.findByText(/invalid email or password/i)).toBeInTheDocument();
     expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('reveals the 2FA field on TOTP_REQUIRED and resubmits with the code', async () => {
+    mockLogin.mockRejectedValueOnce(
+      new ApiError('Two-factor authentication code required', 401, 'TOTP_REQUIRED')
+    );
+    render(<Login />);
+    await userEvent.type(
+      screen.getByRole('textbox', { name: /email/i }),
+      'a@x.com'
+    );
+    await userEvent.type(screen.getByLabelText(/^password/i), 'pw');
+    await userEvent.click(screen.getByRole('button', { name: /sign in|login|submit/i }));
+
+    // The code field appears; no error alert is shown for this state.
+    const codeField = await screen.findByLabelText(/two-factor code/i);
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+
+    mockLogin.mockResolvedValueOnce(undefined);
+    await userEvent.type(codeField, '123456');
+    await userEvent.click(screen.getByRole('button', { name: /sign in|login|submit/i }));
+
+    await waitFor(() =>
+      expect(mockLogin).toHaveBeenLastCalledWith({
+        email: 'a@x.com',
+        password: 'pw',
+        totpCode: '123456',
+      })
+    );
+    expect(mockNavigate).toHaveBeenCalledWith('/dashboard', { replace: true });
   });
 });

--- a/frontend/src/pages/Auth/Login.tsx
+++ b/frontend/src/pages/Auth/Login.tsx
@@ -6,19 +6,21 @@
  * 
  * Features:
  * - Email/password authentication form
+ * - Two-factor (TOTP / recovery code) step when the account has 2FA enabled
  * - Real-time form validation
  * - Loading states during authentication
  * - Error message display
  * - Automatic redirect after successful login
  * - Responsive design with Bootstrap styling
  * - Integration with AuthContext for state management
- * 
+ *
  * @author Luca Ostinelli
  */
 
 import React, { useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
+import { ApiError } from '../../services/apiUtils';
 
 /**
  * Interface for location state with redirect information
@@ -37,9 +39,11 @@ const Login: React.FC = () => {
   const [credentials, setCredentials] = useState({
     email: '',
     password: '',
+    totpCode: '',
   });
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState('');
+  const [totpRequired, setTotpRequired] = useState(false);
 
   const { login } = useAuth();
   const navigate = useNavigate();
@@ -53,10 +57,20 @@ const Login: React.FC = () => {
     setError('');
 
     try {
-      await login(credentials);
+      await login({
+        email: credentials.email,
+        password: credentials.password,
+        ...(credentials.totpCode ? { totpCode: credentials.totpCode } : {}),
+      });
       navigate(from, { replace: true });
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Login failed');
+      if (err instanceof ApiError && err.code === 'TOTP_REQUIRED') {
+        // Credentials are valid but the account has 2FA enabled:
+        // reveal the code field instead of surfacing an error.
+        setTotpRequired(true);
+      } else {
+        setError(err instanceof Error ? err.message : 'Login failed');
+      }
     } finally {
       setIsLoading(false);
     }
@@ -120,6 +134,29 @@ const Login: React.FC = () => {
                       required
                     />
                   </div>
+
+                  {totpRequired && (
+                    <div className="mb-4">
+                      <label htmlFor="totpCode" className="form-label">
+                        Two-factor code
+                      </label>
+                      <input
+                        type="text"
+                        id="totpCode"
+                        name="totpCode"
+                        className="form-control"
+                        value={credentials.totpCode}
+                        onChange={handleChange}
+                        autoComplete="one-time-code"
+                        inputMode="numeric"
+                        required
+                        autoFocus
+                      />
+                      <div className="form-text">
+                        Enter the code from your authenticator app, or a recovery code.
+                      </div>
+                    </div>
+                  )}
 
                   <button
                     type="submit"

--- a/frontend/src/services/apiUtils.ts
+++ b/frontend/src/services/apiUtils.ts
@@ -17,11 +17,12 @@ export const API_BASE_URL = process.env.REACT_APP_API_URL || 'http://localhost:3
 
 /**
  * Custom error class for API-related errors.
- * Carries the HTTP status code alongside the message so callers
- * can distinguish 401 / 403 / 404 / 5xx without parsing strings.
+ * Carries the HTTP status code and the backend error code alongside the
+ * message so callers can distinguish 401 / 403 / 404 / 5xx — and specific
+ * conditions such as TOTP_REQUIRED — without parsing strings.
  */
 export class ApiError extends Error {
-  constructor(message: string, public status?: number) {
+  constructor(message: string, public status?: number, public code?: string) {
     super(message);
     this.name = 'ApiError';
   }
@@ -44,17 +45,20 @@ export const handleResponse = async <T>(response: Response): Promise<ApiResponse
 
   if (!response.ok) {
     let errorMessage = `HTTP error! status: ${response.status}`;
+    let errorCode: string | undefined;
     if (data !== null && typeof data === 'object') {
       const dataObj = data as Record<string, unknown>;
       const errField = dataObj['error'];
       if (errField !== null && typeof errField === 'object') {
         const msg = (errField as Record<string, unknown>)['message'];
         if (typeof msg === 'string') errorMessage = msg;
+        const code = (errField as Record<string, unknown>)['code'];
+        if (typeof code === 'string') errorCode = code;
       } else if (typeof dataObj['message'] === 'string') {
         errorMessage = dataObj['message'];
       }
     }
-    throw new ApiError(errorMessage, response.status);
+    throw new ApiError(errorMessage, response.status, errorCode);
   }
 
   return data as ApiResponse<T>;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -188,6 +188,8 @@ export interface ApiResponse<T = unknown> {
 export interface LoginRequest {
   email: string;
   password: string;
+  /** TOTP or recovery code; required when the account has 2FA enabled. */
+  totpCode?: string;
   rememberMe?: boolean;
 }
 


### PR DESCRIPTION
## Summary

Seventh project-review pass. Fixes every finding from the full review.

### Security
- **2FA is now enforced at login**: accounts with TOTP enabled must supply `totpCode` (TOTP or single-use recovery code). New error codes `TOTP_REQUIRED` / `TOTP_INVALID`. The login page reveals a two-factor field when the backend requests it.
- **Disabling 2FA requires a valid code** (`POST /api/auth/2fa/disable` now validates `code` and answers 401 `TOTP_INVALID` on mismatch).
- **import-vcard hardened**: body validated with Zod; `defaultPassword` (min 8 chars) is now required — the weak `changeme` fallback is gone.

### Operational
- **CORS no longer rejects requests without an Origin header in production.** The Docker healthcheck (`wget` → `/api/health`) sends no Origin and was answered 500 with `NODE_ENV=production`, marking the backend container permanently unhealthy. CORS only guards browser cross-origin access, so no-origin (curl, healthchecks, server-to-server) is always allowed.
- Auth cookie `maxAge` now derives from `JWT_EXPIRES_IN` instead of a hardcoded 24 h.

### Correctness
- Greedy optimizer overlap detection now normalizes overnight shifts (22:00–06:00 vs 23:00–23:59 was previously missed); shift lookups memoized via id-index.
- `org` member routes (`PATCH …/primary`, `DELETE …/members/:userId`) now use `validateParams`.
- Global error handler reads `config.server.env` consistently.

### Documentation
- `openapi.json` synced 1:1 with the implemented routes: 62 missing operations added (notifications, settings subroutes, shift-swap/time-off/policy actions, on-call CRUD, org members/loans, role grants, 2fa/verify, SSE stream, readiness probe, …), phantom `/modules/{name}/enable|disable` replaced with the real `PUT /modules/{code}`, login documented with cookie semantics + `totpCode`, `cookieAuth` security scheme added.
- `DOCUMENTATION.md`: 2FA login flow, updated error-code table, corrected roadmap entries.
- `CLAUDE.md`: table count corrected (37, was 29).

## Test plan
- Backend: 104 suites / 1655 tests green (new: TOTP login enforcement, 2FA disable validation, vcard password validation, production no-origin CORS, overnight overlap).
- Frontend: 19 suites / 103 tests green (new: TOTP challenge flow on the login page); production build passes.
- Verified `openapi.json` ⇄ Express routes 1:1 (no missing, no phantom operations).