### PR TITLE
docs(readme): refresh stale npm audit note for the CRA toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ npm start                  # http://localhost:3000
 ```
 
 > **Note**: `react-scripts@5.0.1` (Create React App) is unmaintained since October 2022.
-> `npm audit` reports 13 HIGH-severity findings — all in CRA's build toolchain (nth-check, serialize-javascript, svgo, etc.), none in the production JS bundle. They cannot be resolved without migrating to Vite. See DOCUMENTATION.md §Future Work.
+> `npm audit` reports findings only in CRA's development toolchain (webpack-dev-server, sockjs, postcss, etc.) — none reach the production JS bundle, and `npm audit --omit=dev` is clean. They cannot be resolved without migrating to Vite. See DOCUMENTATION.md §Future Work.
 
 ### First admin user
 


### PR DESCRIPTION
## Summary
Project-review follow-up: the README claimed `npm audit` reports "13 HIGH-severity findings (nth-check, serialize-javascript, svgo)". The advisory set has since changed — today it is 23 findings concentrated in the dev-only `webpack-dev-server`/`sockjs`/`postcss` chain, and `npm audit --omit=dev` is clean. The note now describes the situation accurately without pinning a count that drifts.

## Test plan
Docs-only change; CI checks confirm nothing else is affected.