### PR TITLE
fix(validation): wire validateParams across all remaining param routes

### DIFF
--- a/backend/src/routes/approvalWorkflows.ts
+++ b/backend/src/routes/approvalWorkflows.ts
@@ -18,7 +18,7 @@ import { Pool } from 'mysql2/promise';
 import { ApprovalEngineService } from '../services/ApprovalEngineService';
 import { authenticate, requirePermission } from '../middleware/auth';
 import { validateParams, validateBody } from '../middleware/validation';
-import { idParam, createApprovalWorkflowBody, updateApprovalWorkflowBody, escalateBody } from '../schemas';
+import { idParam, typeParam, createApprovalWorkflowBody, updateApprovalWorkflowBody, escalateBody } from '../schemas';
 import { logger } from '../config/logger';
 
 export const createApprovalWorkflowsRouter = (pool: Pool): Router => {
@@ -49,9 +49,9 @@ export const createApprovalWorkflowsRouter = (pool: Pool): Router => {
   });
 
   // Get workflow by change type
-  router.get('/:type', authenticate, requirePermission('approval.manage'), async (req: Request, res: Response) => {
+  router.get('/:type', authenticate, requirePermission('approval.manage'), validateParams(typeParam), async (_req: Request, res: Response) => {
     try {
-      const workflow = await engine.getWorkflowByChangeType(req.params.type);
+      const workflow = await engine.getWorkflowByChangeType(res.locals.params.type);
       if (!workflow) {
         return res.status(404).json({ success: false, error: { code: 'NOT_FOUND', message: 'Workflow not found' } });
       }

--- a/backend/src/routes/calendar.ts
+++ b/backend/src/routes/calendar.ts
@@ -17,7 +17,10 @@
 import { Pool, RowDataPacket } from 'mysql2/promise';
 import { Router, Request, Response } from 'express';
 import { authenticate } from '../middleware/auth';
+import { validateParams } from '../middleware/validation';
+import { idParam } from '../schemas';
 import { CalendarService } from '../services/CalendarService';
+import { logger } from '../config/logger';
 
 const writeIcsResponse = (
   res: Response,
@@ -42,71 +45,91 @@ export const createCalendarRouter = (pool: Pool): Router => {
   const service = new CalendarService(pool);
 
   router.post('/token', authenticate, async (req: Request, res: Response) => {
-    const token = await service.getOrCreateToken(req.user!.id);
-    res.json({ success: true, data: { token } });
+    try {
+      const token = await service.getOrCreateToken(req.user!.id);
+      res.json({ success: true, data: { token } });
+    } catch (err) {
+      logger.error('calendar token error:', err);
+      res.status(500).json({ success: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to issue calendar token' } });
+    }
   });
 
   router.post('/token/rotate', authenticate, async (req: Request, res: Response) => {
-    const token = await service.rotateToken(req.user!.id);
-    res.json({ success: true, data: { token } });
+    try {
+      const token = await service.rotateToken(req.user!.id);
+      res.json({ success: true, data: { token } });
+    } catch (err) {
+      logger.error('calendar token rotate error:', err);
+      res.status(500).json({ success: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to rotate calendar token' } });
+    }
   });
 
   router.get('/feed.ics', async (req: Request, res: Response) => {
-    const token = (req.query.token as string | undefined) || '';
-    if (!token) {
-      res.status(401).type('text/plain').send('token query parameter required');
-      return;
+    try {
+      const token = (req.query.token as string | undefined) || '';
+      if (!token) {
+        res.status(401).type('text/plain').send('token query parameter required');
+        return;
+      }
+      const userId = await service.resolveToken(token);
+      if (!userId) {
+        res.status(401).type('text/plain').send('invalid token');
+        return;
+      }
+      const { body, etag } = await service.buildUserFeed(userId);
+      writeIcsResponse(res, body, etag, req.headers['if-none-match'] as string | undefined);
+    } catch (err) {
+      logger.error('calendar feed error:', err);
+      res.status(500).type('text/plain').send('internal error');
     }
-    const userId = await service.resolveToken(token);
-    if (!userId) {
-      res.status(401).type('text/plain').send('invalid token');
-      return;
-    }
-    const { body, etag } = await service.buildUserFeed(userId);
-    writeIcsResponse(res, body, etag, req.headers['if-none-match'] as string | undefined);
   });
 
-  router.get('/department/:id.ics', async (req: Request, res: Response) => {
-    const token = (req.query.token as string | undefined) || '';
-    if (!token) {
-      res.status(401).type('text/plain').send('token query parameter required');
-      return;
-    }
-    const userId = await service.resolveToken(token);
-    if (!userId) {
-      res.status(401).type('text/plain').send('invalid token');
-      return;
-    }
+  router.get('/department/:id.ics', validateParams(idParam), async (req: Request, res: Response) => {
+    try {
+      const token = (req.query.token as string | undefined) || '';
+      if (!token) {
+        res.status(401).type('text/plain').send('token query parameter required');
+        return;
+      }
+      const userId = await service.resolveToken(token);
+      if (!userId) {
+        res.status(401).type('text/plain').send('invalid token');
+        return;
+      }
 
-    // Authorisation: the token's user must be a full administrator (holds the
-    // `settings.manage` permission) OR the manager of the target department.
-    // Permissions are resolved with a correlated EXISTS to avoid pulling in the
-    // heavier UserService/RbacService for a read-only check.
-    const departmentId = Number(req.params.id);
-    const [rows] = await pool.execute<RowDataPacket[]>(
-      `SELECT d.manager_id,
-              EXISTS(
-                SELECT 1 FROM user_roles ur
-                  JOIN role_permissions rp ON rp.role_id = ur.role_id
-                  JOIN permissions p ON p.id = rp.permission_id
-                 WHERE ur.user_id = u.id AND p.code = 'settings.manage'
-                   AND (ur.expires_at IS NULL OR ur.expires_at > NOW())
-              ) AS is_admin
-         FROM users u
-         LEFT JOIN departments d ON d.id = ?
-        WHERE u.id = ? LIMIT 1`,
-      [departmentId, userId]
-    );
-    const row = rows[0];
-    const allowed =
-      !!row && (Number(row.is_admin) === 1 || row.manager_id === userId);
-    if (!allowed) {
-      res.status(403).type('text/plain').send('forbidden');
-      return;
-    }
+      // Authorisation: the token's user must be a full administrator (holds the
+      // `settings.manage` permission) OR the manager of the target department.
+      // Permissions are resolved with a correlated EXISTS to avoid pulling in the
+      // heavier UserService/RbacService for a read-only check.
+      const departmentId = res.locals.params.id;
+      const [rows] = await pool.execute<RowDataPacket[]>(
+        `SELECT d.manager_id,
+                EXISTS(
+                  SELECT 1 FROM user_roles ur
+                    JOIN role_permissions rp ON rp.role_id = ur.role_id
+                    JOIN permissions p ON p.id = rp.permission_id
+                   WHERE ur.user_id = u.id AND p.code = 'settings.manage'
+                     AND (ur.expires_at IS NULL OR ur.expires_at > NOW())
+                ) AS is_admin
+           FROM users u
+           LEFT JOIN departments d ON d.id = ?
+          WHERE u.id = ? LIMIT 1`,
+        [departmentId, userId]
+      );
+      const row = rows[0];
+      const allowed =
+        !!row && (Number(row.is_admin) === 1 || row.manager_id === userId);
+      if (!allowed) {
+        res.status(403).type('text/plain').send('forbidden');
+        return;
+      }
 
-    const { body, etag } = await service.buildDepartmentFeed(departmentId);
-    writeIcsResponse(res, body, etag, req.headers['if-none-match'] as string | undefined);
+      const { body, etag } = await service.buildDepartmentFeed(departmentId);
+      writeIcsResponse(res, body, etag, req.headers['if-none-match'] as string | undefined);
+    } catch (err) {
+      logger.error('calendar department feed error:', err);
+      res.status(500).type('text/plain').send('internal error');
+    }
   });
 
   return router;

--- a/backend/src/routes/directory.ts
+++ b/backend/src/routes/directory.ts
@@ -16,8 +16,8 @@ import { Pool } from 'mysql2/promise';
 import bcrypt from 'bcrypt';
 import { Router, Request, Response } from 'express';
 import { authenticate, requirePermission } from '../middleware/auth';
-import { validateBody } from '../middleware/validation';
-import { directoryFieldsBody, importVcardBody } from '../schemas';
+import { validateBody, validateParams } from '../middleware/validation';
+import { directoryFieldsBody, importVcardBody, idParam, idAndKeyParam } from '../schemas';
 import { UserDirectoryService } from '../services/UserDirectoryService';
 import { config } from '../config';
 
@@ -37,17 +37,17 @@ export const createDirectoryRouter = (pool: Pool): Router => {
     res.json({ success: true, data: profile });
   });
 
-  router.get('/users/:id', requirePermission('user.read'), async (req: Request, res: Response) => {
-    const profile = await service.getProfile(Number(req.params.id));
+  router.get('/users/:id', requirePermission('user.read'), validateParams(idParam), async (_req: Request, res: Response) => {
+    const profile = await service.getProfile(res.locals.params.id);
     if (!profile) return error(res, 404, 'NOT_FOUND', 'Profile not found');
     res.json({ success: true, data: profile });
   });
 
-  router.put('/users/:id/fields', requirePermission('user.manage'), validateBody(directoryFieldsBody), async (req: Request, res: Response) => {
+  router.put('/users/:id/fields', requirePermission('user.manage'), validateParams(idParam), validateBody(directoryFieldsBody), async (_req: Request, res: Response) => {
     try {
       const fields = res.locals.body.fields;
-      await service.setFields(Number(req.params.id), fields);
-      const profile = await service.getProfile(Number(req.params.id));
+      await service.setFields(res.locals.params.id, fields);
+      const profile = await service.getProfile(res.locals.params.id);
       res.json({ success: true, data: profile });
     } catch (err) {
       error(res, 400, 'VALIDATION_ERROR', (err as Error).message);
@@ -57,15 +57,16 @@ export const createDirectoryRouter = (pool: Pool): Router => {
   router.delete(
     '/users/:id/fields/:key',
     requirePermission('user.manage'),
-    async (req: Request, res: Response) => {
-      const ok = await service.removeField(Number(req.params.id), req.params.key);
+    validateParams(idAndKeyParam),
+    async (_req: Request, res: Response) => {
+      const ok = await service.removeField(res.locals.params.id, res.locals.params.key);
       if (!ok) return error(res, 404, 'NOT_FOUND', 'Field not found');
       res.json({ success: true });
     }
   );
 
-  router.get('/users/:id/vcard', requirePermission('user.read'), async (req: Request, res: Response) => {
-    const profile = await service.getProfile(Number(req.params.id));
+  router.get('/users/:id/vcard', requirePermission('user.read'), validateParams(idParam), async (_req: Request, res: Response) => {
+    const profile = await service.getProfile(res.locals.params.id);
     if (!profile) return error(res, 404, 'NOT_FOUND', 'Profile not found');
     const vcf = await service.exportVcf([profile.id]);
     res

--- a/backend/src/routes/modules.ts
+++ b/backend/src/routes/modules.ts
@@ -11,8 +11,8 @@ import { Router, Request, Response } from 'express';
 import { Pool } from 'mysql2/promise';
 import { ModuleService } from '../services/ModuleService';
 import { authenticate, requirePermission } from '../middleware/auth';
-import { validateBody } from '../middleware/validation';
-import { moduleEnabledBody } from '../schemas';
+import { validateBody, validateParams } from '../middleware/validation';
+import { moduleEnabledBody, codeParam } from '../schemas';
 import { logger } from '../config/logger';
 
 export const createModulesRouter = (pool: Pool): Router => {
@@ -29,9 +29,9 @@ export const createModulesRouter = (pool: Pool): Router => {
     }
   });
 
-  router.put('/:code', authenticate, requirePermission('settings.manage'), validateBody(moduleEnabledBody), async (req: Request, res: Response) => {
+  router.put('/:code', authenticate, requirePermission('settings.manage'), validateParams(codeParam), validateBody(moduleEnabledBody), async (_req: Request, res: Response) => {
     try {
-      const { code } = req.params;
+      const { code } = res.locals.params;
       const { isEnabled } = res.locals.body;
       const updated = await moduleService.setEnabled(code, isEnabled);
       res.json({ success: true, data: updated, message: `Module '${code}' ${isEnabled ? 'enabled' : 'disabled'}` });

--- a/backend/src/routes/notifications.ts
+++ b/backend/src/routes/notifications.ts
@@ -12,6 +12,8 @@
 import { Pool } from 'mysql2/promise';
 import { Router, Request, Response } from 'express';
 import { authenticate, requireModule } from '../middleware/auth';
+import { validateParams } from '../middleware/validation';
+import { idParam } from '../schemas';
 import { NotificationService } from '../services/NotificationService';
 import { logger } from '../config/logger';
 
@@ -46,9 +48,9 @@ export const createNotificationsRouter = (pool: Pool): Router => {
     }
   });
 
-  router.patch('/:id/read', async (req: Request, res: Response) => {
+  router.patch('/:id/read', validateParams(idParam), async (req: Request, res: Response) => {
     try {
-      const ok = await service.markRead(Number(req.params.id), req.user!.id);
+      const ok = await service.markRead(res.locals.params.id, req.user!.id);
       if (!ok) {
         res.status(404).json({
           success: false,

--- a/backend/src/routes/onCall.ts
+++ b/backend/src/routes/onCall.ts
@@ -18,7 +18,7 @@ import { Pool } from 'mysql2/promise';
 import { Router, Request, Response } from 'express';
 import { authenticate, requirePermission } from '../middleware/auth';
 import { validateParams, validateBody } from '../middleware/validation';
-import { idParam, createOnCallPeriodBody, updateOnCallPeriodBody, onCallAssignBody } from '../schemas';
+import { idParam, idAndUserIdParam, createOnCallPeriodBody, updateOnCallPeriodBody, onCallAssignBody } from '../schemas';
 import { OnCallService } from '../services/OnCallService';
 import { logger } from '../config/logger';
 
@@ -127,9 +127,9 @@ export const createOnCallRouter = (pool: Pool): Router => {
     }
   });
 
-  router.delete('/periods/:id/assign/:userId', requirePermission('oncall.manage'), async (req: Request, res: Response) => {
+  router.delete('/periods/:id/assign/:userId', requirePermission('oncall.manage'), validateParams(idAndUserIdParam), async (_req: Request, res: Response) => {
     try {
-      const ok = await service.unassign(Number(req.params.id), Number(req.params.userId));
+      const ok = await service.unassign(res.locals.params.id, res.locals.params.userId);
       if (!ok) return error(res, 404, 'NOT_FOUND', 'Assignment not found');
       res.json({ success: true });
     } catch (err) {

--- a/backend/src/routes/org.ts
+++ b/backend/src/routes/org.ts
@@ -62,9 +62,9 @@ export const createOrgRouter = (pool: Pool): Router => {
     }
   });
 
-  router.get('/units/:id', async (req: Request, res: Response) => {
+  router.get('/units/:id', validateParams(idParam), async (_req: Request, res: Response) => {
     try {
-      const u = await units.getById(Number(req.params.id));
+      const u = await units.getById(res.locals.params.id);
       if (!u) return respondError(res, 404, 'NOT_FOUND', 'Org unit not found');
       res.json({ success: true, data: u });
     } catch (err) {
@@ -108,12 +108,12 @@ export const createOrgRouter = (pool: Pool): Router => {
     }
   });
 
-  router.delete('/units/:id', requirePermission('org_unit.manage'), async (req: Request, res: Response) => {
+  router.delete('/units/:id', requirePermission('org_unit.manage'), validateParams(idParam), async (req: Request, res: Response) => {
     try {
-      await units.remove(Number(req.params.id));
+      await units.remove(res.locals.params.id);
       await audit.write({
         actorId: req.user!.id, action: 'org_unit.delete',
-        entityType: 'org_unit', entityId: Number(req.params.id),
+        entityType: 'org_unit', entityId: res.locals.params.id,
       });
       res.json({ success: true });
     } catch (err) {
@@ -125,9 +125,9 @@ export const createOrgRouter = (pool: Pool): Router => {
 
   // ------------- Memberships -------------
 
-  router.get('/units/:id/members', async (req: Request, res: Response) => {
+  router.get('/units/:id/members', validateParams(idParam), async (_req: Request, res: Response) => {
     try {
-      res.json({ success: true, data: await units.listMembers(Number(req.params.id)) });
+      res.json({ success: true, data: await units.listMembers(res.locals.params.id) });
     } catch (err) {
       logger.error('members list failed', err);
       respondError(res, 500, 'INTERNAL_ERROR', 'Failed to list members');
@@ -216,9 +216,9 @@ export const createOrgRouter = (pool: Pool): Router => {
     }
   });
 
-  router.post('/loans/:id/approve', requirePermission('loan.approve'), validateBody(optionalNotesBody), async (req: Request, res: Response) => {
+  router.post('/loans/:id/approve', requirePermission('loan.approve'), validateParams(idParam), validateBody(optionalNotesBody), async (req: Request, res: Response) => {
     try {
-      const updated = await loans.approve(Number(req.params.id), req.user!.id, (res.locals.body.notes as string | null | undefined) ?? null);
+      const updated = await loans.approve(res.locals.params.id, req.user!.id, (res.locals.body.notes as string | null | undefined) ?? null);
       res.json({ success: true, data: updated });
     } catch (err) {
       const msg = (err as Error).message;
@@ -230,9 +230,9 @@ export const createOrgRouter = (pool: Pool): Router => {
     }
   });
 
-  router.post('/loans/:id/reject', requirePermission('loan.approve'), validateBody(optionalNotesBody), async (req: Request, res: Response) => {
+  router.post('/loans/:id/reject', requirePermission('loan.approve'), validateParams(idParam), validateBody(optionalNotesBody), async (req: Request, res: Response) => {
     try {
-      const updated = await loans.reject(Number(req.params.id), req.user!.id, (res.locals.body.notes as string | null | undefined) ?? null);
+      const updated = await loans.reject(res.locals.params.id, req.user!.id, (res.locals.body.notes as string | null | undefined) ?? null);
       res.json({ success: true, data: updated });
     } catch (err) {
       const msg = (err as Error).message;
@@ -244,9 +244,9 @@ export const createOrgRouter = (pool: Pool): Router => {
     }
   });
 
-  router.post('/loans/:id/cancel', async (req: Request, res: Response) => {
+  router.post('/loans/:id/cancel', validateParams(idParam), async (req: Request, res: Response) => {
     try {
-      const updated = await loans.cancel(Number(req.params.id), req.user!.id);
+      const updated = await loans.cancel(res.locals.params.id, req.user!.id);
       res.json({ success: true, data: updated });
     } catch (err) {
       const msg = (err as Error).message;

--- a/backend/src/routes/policies.ts
+++ b/backend/src/routes/policies.ts
@@ -22,8 +22,8 @@
 import { Pool } from 'mysql2/promise';
 import { Router, Request, Response } from 'express';
 import { authenticate, requirePermission, userHasPermission } from '../middleware/auth';
-import { validateBody } from '../middleware/validation';
-import { createPolicyExceptionBody, createPolicyBody, updatePolicyBody, validateAssignmentBody, updateApprovalMatrixBody, optionalNotesBody } from '../schemas';
+import { validateBody, validateParams } from '../middleware/validation';
+import { createPolicyExceptionBody, createPolicyBody, updatePolicyBody, validateAssignmentBody, updateApprovalMatrixBody, optionalNotesBody, idParam, changeTypeParam } from '../schemas';
 import { PolicyService } from '../services/PolicyService';
 import { PolicyExceptionService } from '../services/PolicyExceptionService';
 import { ApprovalMatrixService } from '../services/ApprovalMatrixService';
@@ -72,9 +72,9 @@ export const createPoliciesRouter = (pool: Pool): Router => {
     }
   });
 
-  router.put('/approval-matrix/:changeType', requirePermission('approval.manage'), validateBody(updateApprovalMatrixBody), async (req: Request, res: Response) => {
+  router.put('/approval-matrix/:changeType', requirePermission('approval.manage'), validateParams(changeTypeParam), validateBody(updateApprovalMatrixBody), async (_req: Request, res: Response) => {
     try {
-      const updated = await matrix.update(req.params.changeType, res.locals.body);
+      const updated = await matrix.update(res.locals.params.changeType, res.locals.body);
       res.json({ success: true, data: updated });
     } catch (err) {
       const msg = (err as Error).message;
@@ -121,10 +121,10 @@ export const createPoliciesRouter = (pool: Pool): Router => {
     }
   });
 
-  router.post('/exceptions/:id/approve', requirePermission('policy.approve'), validateBody(optionalNotesBody), async (req: Request, res: Response) => {
+  router.post('/exceptions/:id/approve', requirePermission('policy.approve'), validateParams(idParam), validateBody(optionalNotesBody), async (req: Request, res: Response) => {
     try {
       const updated = await exceptions.approve(
-        Number(req.params.id),
+        res.locals.params.id,
         req.user!.id,
         (res.locals.body.notes as string | null | undefined) ?? null
       );
@@ -136,10 +136,10 @@ export const createPoliciesRouter = (pool: Pool): Router => {
     }
   });
 
-  router.post('/exceptions/:id/reject', requirePermission('policy.approve'), validateBody(optionalNotesBody), async (req: Request, res: Response) => {
+  router.post('/exceptions/:id/reject', requirePermission('policy.approve'), validateParams(idParam), validateBody(optionalNotesBody), async (req: Request, res: Response) => {
     try {
       const updated = await exceptions.reject(
-        Number(req.params.id),
+        res.locals.params.id,
         req.user!.id,
         (res.locals.body.notes as string | null | undefined) ?? null
       );
@@ -151,9 +151,9 @@ export const createPoliciesRouter = (pool: Pool): Router => {
     }
   });
 
-  router.post('/exceptions/:id/cancel', async (req: Request, res: Response) => {
+  router.post('/exceptions/:id/cancel', validateParams(idParam), async (req: Request, res: Response) => {
     try {
-      const updated = await exceptions.cancel(Number(req.params.id), req.user!.id);
+      const updated = await exceptions.cancel(res.locals.params.id, req.user!.id);
       res.json({ success: true, data: updated });
     } catch (err) {
       const msg = (err as Error).message;
@@ -174,9 +174,9 @@ export const createPoliciesRouter = (pool: Pool): Router => {
     }
   });
 
-  router.get('/:id', async (req: Request, res: Response) => {
+  router.get('/:id', validateParams(idParam), async (_req: Request, res: Response) => {
     try {
-      const p = await policies.getById(Number(req.params.id));
+      const p = await policies.getById(res.locals.params.id);
       if (!p) return respondError(res, 404, 'NOT_FOUND', 'Policy not found');
       res.json({ success: true, data: p });
     } catch (err) {
@@ -206,15 +206,15 @@ export const createPoliciesRouter = (pool: Pool): Router => {
     }
   });
 
-  router.put('/:id', requirePermission('policy.manage'), validateBody(updatePolicyBody), async (req: Request, res: Response) => {
+  router.put('/:id', requirePermission('policy.manage'), validateParams(idParam), validateBody(updatePolicyBody), async (req: Request, res: Response) => {
     try {
-      const existing = await policies.getById(Number(req.params.id));
+      const existing = await policies.getById(res.locals.params.id);
       if (!existing) return respondError(res, 404, 'NOT_FOUND', 'Policy not found');
       // Only the owner or a full administrator may edit a policy directly.
       if (existing.imposedByUserId !== req.user!.id && !userHasPermission(req.user, 'settings.manage')) {
         return respondError(res, 403, 'FORBIDDEN', 'Only the policy owner or an administrator may edit this policy');
       }
-      const updated = await policies.update(Number(req.params.id), res.locals.body);
+      const updated = await policies.update(res.locals.params.id, res.locals.body);
       await audit.write({
         actorId: req.user!.id, action: 'policy.update',
         entityType: 'policy', entityId: updated.id,
@@ -229,17 +229,17 @@ export const createPoliciesRouter = (pool: Pool): Router => {
     }
   });
 
-  router.delete('/:id', requirePermission('policy.manage'), async (req: Request, res: Response) => {
+  router.delete('/:id', requirePermission('policy.manage'), validateParams(idParam), async (req: Request, res: Response) => {
     try {
-      const existing = await policies.getById(Number(req.params.id));
+      const existing = await policies.getById(res.locals.params.id);
       if (!existing) return respondError(res, 404, 'NOT_FOUND', 'Policy not found');
       if (existing.imposedByUserId !== req.user!.id && !userHasPermission(req.user, 'settings.manage')) {
         return respondError(res, 403, 'FORBIDDEN', 'Only the policy owner or an administrator may delete this policy');
       }
-      await policies.remove(Number(req.params.id));
+      await policies.remove(res.locals.params.id);
       await audit.write({
         actorId: req.user!.id, action: 'policy.delete',
-        entityType: 'policy', entityId: Number(req.params.id),
+        entityType: 'policy', entityId: res.locals.params.id,
         before: { key: existing.policyKey, value: existing.policyValue },
       });
       res.json({ success: true });

--- a/backend/src/routes/reports.ts
+++ b/backend/src/routes/reports.ts
@@ -7,6 +7,8 @@
 import { Pool } from 'mysql2/promise';
 import { Router, Request, Response } from 'express';
 import { authenticate, requirePermission, requireModule } from '../middleware/auth';
+import { validateParams } from '../middleware/validation';
+import { scheduleIdParam } from '../schemas';
 import { ReportsService } from '../services/ReportsService';
 import { logger } from '../config/logger';
 
@@ -51,13 +53,9 @@ export const createReportsRouter = (pool: Pool): Router => {
     }
   });
 
-  router.get('/fairness/:scheduleId', async (req: Request, res: Response) => {
+  router.get('/fairness/:scheduleId', validateParams(scheduleIdParam), async (_req: Request, res: Response) => {
     try {
-      const scheduleId = parseInt(req.params.scheduleId, 10);
-      if (isNaN(scheduleId) || scheduleId <= 0) {
-        return respondError(res, 400, 'VALIDATION_ERROR', 'scheduleId must be a positive integer');
-      }
-      const data = await service.fairnessForSchedule(scheduleId);
+      const data = await service.fairnessForSchedule(res.locals.params.scheduleId);
       res.json({ success: true, data });
     } catch (err) {
       logger.error('reports error:', err);

--- a/backend/src/routes/settings.ts
+++ b/backend/src/routes/settings.ts
@@ -17,8 +17,8 @@ import { Router } from 'express';
 import { Pool } from 'mysql2/promise';
 import { SystemSettingsService } from '../services/SystemSettingsService';
 import { authenticate, userHasPermission } from '../middleware/auth';
-import { validateBody } from '../middleware/validation';
-import { updateCurrencyBody, updateTimePeriodBody, updateSettingValueBody } from '../schemas';
+import { validateBody, validateParams } from '../middleware/validation';
+import { updateCurrencyBody, updateTimePeriodBody, updateSettingValueBody, categoryParam, categoryKeyParam } from '../schemas';
 import { logger } from '../config/logger';
 
 export const createSystemSettingsRouter = (pool: Pool) => {
@@ -44,9 +44,9 @@ export const createSystemSettingsRouter = (pool: Pool) => {
   });
 
   // Get settings by category
-  router.get('/category/:category', authenticate, async (req, res) => {
+  router.get('/category/:category', authenticate, validateParams(categoryParam), async (_req, res) => {
     try {
-      const { category } = req.params;
+      const { category } = res.locals.params;
       const settings = await settingsService.getSettingsByCategory(category);
 
       res.json({
@@ -157,9 +157,9 @@ export const createSystemSettingsRouter = (pool: Pool) => {
   });
 
   // Get specific setting value
-  router.get('/:category/:key', authenticate, async (req, res) => {
+  router.get('/:category/:key', authenticate, validateParams(categoryKeyParam), async (_req, res) => {
     try {
-      const { category, key } = req.params;
+      const { category, key } = res.locals.params;
       const value = await settingsService.getSetting(category, key);
 
       if (value === null) {
@@ -183,7 +183,7 @@ export const createSystemSettingsRouter = (pool: Pool) => {
   });
 
   // Update setting value (admin only)
-  router.put('/:category/:key', authenticate, validateBody(updateSettingValueBody), async (req, res) => {
+  router.put('/:category/:key', authenticate, validateParams(categoryKeyParam), validateBody(updateSettingValueBody), async (req, res) => {
     try {
       const user = req.user!;
 
@@ -195,7 +195,7 @@ export const createSystemSettingsRouter = (pool: Pool) => {
         });
       }
 
-      const { category, key } = req.params;
+      const { category, key } = res.locals.params;
       const { value } = res.locals.body;
 
       // Validate specific settings
@@ -249,7 +249,7 @@ export const createSystemSettingsRouter = (pool: Pool) => {
   });
 
   // Reset setting to default value (admin only)
-  router.post('/:category/:key/reset', authenticate, async (req, res) => {
+  router.post('/:category/:key/reset', authenticate, validateParams(categoryKeyParam), async (req, res) => {
     try {
       const user = req.user!;
 
@@ -261,7 +261,7 @@ export const createSystemSettingsRouter = (pool: Pool) => {
         });
       }
 
-      const { category, key } = req.params;
+      const { category, key } = res.locals.params;
       const reset = await settingsService.resetSetting(category, key);
 
       if (!reset) {

--- a/backend/src/routes/shiftSwap.ts
+++ b/backend/src/routes/shiftSwap.ts
@@ -7,8 +7,8 @@
 import { Pool } from 'mysql2/promise';
 import { Router, Request, Response } from 'express';
 import { authenticate, requirePermission, userHasPermission } from '../middleware/auth';
-import { validateBody } from '../middleware/validation';
-import { createShiftSwapBody, optionalNotesBody } from '../schemas';
+import { validateBody, validateParams } from '../middleware/validation';
+import { createShiftSwapBody, optionalNotesBody, idParam } from '../schemas';
 import { ShiftSwapService } from '../services/ShiftSwapService';
 import { logger } from '../config/logger';
 
@@ -54,9 +54,9 @@ export const createShiftSwapRouter = (pool: Pool): Router => {
     }
   });
 
-  router.get('/:id', async (req: Request, res: Response) => {
+  router.get('/:id', validateParams(idParam), async (req: Request, res: Response) => {
     try {
-      const id = Number(req.params.id);
+      const { id } = res.locals.params;
       const item = await service.getById(id);
       if (!item) return respondError(res, 404, 'NOT_FOUND', 'Shift swap request not found');
       const involves =
@@ -70,9 +70,9 @@ export const createShiftSwapRouter = (pool: Pool): Router => {
     }
   });
 
-  router.post('/:id/approve', requirePermission('shiftswap.approve'), validateBody(optionalNotesBody), async (req: Request, res: Response) => {
+  router.post('/:id/approve', requirePermission('shiftswap.approve'), validateParams(idParam), validateBody(optionalNotesBody), async (req: Request, res: Response) => {
     try {
-      const id = Number(req.params.id);
+      const { id } = res.locals.params;
       const updated = await service.approve(id, req.user!.id, (res.locals.body.notes as string | null | undefined) ?? null);
       res.json({ success: true, data: updated });
     } catch (err) {
@@ -82,9 +82,9 @@ export const createShiftSwapRouter = (pool: Pool): Router => {
     }
   });
 
-  router.post('/:id/decline', requirePermission('shiftswap.approve'), validateBody(optionalNotesBody), async (req: Request, res: Response) => {
+  router.post('/:id/decline', requirePermission('shiftswap.approve'), validateParams(idParam), validateBody(optionalNotesBody), async (req: Request, res: Response) => {
     try {
-      const id = Number(req.params.id);
+      const { id } = res.locals.params;
       const updated = await service.decline(id, req.user!.id, (res.locals.body.notes as string | null | undefined) ?? null);
       res.json({ success: true, data: updated });
     } catch (err) {
@@ -94,9 +94,9 @@ export const createShiftSwapRouter = (pool: Pool): Router => {
     }
   });
 
-  router.post('/:id/cancel', async (req: Request, res: Response) => {
+  router.post('/:id/cancel', validateParams(idParam), async (req: Request, res: Response) => {
     try {
-      const id = Number(req.params.id);
+      const { id } = res.locals.params;
       const updated = await service.cancel(id, req.user!.id);
       res.json({ success: true, data: updated });
     } catch (err) {

--- a/backend/src/routes/timeOff.ts
+++ b/backend/src/routes/timeOff.ts
@@ -14,8 +14,8 @@
 import { Pool } from 'mysql2/promise';
 import { Router, Request, Response } from 'express';
 import { authenticate, requirePermission, userHasPermission } from '../middleware/auth';
-import { validateBody } from '../middleware/validation';
-import { createTimeOffBody, optionalNotesBody } from '../schemas';
+import { validateBody, validateParams } from '../middleware/validation';
+import { createTimeOffBody, optionalNotesBody, idParam } from '../schemas';
 import { TimeOffService } from '../services/TimeOffService';
 import { logger } from '../config/logger';
 
@@ -62,9 +62,9 @@ export const createTimeOffRouter = (pool: Pool): Router => {
     }
   });
 
-  router.get('/:id', async (req: Request, res: Response) => {
+  router.get('/:id', validateParams(idParam), async (req: Request, res: Response) => {
     try {
-      const id = Number(req.params.id);
+      const { id } = res.locals.params;
       const item = await service.getById(id);
       if (!item) return respondError(res, 404, 'NOT_FOUND', 'Time-off request not found');
       const isOwn = item.userId === req.user!.id;
@@ -77,9 +77,9 @@ export const createTimeOffRouter = (pool: Pool): Router => {
     }
   });
 
-  router.post('/:id/approve', requirePermission('timeoff.approve'), validateBody(optionalNotesBody), async (req: Request, res: Response) => {
+  router.post('/:id/approve', requirePermission('timeoff.approve'), validateParams(idParam), validateBody(optionalNotesBody), async (req: Request, res: Response) => {
     try {
-      const id = Number(req.params.id);
+      const { id } = res.locals.params;
       const updated = await service.approve(id, req.user!.id, (res.locals.body.notes as string | null | undefined) ?? null);
       res.json({ success: true, data: updated });
     } catch (err) {
@@ -89,9 +89,9 @@ export const createTimeOffRouter = (pool: Pool): Router => {
     }
   });
 
-  router.post('/:id/reject', requirePermission('timeoff.approve'), validateBody(optionalNotesBody), async (req: Request, res: Response) => {
+  router.post('/:id/reject', requirePermission('timeoff.approve'), validateParams(idParam), validateBody(optionalNotesBody), async (req: Request, res: Response) => {
     try {
-      const id = Number(req.params.id);
+      const { id } = res.locals.params;
       const updated = await service.reject(id, req.user!.id, (res.locals.body.notes as string | null | undefined) ?? null);
       res.json({ success: true, data: updated });
     } catch (err) {
@@ -101,9 +101,9 @@ export const createTimeOffRouter = (pool: Pool): Router => {
     }
   });
 
-  router.post('/:id/cancel', async (req: Request, res: Response) => {
+  router.post('/:id/cancel', validateParams(idParam), async (req: Request, res: Response) => {
     try {
-      const id = Number(req.params.id);
+      const { id } = res.locals.params;
       const updated = await service.cancel(id, req.user!.id);
       res.json({ success: true, data: updated });
     } catch (err) {

--- a/backend/src/schemas/index.ts
+++ b/backend/src/schemas/index.ts
@@ -12,6 +12,15 @@ export const departmentIdParam = z.object({ departmentId: positiveInt });
 export const idAndSkillIdParam = z.object({ id: positiveInt, skillId: positiveInt });
 export const idAndUserIdParam = z.object({ id: positiveInt, userId: positiveInt });
 
+const shortString = z.string().min(1).max(64);
+
+export const idAndKeyParam = z.object({ id: positiveInt, key: z.string().min(1).max(128) });
+export const codeParam = z.object({ code: shortString });
+export const typeParam = z.object({ type: shortString });
+export const changeTypeParam = z.object({ changeType: shortString });
+export const categoryParam = z.object({ category: shortString });
+export const categoryKeyParam = z.object({ category: shortString, key: z.string().min(1).max(128) });
+
 // ── Body schemas ──────────────────────────────────────────────────────────────
 
 export const createUserBody = z.object({


### PR DESCRIPTION
## Summary

Latest project-review pass flagged 36 route handlers that still parsed path parameters with `Number()` / `parseInt` instead of the documented `validateParams` + Zod convention, plus missing error handling in the calendar routes.

- Apply `validateParams` to every remaining `:id`-style route (time-off, shift-swap, notifications, directory, org, policies, on-call, calendar, reports, modules, settings, approval-workflows), so malformed ids return `400 VALIDATION_ERROR` instead of leaking `NaN` into service-layer SQL.
- Add bounded string param schemas (`codeParam`, `typeParam`, `changeTypeParam`, `categoryParam`, `categoryKeyParam`, `idAndKeyParam`) for non-numeric params.
- Wrap the four calendar route handlers in try/catch: a rejected promise previously left the request hanging with no response (Express 4 does not forward async rejections).

No endpoint paths or success shapes changed, so `openapi.json` needs no update (the spec does not enumerate per-endpoint 400 responses for already-validated routes either).

## Test plan
- `npm run build` (backend) — clean
- `npm run lint` (backend) — clean
- `npm test` — 104 suites, 1655 tests pass