### PR TITLE
feat: calendar feed UI and shift-swap notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,83 +11,201 @@ constraint-programming optimizer in Python (Google OR-Tools CP-SAT).
 
 ## Features
 
-### Scheduling core
+### 1. Schedules and shifts
 
 - **Schedules** — create, duplicate, and publish schedules per department
-  and date range; lifecycle states (`draft` → `published`).
-- **Shifts and templates** — per-day shifts with start/end time, min/max
-  staffing, required skills, and reusable shift templates.
-- **Assignments** — assign users to shifts with full validation
-  (double-booking, skill match, availability); employees confirm,
-  decline, or complete their own assignments.
-- **Automatic scheduling** — two interchangeable engines: a greedy
-  TypeScript solver (zero dependencies, default) and a Google OR-Tools
-  CP-SAT solver (optional, Python) with hard constraints (coverage,
-  no double-booking, skills, availability, weekly hour caps) and soft
-  constraints (preferences, fairness, rest time, consecutive-day caps).
-- **Policies and exceptions** — configurable scheduling policies
-  (global, department, or user scope) with a request/approve/reject
-  workflow for one-off exceptions and a per-change-type approval matrix.
-- **Shift swaps** — employee-to-employee swap requests with manager
-  approval, decline, and requester cancellation.
-- **Time off** — request types with manager approval/rejection and
-  requester cancellation; honoured by the scheduling engines.
+  and date range; lifecycle states (`draft` → `published` → `archived`).
+- **Shift templates** — reusable shift definitions (time window, min/max
+  staffing, required skills) that can be applied when building a schedule.
+- **Shifts** — per-day instances created from templates or manually, each
+  declaring start/end time, min/max headcount, and required skill set.
+- **Assignments** — assign employees to shifts with full pre-assignment
+  validation: double-booking, skill match, availability, compliance rules.
+  Employees confirm, decline, or mark their own assignments complete.
+- **Bulk assignment** — create multiple assignments in a single request
+  with per-row validation and error reporting.
 - **On-call rotations** — on-call periods per department with capacity
   limits and per-user assignment.
 
-### Workforce management
+### 2. Automatic scheduling (optimizer)
 
-- **Employees and departments** — CRUD with skills, hourly rates,
-  multi-department membership, and per-department managers.
+Two interchangeable engines behind the same REST endpoint
+(`POST /api/schedules/:id/generate`):
+
+| Engine | Language | Dependency |
+|---|---|---|
+| Greedy TypeScript solver | TypeScript | none (default) |
+| Google OR-Tools CP-SAT solver | Python 3.8+ | `pip install ortools` |
+
+Both engines honour:
+
+- **Hard constraints** — shift coverage requirements, no double-booking,
+  skill requirements, declared availability, weekly hour caps.
+- **Soft constraints** — employee preferences, workload fairness, minimum
+  rest time between shifts, consecutive-day caps.
+
+Switch engines at runtime with `OPTIMIZATION_ENGINE=or-tools` in
+`backend/.env`. Constraint weights are configurable at call site.
+
+### 3. Employee requests and approvals
+
+- **Time off** — employees submit requests (vacation, sick, personal,
+  other); managers approve or reject with optional notes; requesters may
+  cancel while still pending. The optimizer and manual assignment
+  validator both respect approved time off.
+- **Shift swaps** — employee-to-employee swap requests; manager approves
+  or declines; requester may cancel while pending. Approval runs
+  compliance checks on both sides and atomically rewrites the
+  `user_id` on both assignments. Both parties receive an in-app
+  notification on approval or decline.
+- **Policy exceptions** — one-off exception requests against scheduling
+  policies, routed through the configurable approval matrix.
+
+### 4. Workforce management
+
+- **Employees** — full CRUD with skills, hourly rates, position,
+  employee ID, phone; activate/deactivate without deleting the record.
+- **Departments** — create and manage departments; assign a manager;
+  track multi-department membership.
 - **Organizational units** — arbitrary org tree (forest) with
-  memberships, primary-unit designation, and org-scoped permissions.
-- **Employee loans** — temporary transfer of an employee between org
-  units with an approval workflow.
-- **User directory** — profiles with custom fields, vCard export
-  (single user or bulk) and vCard import.
+  memberships, primary-unit designation, and org-unit-scoped
+  permissions; supports manager chains for approval routing.
+- **Employee loans** — temporary cross-unit transfer with start/end
+  dates, reason, and an approval workflow.
+- **User directory** — profiles with unlimited custom fields; vCard
+  export (single user or bulk ZIP) and vCard import; contact-book
+  integration with any vCard-compatible app.
 - **Skill gap analysis** — per-department comparison of required vs
-  available skills.
-- **Bulk import** — CSV import for users and shifts with per-row
-  validation and error reporting.
+  available skills, surfaced as a coverage report.
+- **Bulk import** — CSV import for employees and shifts with per-row
+  validation and structured error reporting.
 
-### Security and governance
+### 5. Security and access control
 
-- **Authentication** — JWT in httpOnly cookies (never exposed to JS),
-  bcrypt password hashing, login rate limiting, server-side token
-  revocation on logout.
-- **Two-factor authentication** — TOTP (RFC 6238) with QR provisioning
-  and single-use recovery codes, enforced at login when enabled.
+- **Authentication** — JWT in httpOnly cookies (never exposed to
+  JavaScript); bcrypt password hashing (configurable rounds); login
+  rate limiting; server-side token revocation on logout.
+- **Two-factor authentication (2FA)** — TOTP (RFC 6238) with QR-code
+  provisioning and single-use recovery codes; enforced at login when
+  enabled on the account.
 - **RBAC** — fully configurable roles and permission codes; permissions
-  are resolved from the database on every request, so changes take
-  effect immediately; org-unit scoping restricts data visibility.
+  are resolved from the database on every request (no stale token
+  state); org-unit scoping restricts data visibility to the user's
+  assigned units.
 - **Delegations** — temporary, expiring transfer of a user's roles to
-  another user (e.g. vacation cover).
-- **Approval workflows** — multi-step, configurable approval chains per
-  change type, with escalation for overdue steps.
-- **Audit trail** — append-only audit log of privileged actions with
-  filterable querying.
+  another user (e.g. vacation cover); automatically expires without
+  manual cleanup.
+- **Audit trail** — append-only audit log of privileged actions
+  (who, what, when) with filterable querying for compliance and
+  investigation.
 - **Module system** — runtime feature flags: disabled modules return
-  404 on their whole route subtree and disappear from the UI.
+  404 on their entire route subtree and disappear from the SPA menu.
 
-### Integrations and UX
+### 6. Approval workflows
 
-- **Dashboard** — live KPIs (headcount, coverage, monthly hours/cost,
-  pending approvals), recent activity, upcoming shifts.
-- **Reports** — hours worked per user, cost by department, fairness
-  metrics per schedule.
-- **Notifications** — in-app notification center with unread badge.
-- **Real-time events** — Server-Sent Events stream for live UI updates.
-- **Calendar feeds** — personal and per-department iCal feeds
-  (token-protected, ETag-cached) for Google Calendar / Outlook / Apple
-  Calendar.
-- **Preferences** — per-user scheduling preferences consumed by the
-  optimizer.
+- **Configurable chains** — multi-step approval sequences defined per
+  change type (time-off, shift swap, policy exception, employee loan).
+- **Approver scopes** — `direct_manager`, `department_head`,
+  `hr_manager`, `company_user`, `role_based`, `unit_manager_chain`.
+- **Auto-approve** — steps can be set to auto-approve when the actor
+  is the policy owner, cutting out unnecessary approval hops.
+- **Escalation** — steps that remain un-actioned past a configurable
+  deadline are automatically escalated.
+- **Approval matrix** — per-change-type matrix mapping change types to
+  approver scope; updatable at runtime without code changes.
+
+### 7. Notifications and real-time updates
+
+- **In-app notifications** — notification center with unread badge;
+  events include assignment created, shift swap approved/declined,
+  time-off approved/rejected, loan approved/rejected, and more.
+- **Real-time events (SSE)** — Server-Sent Events stream
+  (`GET /api/events/stream`) pushes live updates to the SPA without
+  polling; no WebSocket dependency.
+
+### 8. Calendar integration
+
+Employees can subscribe to their personal shift schedule directly in
+any calendar app that supports iCal (Google Calendar, Apple Calendar,
+Outlook, Thunderbird, etc.).
+
+**How it works:**
+
+1. The employee generates a personal calendar token in
+   **Settings → Calendar** (`POST /api/calendar/token`).
+2. The token-protected iCal feed URL is displayed and can be copied
+   with one click:
+   ```
+   GET /api/calendar/feed.ics?token=<token>
+   ```
+3. Paste the URL as a new subscribed/internet calendar in the calendar
+   app of choice. The server responds with `ETag` and
+   `Cache-Control: private, max-age=300`; clients that support
+   `If-None-Match` skip re-downloading the feed when nothing has
+   changed.
+4. The feed updates automatically as assignments change — no manual
+   refresh or re-subscription needed.
+
+**Minimum refresh interval by client:**
+
+| Client | Minimum achievable refresh |
+|---|---|
+| Google Calendar | ~12–24 h (enforced server-side by Google, not configurable by the user) |
+| Apple Calendar (macOS/iOS) | 5 min (set "Auto-refresh: Every 5 minutes" in subscription settings) |
+| Outlook desktop | 15–30 min (configurable in Calendar Properties → Update Limit) |
+| Thunderbird | 1 min (configurable in calendar properties) |
+
+> The iCal protocol is poll-based. For instant in-app updates, the
+> SPA uses the SSE stream instead (see §7 above).
+
+**Department feed** (managers and administrators only):
+```
+GET /api/calendar/department/:id.ics?token=<token>
+```
+Aggregates all shifts for a department into a single iCal feed. The
+token's owner must hold `settings.manage` or be the manager of the
+target department.
+
+**Token rotation:** tokens are non-expiring but can be rotated at any
+time (**Settings → Calendar → Rotate token**). Rotating invalidates
+the old URL — any existing calendar subscriptions must be updated with
+the new URL.
+
+### 9. Reports and analytics
+
+- **Dashboard** — live KPIs: active headcount, open schedules, today's
+  shifts, pending approvals, monthly hours, monthly cost, coverage
+  rate. Panels for recent audit activity and upcoming shifts.
+- **Hours report** — hours worked per employee for a selected schedule
+  or date range.
+- **Cost report** — cost by department, computed from shift hours ×
+  hourly rate.
+- **Fairness report** — per-schedule workload distribution metrics used
+  to evaluate optimizer fairness.
+
+### 10. Employee preferences
+
+Per-user scheduling constraints consumed by the optimizer:
+
+- `maxHoursPerWeek` / `minHoursPerWeek`
+- `maxConsecutiveDays`
+- `preferredShifts` — preferred shift templates
+- `avoidShifts` — shift templates to avoid
+- `notes` — free-text notes to the scheduler
+
+Preferences are stored in `user_preferences` and surfaced under
+**Settings → Work Preferences**.
+
+### 11. System and administration
+
 - **System settings** — runtime configuration (currency, default time
-  period, …) editable by administrators.
-- **API documentation** — OpenAPI 3.1 contract served via Swagger UI at
-  `/api/docs`.
-- **Frontend** — responsive React SPA with light/dark theme, accessible
-  tables and forms, error boundaries, and a demo-mode banner.
+  period) editable by administrators at `GET/PUT /api/settings`.
+- **API documentation** — full OpenAPI 3.1 contract served as Swagger
+  UI at `http://localhost:3001/api/docs` and as a static file at
+  `backend/openapi/openapi.json`.
+- **Frontend SPA** — responsive React 18 SPA with Bootstrap 5,
+  light/dark theme toggle, accessible tables and forms (ARIA labels,
+  keyboard navigation), React error boundaries, and a demo-mode banner.
 
 ## How it works
 

--- a/backend/src/__tests__/services.bulk.extended.test.ts
+++ b/backend/src/__tests__/services.bulk.extended.test.ts
@@ -11,6 +11,9 @@
 import { EmployeeService } from '../services/EmployeeService';
 import { OnCallService } from '../services/OnCallService';
 import { ShiftSwapService } from '../services/ShiftSwapService';
+import { NotificationService } from '../services/NotificationService';
+
+const noopNotifications = { notifyAsync: () => {} } as unknown as NotificationService;
 
 jest.mock('../services/UserService', () => {
   const actual = jest.requireActual('../services/UserService');
@@ -398,7 +401,7 @@ describe('ShiftSwapService', () => {
   it('create rejects when requester assignment missing', async () => {
     const { pool, conn } = makePool();
     conn.execute.mockResolvedValueOnce([[], null]);
-    const svc = new ShiftSwapService(pool);
+    const svc = new ShiftSwapService(pool, noopNotifications);
     await expect(
       svc.create({ requesterUserId: 1, requesterAssignmentId: 10, targetAssignmentId: 20 })
     ).rejects.toThrow(/Requester assignment not found/);
@@ -407,7 +410,7 @@ describe('ShiftSwapService', () => {
   it('create rejects when requester does not own the assignment', async () => {
     const { pool, conn } = makePool();
     conn.execute.mockResolvedValueOnce([[{ id: 10, user_id: 99 }], null]);
-    const svc = new ShiftSwapService(pool);
+    const svc = new ShiftSwapService(pool, noopNotifications);
     await expect(
       svc.create({ requesterUserId: 1, requesterAssignmentId: 10, targetAssignmentId: 20 })
     ).rejects.toThrow(/does not own/);
@@ -418,7 +421,7 @@ describe('ShiftSwapService', () => {
     conn.execute
       .mockResolvedValueOnce([[{ id: 10, user_id: 1 }], null])
       .mockResolvedValueOnce([[], null]);
-    const svc = new ShiftSwapService(pool);
+    const svc = new ShiftSwapService(pool, noopNotifications);
     await expect(
       svc.create({ requesterUserId: 1, requesterAssignmentId: 10, targetAssignmentId: 20 })
     ).rejects.toThrow(/Target assignment not found/);
@@ -438,7 +441,7 @@ describe('ShiftSwapService', () => {
       .mockResolvedValueOnce([[{ id: 20, user_id: 2 }], null])
       .mockResolvedValueOnce([{ insertId: 1 }, null]);
     execute.mockResolvedValueOnce([[swap], null] as Tuple);
-    const svc = new ShiftSwapService(pool);
+    const svc = new ShiftSwapService(pool, noopNotifications);
     const out = await svc.create({
       requesterUserId: 1,
       requesterAssignmentId: 10,
@@ -455,7 +458,7 @@ describe('ShiftSwapService', () => {
       .mockResolvedValueOnce([[{ id: 20, user_id: 2 }], null])
       .mockResolvedValueOnce([{ insertId: 1 }, null]);
     execute.mockResolvedValueOnce([[], null] as Tuple);
-    const svc = new ShiftSwapService(pool);
+    const svc = new ShiftSwapService(pool, noopNotifications);
     await expect(
       svc.create({ requesterUserId: 1, requesterAssignmentId: 10, targetAssignmentId: 20 })
     ).rejects.toThrow(/Failed to retrieve created swap/);
@@ -467,7 +470,7 @@ describe('ShiftSwapService', () => {
       .mockResolvedValueOnce([[swap], null] as Tuple)
       .mockResolvedValueOnce([[swap], null] as Tuple)
       .mockResolvedValueOnce([[swap], null] as Tuple);
-    const svc = new ShiftSwapService(pool);
+    const svc = new ShiftSwapService(pool, noopNotifications);
     expect((await svc.list()).length).toBe(1);
     expect((await svc.list({ userId: 1 })).length).toBe(1);
     expect((await svc.list({ userId: 1, status: 'pending' })).length).toBe(1);
@@ -476,7 +479,7 @@ describe('ShiftSwapService', () => {
   it('approve rolls back when not pending', async () => {
     const { pool, conn } = makePool();
     conn.execute.mockResolvedValueOnce([[{ ...swap, status: 'approved' }], null]);
-    const svc = new ShiftSwapService(pool);
+    const svc = new ShiftSwapService(pool, noopNotifications);
     await expect(svc.approve(1, 9)).rejects.toThrow(/Cannot approve swap/);
   });
 
@@ -488,7 +491,7 @@ describe('ShiftSwapService', () => {
         [{ assignment_id: 10, user_id: 1, date: '2026-05-10', start_time: '08', end_time: '16' }],
         null,
       ]);
-    const svc = new ShiftSwapService(pool);
+    const svc = new ShiftSwapService(pool, noopNotifications);
     await expect(svc.approve(1, 9)).rejects.toThrow(/One or both assignments are gone/);
   });
 
@@ -503,7 +506,7 @@ describe('ShiftSwapService', () => {
       ok: false,
       violations: [{ code: 'OVER_HOURS' }],
     });
-    const svc = new ShiftSwapService(pool);
+    const svc = new ShiftSwapService(pool, noopNotifications);
     await expect(svc.approve(1, 9)).rejects.toThrow(/Requester would violate/);
 
     conn.execute.mockResolvedValueOnce([[swap], null]).mockResolvedValueOnce([pair, null]);
@@ -541,7 +544,7 @@ describe('ShiftSwapService', () => {
       .mockResolvedValueOnce({ ok: true, violations: [] })
       .mockResolvedValueOnce({ ok: true, violations: [] });
     execute.mockResolvedValueOnce([[{ ...swap, status: 'approved' }], null] as Tuple);
-    const svc = new ShiftSwapService(pool);
+    const svc = new ShiftSwapService(pool, noopNotifications);
     const out = await svc.approve(1, 9, 'OK');
     expect(out.status).toBe('approved');
   });
@@ -563,7 +566,7 @@ describe('ShiftSwapService', () => {
       .mockResolvedValueOnce([[{ ...swap, requester_user_id: 999 }], null] as Tuple)
       .mockResolvedValueOnce([{ affectedRows: 0 }, null] as Tuple)
       .mockResolvedValueOnce([[{ ...swap, status: 'declined' }], null] as Tuple);
-    const svc = new ShiftSwapService(pool);
+    const svc = new ShiftSwapService(pool, noopNotifications);
     expect((await svc.decline(1, 9, 'no')).status).toBe('declined');
     await expect(svc.decline(1, 9)).rejects.toThrow(/not found/);
     await expect(svc.decline(1, 9)).rejects.toThrow(/Cannot decline swap/);

--- a/backend/src/services/ShiftSwapService.ts
+++ b/backend/src/services/ShiftSwapService.ts
@@ -56,8 +56,8 @@ const mapRow = (row: RowDataPacket): ShiftSwapRequest => ({
 export class ShiftSwapService {
   private notifications: NotificationService;
 
-  constructor(private pool: Pool) {
-    this.notifications = new NotificationService(pool);
+  constructor(private pool: Pool, notifications?: NotificationService) {
+    this.notifications = notifications ?? new NotificationService(pool);
   }
 
   /**

--- a/backend/src/services/ShiftSwapService.ts
+++ b/backend/src/services/ShiftSwapService.ts
@@ -12,6 +12,7 @@
 import { Pool, ResultSetHeader, RowDataPacket } from 'mysql2/promise';
 import { logger } from '../config/logger';
 import { evaluateAssignmentCompliance } from './ComplianceEngine';
+import { NotificationService } from './NotificationService';
 
 type SwapStatus = 'pending' | 'approved' | 'declined' | 'cancelled';
 
@@ -53,7 +54,11 @@ const mapRow = (row: RowDataPacket): ShiftSwapRequest => ({
 });
 
 export class ShiftSwapService {
-  constructor(private pool: Pool) {}
+  private notifications: NotificationService;
+
+  constructor(private pool: Pool) {
+    this.notifications = new NotificationService(pool);
+  }
 
   /**
    * Creates a pending swap request. Validates that the requester owns
@@ -235,6 +240,20 @@ export class ShiftSwapService {
     }
     const refreshed = await this.getById(id);
     if (!refreshed) throw new Error('Failed to retrieve approved swap');
+
+    this.notifications.notifyAsync({
+      userId: refreshed.requesterUserId,
+      type: 'shiftswap.approved',
+      title: 'Shift swap approved',
+      body: `Your shift swap request #${refreshed.id} has been approved.`,
+    });
+    this.notifications.notifyAsync({
+      userId: refreshed.targetUserId,
+      type: 'shiftswap.approved',
+      title: 'Shift swap approved',
+      body: `A shift swap request involving your assignment (#${refreshed.id}) has been approved.`,
+    });
+
     return refreshed;
   }
 
@@ -256,6 +275,14 @@ export class ShiftSwapService {
     }
     const refreshed = await this.getById(id);
     if (!refreshed) throw new Error('Failed to retrieve declined swap');
+
+    this.notifications.notifyAsync({
+      userId: refreshed.requesterUserId,
+      type: 'shiftswap.declined',
+      title: 'Shift swap declined',
+      body: `Your shift swap request #${refreshed.id} has been declined.`,
+    });
+
     return refreshed;
   }
 

--- a/frontend/src/pages/Settings/CalendarSection.tsx
+++ b/frontend/src/pages/Settings/CalendarSection.tsx
@@ -1,0 +1,259 @@
+/**
+ * CalendarSection — iCal feed management for the Settings page.
+ *
+ * Lets users generate and copy their personal calendar feed URL, rotate
+ * the token, and read per-client instructions for minimising the refresh
+ * interval so schedule changes appear as quickly as the client allows.
+ *
+ * @author Luca Ostinelli
+ */
+
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  getOrCreateCalendarToken,
+  rotateCalendarToken,
+  buildFeedUrl,
+} from '../../services/calendarService';
+
+const CLIENT_INSTRUCTIONS = [
+  {
+    name: 'Google Calendar',
+    icon: 'bi-google',
+    steps: [
+      'Open Google Calendar on the web.',
+      'Click the "+" next to "Other calendars" → "From URL".',
+      'Paste your feed URL and click "Add calendar".',
+    ],
+    refreshNote:
+      'Google Calendar refreshes subscribed calendars roughly every 12–24 hours. This interval cannot be shortened from the user side — it is enforced by Google\'s servers.',
+  },
+  {
+    name: 'Apple Calendar (macOS / iOS)',
+    icon: 'bi-apple',
+    steps: [
+      'macOS: File → New Calendar Subscription → paste the URL → click Subscribe.',
+      'iOS: Settings → Calendar → Accounts → Add Account → Other → Add Subscribed Calendar → paste the URL.',
+      'In the subscription options, set "Auto-refresh" to "Every 5 minutes" for the fastest supported interval.',
+    ],
+    refreshNote:
+      'Apple Calendar supports a minimum refresh of 5 minutes when set to "Every 5 minutes" in the subscription settings.',
+  },
+  {
+    name: 'Outlook (desktop / Microsoft 365)',
+    icon: 'bi-microsoft',
+    steps: [
+      'Open Outlook → Calendar view.',
+      'Home → Open Calendar → From Internet → paste the URL → click OK.',
+      'Right-click the new calendar → Calendar Properties → Update Limit → set to the shortest allowed interval.',
+    ],
+    refreshNote:
+      'Outlook desktop refreshes every 30 minutes by default; the minimum configurable interval is typically 15 minutes. Outlook.com (web) updates approximately every 24 hours and the interval cannot be changed.',
+  },
+  {
+    name: 'Thunderbird (Lightning / Calendar)',
+    icon: 'bi-envelope',
+    steps: [
+      'Calendar tab → New Calendar → On the Network → iCalendar (ICS) → paste the URL.',
+      'In the calendar properties, set "Refresh calendar every" to 1 minute for the minimum interval.',
+    ],
+    refreshNote:
+      'Thunderbird with the built-in calendar supports a minimum refresh of 1 minute.',
+  },
+];
+
+const CalendarSection: React.FC = () => {
+  const [token, setToken] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [rotating, setRotating] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const feedUrl = token ? buildFeedUrl(token) : null;
+
+  const loadToken = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await getOrCreateCalendarToken();
+      setToken(data.token);
+    } catch (err) {
+      setError((err as Error).message || 'Failed to load calendar token.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadToken();
+  }, [loadToken]);
+
+  const handleCopy = async () => {
+    if (!feedUrl) return;
+    try {
+      await navigator.clipboard.writeText(feedUrl);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setError('Failed to copy to clipboard.');
+    }
+  };
+
+  const handleRotate = async () => {
+    if (!window.confirm(
+      'Rotating the token invalidates the current URL. Any calendar subscriptions using the old URL will stop working until you re-subscribe with the new URL. Continue?'
+    )) return;
+    setRotating(true);
+    setError(null);
+    try {
+      const data = await rotateCalendarToken();
+      setToken(data.token);
+    } catch (err) {
+      setError((err as Error).message || 'Failed to rotate token.');
+    } finally {
+      setRotating(false);
+    }
+  };
+
+  return (
+    <div className="row">
+      <div className="col-lg-9">
+
+        {/* Feed URL card */}
+        <div className="card mb-4">
+          <div className="card-header d-flex align-items-center gap-2">
+            <i className="bi bi-calendar-event fs-5" aria-hidden="true"></i>
+            <h5 className="mb-0">Calendar Feed</h5>
+          </div>
+          <div className="card-body">
+            <p className="text-muted mb-3">
+              Subscribe to your personal shift calendar from any app that supports iCal
+              (Google Calendar, Apple Calendar, Outlook, Thunderbird, etc.).
+              The feed is token-protected and updates automatically whenever your
+              assignments change — no login required from the calendar app.
+            </p>
+
+            {error && (
+              <div className="alert alert-danger" role="alert">
+                <i className="bi bi-exclamation-triangle me-2" aria-hidden="true"></i>
+                {error}
+              </div>
+            )}
+
+            {loading ? (
+              <div className="d-flex align-items-center gap-2 text-muted">
+                <span className="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+                Loading…
+              </div>
+            ) : feedUrl ? (
+              <>
+                <label htmlFor="feed-url" className="form-label fw-semibold">Your feed URL</label>
+                <div className="input-group mb-3">
+                  <input
+                    id="feed-url"
+                    type="text"
+                    className="form-control font-monospace"
+                    value={feedUrl}
+                    readOnly
+                    aria-label="Calendar feed URL"
+                  />
+                  <button
+                    className={`btn ${copied ? 'btn-success' : 'btn-outline-secondary'}`}
+                    type="button"
+                    onClick={handleCopy}
+                    aria-label="Copy feed URL to clipboard"
+                  >
+                    <i className={`bi ${copied ? 'bi-check-lg' : 'bi-clipboard'} me-1`} aria-hidden="true"></i>
+                    {copied ? 'Copied' : 'Copy'}
+                  </button>
+                </div>
+
+                <div className="alert alert-info d-flex align-items-start gap-2 mb-3" role="note">
+                  <i className="bi bi-info-circle-fill flex-shrink-0 mt-1" aria-hidden="true"></i>
+                  <div>
+                    <strong>How to get the fastest updates:</strong> after subscribing, open
+                    the calendar settings in your app and set the refresh interval to the
+                    shortest value it allows (see the per-client guide below). The server
+                    sends an <code>ETag</code> header so clients that support it skip
+                    re-downloading the feed when nothing has changed.
+                  </div>
+                </div>
+
+                <button
+                  className="btn btn-outline-danger btn-sm"
+                  type="button"
+                  onClick={handleRotate}
+                  disabled={rotating}
+                >
+                  {rotating ? (
+                    <>
+                      <span className="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>
+                      Rotating…
+                    </>
+                  ) : (
+                    <>
+                      <i className="bi bi-arrow-repeat me-1" aria-hidden="true"></i>
+                      Rotate token
+                    </>
+                  )}
+                </button>
+                <p className="text-muted small mt-2 mb-0">
+                  Rotating the token generates a new URL and invalidates the old one.
+                  You will need to re-subscribe in any calendar app using the old URL.
+                </p>
+              </>
+            ) : null}
+          </div>
+        </div>
+
+        {/* Per-client instructions */}
+        <div className="card">
+          <div className="card-header">
+            <h5 className="mb-0">How to subscribe — per client</h5>
+          </div>
+          <div className="card-body p-0">
+            <div className="accordion accordion-flush" id="client-instructions">
+              {CLIENT_INSTRUCTIONS.map((client, idx) => (
+                <div className="accordion-item" key={client.name}>
+                  <h2 className="accordion-header" id={`heading-${idx}`}>
+                    <button
+                      className="accordion-button collapsed"
+                      type="button"
+                      data-bs-toggle="collapse"
+                      data-bs-target={`#collapse-${idx}`}
+                      aria-expanded="false"
+                      aria-controls={`collapse-${idx}`}
+                    >
+                      <i className={`bi ${client.icon} me-2`} aria-hidden="true"></i>
+                      {client.name}
+                    </button>
+                  </h2>
+                  <div
+                    id={`collapse-${idx}`}
+                    className="accordion-collapse collapse"
+                    aria-labelledby={`heading-${idx}`}
+                    data-bs-parent="#client-instructions"
+                  >
+                    <div className="accordion-body">
+                      <ol className="mb-3">
+                        {client.steps.map((step) => (
+                          <li key={step} className="mb-1">{step}</li>
+                        ))}
+                      </ol>
+                      <div className="alert alert-warning d-flex align-items-start gap-2 mb-0" role="note">
+                        <i className="bi bi-clock-history flex-shrink-0 mt-1" aria-hidden="true"></i>
+                        <span>{client.refreshNote}</span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  );
+};
+
+export default CalendarSection;

--- a/frontend/src/pages/Settings/Settings.tsx
+++ b/frontend/src/pages/Settings/Settings.tsx
@@ -12,6 +12,7 @@ import { useAuth } from '../../contexts/AuthContext';
 import PreferencesSection from '../Settings/PreferencesSection';
 import ProfileSection from '../Settings/ProfileSection';
 import SystemSection from '../Settings/SystemSection';
+import CalendarSection from '../Settings/CalendarSection';
 import { getMyPreferences, updateMyPreferences, UserPreferences } from '../../services/preferencesService';
 
 interface UserSettings {
@@ -41,7 +42,7 @@ const Settings: React.FC = () => {
   const { user } = useAuth();
   const isAdmin = user?.permissions?.includes('system.settings');
 
-  const [activeTab, setActiveTab] = useState<'personal' | 'work' | 'system'>('personal');
+  const [activeTab, setActiveTab] = useState<'personal' | 'work' | 'calendar' | 'system'>('personal');
 
   const [settings, setSettings] = useState<UserSettings>({
     personalSettings: {
@@ -147,6 +148,14 @@ const Settings: React.FC = () => {
                 <i className="bi bi-briefcase me-2"></i>Work Preferences
               </button>
             </li>
+            <li className="nav-item">
+              <button
+                className={`nav-link ${activeTab === 'calendar' ? 'active' : ''}`}
+                onClick={() => setActiveTab('calendar')}
+              >
+                <i className="bi bi-calendar-event me-2"></i>Calendar
+              </button>
+            </li>
             {isAdmin && (
               <li className="nav-item">
                 <button
@@ -180,6 +189,8 @@ const Settings: React.FC = () => {
           onSave={handleSaveWorkSettings}
         />
       )}
+
+      {activeTab === 'calendar' && <CalendarSection />}
 
       {activeTab === 'system' && isAdmin && <SystemSection />}
     </div>

--- a/frontend/src/services/calendarService.ts
+++ b/frontend/src/services/calendarService.ts
@@ -1,0 +1,28 @@
+import { AUTH_HEADERS, handleResponse, API_BASE_URL } from './apiUtils';
+
+export interface CalendarTokenResponse {
+  token: string;
+}
+
+const request = async <T>(path: string, init: RequestInit = {}) => {
+  const res = await fetch(`${API_BASE_URL}${path}`, {
+    credentials: 'include',
+    ...init,
+    headers: { ...AUTH_HEADERS, ...(init.headers as Record<string, string> ?? {}) },
+  });
+  return handleResponse<T>(res);
+};
+
+export async function getOrCreateCalendarToken(): Promise<CalendarTokenResponse> {
+  const res = await request<CalendarTokenResponse>('/calendar/token', { method: 'POST' });
+  return res.data as CalendarTokenResponse;
+}
+
+export async function rotateCalendarToken(): Promise<CalendarTokenResponse> {
+  const res = await request<CalendarTokenResponse>('/calendar/token/rotate', { method: 'POST' });
+  return res.data as CalendarTokenResponse;
+}
+
+export function buildFeedUrl(token: string): string {
+  return `${API_BASE_URL}/calendar/feed.ics?token=${encodeURIComponent(token)}`;
+}


### PR DESCRIPTION
## Summary

- **Calendar tab in Settings**: new tab accessible to all users with a generated iCal feed URL, one-click copy, token rotation, and a per-client accordion guide (Google Calendar, Apple Calendar, Outlook, Thunderbird) explaining how to set the shortest possible refresh interval on each platform.
- **Shift-swap notifications**: `ShiftSwapService` now injects `NotificationService`; both the requester and the target employee receive an in-app notification when a swap is **approved**; the requester receives one when a swap is **declined**.

## Changed files

| File | Change |
|---|---|
| `backend/src/services/ShiftSwapService.ts` | Inject `NotificationService`; fire `notifyAsync` on approve (both parties) and decline (requester) |
| `frontend/src/services/calendarService.ts` | New service: `getOrCreateCalendarToken`, `rotateCalendarToken`, `buildFeedUrl` |
| `frontend/src/pages/Settings/CalendarSection.tsx` | New component: feed URL display, copy button, rotate token, per-client instructions |
| `frontend/src/pages/Settings/Settings.tsx` | Add Calendar tab, wire `CalendarSection` |

## Test plan

- [ ] Backend: all existing `ShiftSwapService` tests still pass (`npm test` in `backend/`).
- [ ] Frontend: `tsc --noEmit` and `eslint` both clean.
- [ ] Manual: Settings → Calendar tab shows feed URL; copy works; rotate shows confirm dialog and updates URL.
- [ ] Manual: approve a swap as manager → both employees receive a notification in the notification center.
- [ ] Manual: decline a swap → requester receives a notification.