### PR TITLE
feat(seed): full-coverage demo seed and production first-deployment seed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -198,6 +198,9 @@ vite.config.ts.timestamp-*
 database.json
 db-config.json
 
+# Production seed config — contains real credentials, never commit
+backend/scripts/fixtures/production/config.json
+
 # SSL certificates and keys
 *.pem
 *.key

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,9 @@ Staff Scheduler is an enterprise workforce management system.
 npm run dev          # Start dev server with hot reload (nodemon + ts-node)
 npm run build        # Compile TypeScript → dist/
 npm run start        # Run compiled production build
-npm run db:init      # Initialize DB schema (no demo data)
+npm run db:init             # Initialize DB schema (no data)
+npm run db:seed:demo        # Populate with realistic demo data (idempotent)
+npm run db:seed:production  # Seed from scripts/fixtures/production/config.json (first deployment)
 npm test             # Run all tests (Jest + ts-jest)
 npm run test:watch   # Tests in watch mode
 npm run test:coverage

--- a/README.md
+++ b/README.md
@@ -294,17 +294,16 @@ npm start                  # http://localhost:3000
 > **Note**: `react-scripts@5.0.1` (Create React App) is unmaintained since October 2022.
 > `npm audit` reports findings only in CRA's development toolchain (webpack-dev-server, sockjs, postcss, etc.) — none reach the production JS bundle, and `npm audit --omit=dev` is clean. They cannot be resolved without migrating to Vite. See DOCUMENTATION.md §Future Work.
 
-### First admin user
+### Startup modes
 
-`npm run db:init` creates only the schema. There are no default
-accounts. Either provision the first admin via the API (`/api/users`)
-from a privileged session, or use the demo profile below to bootstrap a
-working environment for evaluation.
+The project supports two mutually exclusive startup modes after `npm run db:init`:
 
-## Demo data (optional)
+| Mode | Command | Purpose |
+|---|---|---|
+| **Demo** | `npm run db:seed:demo` | Realistic fake dataset covering every feature. Safe to re-run (idempotent). |
+| **Production** | `npm run db:seed:production` | Minimal real configuration from your own config file. No fake data inserted. |
 
-The project ships an isolated, opt-in demo profile. Nothing in the
-production path depends on it.
+### Demo mode
 
 ```bash
 # One-shot orchestration: docker stack up + schema init + demo seed.
@@ -337,6 +336,29 @@ seed the banner does not render and `demo1234` is not a valid password
 against any account.
 
 No demo or mock accounts are created automatically.
+
+### Production mode (first deployment)
+
+```bash
+# 1. Copy the template — config.json is gitignored, never committed.
+cp backend/scripts/fixtures/production/config.template.json \
+   backend/scripts/fixtures/production/config.json
+
+# 2. Open config.json and replace every TODO_ placeholder:
+#    - admin credentials (change the password after first login)
+#    - departments, skills, shift templates, system settings
+
+# 3. Apply the schema, then seed.
+cd backend
+npm run db:init
+npm run db:seed:production
+```
+
+The seed is idempotent for all entities except the admin user (created
+only when the e-mail does not yet exist). It sets
+`system_settings(runtime.mode = production)` so the demo banner is never
+shown. Only the minimum viable configuration is inserted — no employees,
+no schedules, no shifts. Add those through the UI after logging in.
 
 ## Schedule optimization with OR-Tools
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,6 +18,7 @@
     "format": "prettier --write src/**/*.ts",
     "db:init": "npx ts-node scripts/init-database.ts",
     "db:seed:demo": "npx ts-node scripts/seed-demo.ts",
+    "db:seed:production": "npx ts-node scripts/seed-production.ts",
     "deadcode": "knip",
     "clean": "rm -rf dist"
   },

--- a/backend/scripts/fixtures/demo/data.json
+++ b/backend/scripts/fixtures/demo/data.json
@@ -1,187 +1,181 @@
 {
   "_marker": "DEMO — fake data only. Do not enter real personal information.",
   "departments": [
-    { "name": "Emergency", "description": "[DEMO] Emergency department" },
-    { "name": "Surgery", "description": "[DEMO] Surgical department" },
+    { "name": "Emergency",  "description": "[DEMO] Emergency department" },
+    { "name": "Surgery",    "description": "[DEMO] Surgical department" },
     { "name": "Pediatrics", "description": "[DEMO] Pediatric department" },
-    { "name": "Nursing", "description": "[DEMO] Nursing pool" }
+    { "name": "Nursing",    "description": "[DEMO] Nursing pool" }
   ],
   "skills": [
-    { "name": "Triage", "description": "[DEMO] Initial patient assessment" },
-    { "name": "Surgery Assist", "description": "[DEMO] Operating room assistance" },
-    { "name": "Pediatric Care", "description": "[DEMO] Care for pediatric patients" },
-    { "name": "Cardiac Care", "description": "[DEMO] Cardiac monitoring" },
-    { "name": "Pharmacology", "description": "[DEMO] Medication administration" },
-    { "name": "IV Therapy", "description": "[DEMO] Intravenous therapy" },
-    { "name": "CPR Certified", "description": "[DEMO] CPR certification" },
+    { "name": "Triage",                "description": "[DEMO] Initial patient assessment" },
+    { "name": "Surgery Assist",        "description": "[DEMO] Operating room assistance" },
+    { "name": "Pediatric Care",        "description": "[DEMO] Care for pediatric patients" },
+    { "name": "Cardiac Care",          "description": "[DEMO] Cardiac monitoring" },
+    { "name": "Pharmacology",          "description": "[DEMO] Medication administration" },
+    { "name": "IV Therapy",            "description": "[DEMO] Intravenous therapy" },
+    { "name": "CPR Certified",         "description": "[DEMO] CPR certification" },
     { "name": "Mental Health Support", "description": "[DEMO] Mental health support" }
   ],
   "users": [
     {
       "email": "admin@demo.staffscheduler.local",
-      "firstName": "Ada",
-      "lastName": "Demo",
-      "role": "admin",
+      "firstName": "Ada", "lastName": "Demo", "role": "admin",
       "employeeId": "DEMO-A001",
       "departments": ["Emergency", "Surgery", "Pediatrics", "Nursing"],
-      "skillsByName": ["Triage", "CPR Certified"]
+      "skillsByName": ["Triage", "CPR Certified"],
+      "position": "System Administrator",
+      "phone": "+39 02 0000001",
+      "hourlyRate": 0
     },
     {
       "email": "emergency.manager@demo.staffscheduler.local",
-      "firstName": "Mara",
-      "lastName": "Demo",
-      "role": "manager",
+      "firstName": "Mara", "lastName": "Demo", "role": "manager",
       "employeeId": "DEMO-M001",
       "departments": ["Emergency"],
       "managesDepartment": "Emergency",
-      "skillsByName": ["Triage", "Cardiac Care", "CPR Certified"]
+      "skillsByName": ["Triage", "Cardiac Care", "CPR Certified"],
+      "position": "Emergency Head Nurse",
+      "phone": "+39 02 0000002",
+      "hourlyRate": 42.50
     },
     {
       "email": "surgery.manager@demo.staffscheduler.local",
-      "firstName": "Sergio",
-      "lastName": "Demo",
-      "role": "manager",
+      "firstName": "Sergio", "lastName": "Demo", "role": "manager",
       "employeeId": "DEMO-M002",
       "departments": ["Surgery"],
       "managesDepartment": "Surgery",
-      "skillsByName": ["Surgery Assist", "Pharmacology"]
+      "skillsByName": ["Surgery Assist", "Pharmacology"],
+      "position": "Surgery Coordinator",
+      "phone": "+39 02 0000003",
+      "hourlyRate": 44.00
     },
     {
       "email": "pediatrics.manager@demo.staffscheduler.local",
-      "firstName": "Paola",
-      "lastName": "Demo",
-      "role": "manager",
+      "firstName": "Paola", "lastName": "Demo", "role": "manager",
       "employeeId": "DEMO-M003",
       "departments": ["Pediatrics"],
       "managesDepartment": "Pediatrics",
-      "skillsByName": ["Pediatric Care", "Mental Health Support"]
+      "skillsByName": ["Pediatric Care", "Mental Health Support"],
+      "position": "Pediatric Ward Manager",
+      "phone": "+39 02 0000004",
+      "hourlyRate": 43.00
+    },
+    { "email": "emp01@demo.staffscheduler.local", "firstName": "Anna",    "lastName": "Demo", "role": "employee", "employeeId": "DEMO-E001", "departments": ["Emergency"], "skillsByName": ["Triage", "IV Therapy", "CPR Certified"],                   "position": "Nurse", "phone": "+39 02 0000101", "hourlyRate": 28.00 },
+    { "email": "emp02@demo.staffscheduler.local", "firstName": "Bruno",   "lastName": "Demo", "role": "employee", "employeeId": "DEMO-E002", "departments": ["Emergency"], "skillsByName": ["Triage", "CPR Certified"],                                   "position": "Nurse", "phone": "+39 02 0000102", "hourlyRate": 27.50 },
+    { "email": "emp03@demo.staffscheduler.local", "firstName": "Carla",   "lastName": "Demo", "role": "employee", "employeeId": "DEMO-E003", "departments": ["Emergency"], "skillsByName": ["Triage", "IV Therapy"],                                     "position": "Nurse", "phone": "+39 02 0000103", "hourlyRate": 27.50 },
+    { "email": "emp04@demo.staffscheduler.local", "firstName": "Davide",  "lastName": "Demo", "role": "employee", "employeeId": "DEMO-E004", "departments": ["Emergency", "Nursing"], "skillsByName": ["IV Therapy", "Cardiac Care"],                   "position": "Nurse",  "phone": "+39 02 0000104", "hourlyRate": 28.50 },
+    { "email": "emp05@demo.staffscheduler.local", "firstName": "Elena",   "lastName": "Demo", "role": "employee", "employeeId": "DEMO-E005", "departments": ["Emergency"], "skillsByName": ["Triage", "Pharmacology"],                                  "position": "Nurse", "phone": "+39 02 0000105", "hourlyRate": 28.00 },
+    { "email": "emp06@demo.staffscheduler.local", "firstName": "Fabio",   "lastName": "Demo", "role": "employee", "employeeId": "DEMO-E006", "departments": ["Surgery"],   "skillsByName": ["Surgery Assist", "Pharmacology"],                          "position": "Surgical Nurse", "phone": "+39 02 0000106", "hourlyRate": 30.00 },
+    { "email": "emp07@demo.staffscheduler.local", "firstName": "Giulia",  "lastName": "Demo", "role": "employee", "employeeId": "DEMO-E007", "departments": ["Surgery"],   "skillsByName": ["Surgery Assist", "IV Therapy"],                            "position": "Surgical Nurse", "phone": "+39 02 0000107", "hourlyRate": 29.50 },
+    { "email": "emp08@demo.staffscheduler.local", "firstName": "Hugo",    "lastName": "Demo", "role": "employee", "employeeId": "DEMO-E008", "departments": ["Surgery"],   "skillsByName": ["Surgery Assist", "Pharmacology", "CPR Certified"],         "position": "Surgical Nurse", "phone": "+39 02 0000108", "hourlyRate": 31.00 },
+    { "email": "emp09@demo.staffscheduler.local", "firstName": "Ilaria",  "lastName": "Demo", "role": "employee", "employeeId": "DEMO-E009", "departments": ["Surgery", "Nursing"], "skillsByName": ["Surgery Assist"],                               "position": "Nurse", "phone": "+39 02 0000109", "hourlyRate": 27.00 },
+    { "email": "emp10@demo.staffscheduler.local", "firstName": "Jacopo",  "lastName": "Demo", "role": "employee", "employeeId": "DEMO-E010", "departments": ["Surgery"],   "skillsByName": ["Surgery Assist", "Pharmacology"],                          "position": "Surgical Nurse", "phone": "+39 02 0000110", "hourlyRate": 29.00 },
+    { "email": "emp11@demo.staffscheduler.local", "firstName": "Klara",   "lastName": "Demo", "role": "employee", "employeeId": "DEMO-E011", "departments": ["Pediatrics"], "skillsByName": ["Pediatric Care", "Mental Health Support"],                "position": "Pediatric Nurse", "phone": "+39 02 0000111", "hourlyRate": 28.00 },
+    { "email": "emp12@demo.staffscheduler.local", "firstName": "Luca",    "lastName": "Demo", "role": "employee", "employeeId": "DEMO-E012", "departments": ["Pediatrics"], "skillsByName": ["Pediatric Care", "CPR Certified"],                        "position": "Pediatric Nurse", "phone": "+39 02 0000112", "hourlyRate": 28.50 },
+    { "email": "emp13@demo.staffscheduler.local", "firstName": "Marta",   "lastName": "Demo", "role": "employee", "employeeId": "DEMO-E013", "departments": ["Pediatrics"], "skillsByName": ["Pediatric Care", "IV Therapy"],                           "position": "Pediatric Nurse", "phone": "+39 02 0000113", "hourlyRate": 27.50 },
+    { "email": "emp14@demo.staffscheduler.local", "firstName": "Nicola",  "lastName": "Demo", "role": "employee", "employeeId": "DEMO-E014", "departments": ["Pediatrics", "Nursing"], "skillsByName": ["Pediatric Care", "Mental Health Support"],    "position": "Nurse",  "phone": "+39 02 0000114", "hourlyRate": 27.50 },
+    { "email": "emp15@demo.staffscheduler.local", "firstName": "Olga",    "lastName": "Demo", "role": "employee", "employeeId": "DEMO-E015", "departments": ["Pediatrics"], "skillsByName": ["Pediatric Care"],                                         "position": "Pediatric Nurse", "phone": "+39 02 0000115", "hourlyRate": 26.50 },
+    { "email": "emp16@demo.staffscheduler.local", "firstName": "Paolo",   "lastName": "Demo", "role": "employee", "employeeId": "DEMO-E016", "departments": ["Nursing"],    "skillsByName": ["IV Therapy", "CPR Certified"],                            "position": "Nurse", "phone": "+39 02 0000116", "hourlyRate": 27.00 },
+    { "email": "emp17@demo.staffscheduler.local", "firstName": "Quirina", "lastName": "Demo", "role": "employee", "employeeId": "DEMO-E017", "departments": ["Nursing"],    "skillsByName": ["IV Therapy", "Pharmacology"],                             "position": "Nurse", "phone": "+39 02 0000117", "hourlyRate": 27.00 },
+    { "email": "emp18@demo.staffscheduler.local", "firstName": "Roberto", "lastName": "Demo", "role": "employee", "employeeId": "DEMO-E018", "departments": ["Nursing"],    "skillsByName": ["CPR Certified", "Cardiac Care"],                          "position": "Nurse", "phone": "+39 02 0000118", "hourlyRate": 28.00 },
+    { "email": "emp19@demo.staffscheduler.local", "firstName": "Sara",    "lastName": "Demo", "role": "employee", "employeeId": "DEMO-E019", "departments": ["Nursing"],    "skillsByName": ["IV Therapy"],                                             "position": "Nurse", "phone": "+39 02 0000119", "hourlyRate": 26.50 },
+    { "email": "emp20@demo.staffscheduler.local", "firstName": "Teo",     "lastName": "Demo", "role": "employee", "employeeId": "DEMO-E020", "departments": ["Emergency", "Nursing"], "skillsByName": ["Triage", "IV Therapy"],                       "position": "Nurse",  "phone": "+39 02 0000120", "hourlyRate": 28.00 },
+    { "email": "emp21@demo.staffscheduler.local", "firstName": "Ursula",  "lastName": "Demo", "role": "employee", "employeeId": "DEMO-E021", "departments": ["Emergency"], "skillsByName": ["Triage", "Cardiac Care", "CPR Certified"],                 "position": "Nurse", "phone": "+39 02 0000121", "hourlyRate": 29.00 },
+    { "email": "emp22@demo.staffscheduler.local", "firstName": "Valter",  "lastName": "Demo", "role": "employee", "employeeId": "DEMO-E022", "departments": ["Surgery"],   "skillsByName": ["Surgery Assist", "CPR Certified"],                         "position": "Surgical Nurse", "phone": "+39 02 0000122", "hourlyRate": 29.50 },
+    { "email": "emp23@demo.staffscheduler.local", "firstName": "Wanda",   "lastName": "Demo", "role": "employee", "employeeId": "DEMO-E023", "departments": ["Pediatrics"], "skillsByName": ["Pediatric Care", "Mental Health Support"],                "position": "Pediatric Nurse", "phone": "+39 02 0000123", "hourlyRate": 27.50 },
+    { "email": "emp24@demo.staffscheduler.local", "firstName": "Xeno",    "lastName": "Demo", "role": "employee", "employeeId": "DEMO-E024", "departments": ["Surgery", "Emergency"], "skillsByName": ["Surgery Assist", "Triage"],                   "position": "Nurse",  "phone": "+39 02 0000124", "hourlyRate": 30.00 },
+    { "email": "emp25@demo.staffscheduler.local", "firstName": "Yara",    "lastName": "Demo", "role": "employee", "employeeId": "DEMO-E025", "departments": ["Nursing", "Pediatrics"], "skillsByName": ["IV Therapy", "Pediatric Care"],              "position": "Nurse",  "phone": "+39 02 0000125", "hourlyRate": 27.50 }
+  ],
+  "customFields": [
+    { "userEmail": "emp01@demo.staffscheduler.local", "key": "emergency_contact", "value": "Maria Rossi +39 333 1234567", "isPublic": false },
+    { "userEmail": "emp01@demo.staffscheduler.local", "key": "certifications",    "value": "ACLS, BLS, PALS", "isPublic": true },
+    { "userEmail": "emp01@demo.staffscheduler.local", "key": "notes",             "value": "[DEMO] Fluent in English and Spanish.", "isPublic": true },
+    { "userEmail": "emp06@demo.staffscheduler.local", "key": "certifications",    "value": "CSRN, CNOR", "isPublic": true },
+    { "userEmail": "emp06@demo.staffscheduler.local", "key": "specialty",         "value": "Cardiothoracic surgery", "isPublic": true },
+    { "userEmail": "emergency.manager@demo.staffscheduler.local", "key": "bio",   "value": "[DEMO] 15 years in emergency medicine. Certified trauma nurse.", "isPublic": true }
+  ],
+  "delegations": [
+    {
+      "delegatorEmail": "surgery.manager@demo.staffscheduler.local",
+      "delegateeEmail": "emp06@demo.staffscheduler.local",
+      "permissionCodes": ["timeoff.approve"],
+      "daysFromNow": 14,
+      "note": "Active: surgery manager delegates time-off approval to emp06 for cover"
     },
     {
-      "email": "emp01@demo.staffscheduler.local", "firstName": "Anna",   "lastName": "Demo", "role": "employee", "employeeId": "DEMO-E001",
-      "departments": ["Emergency"], "skillsByName": ["Triage", "IV Therapy", "CPR Certified"]
-    },
-    {
-      "email": "emp02@demo.staffscheduler.local", "firstName": "Bruno",  "lastName": "Demo", "role": "employee", "employeeId": "DEMO-E002",
-      "departments": ["Emergency"], "skillsByName": ["Triage", "CPR Certified"]
-    },
-    {
-      "email": "emp03@demo.staffscheduler.local", "firstName": "Carla",  "lastName": "Demo", "role": "employee", "employeeId": "DEMO-E003",
-      "departments": ["Emergency"], "skillsByName": ["Triage", "IV Therapy"]
-    },
-    {
-      "email": "emp04@demo.staffscheduler.local", "firstName": "Davide", "lastName": "Demo", "role": "employee", "employeeId": "DEMO-E004",
-      "departments": ["Emergency", "Nursing"], "skillsByName": ["IV Therapy", "Cardiac Care"]
-    },
-    {
-      "email": "emp05@demo.staffscheduler.local", "firstName": "Elena",  "lastName": "Demo", "role": "employee", "employeeId": "DEMO-E005",
-      "departments": ["Emergency"], "skillsByName": ["Triage", "Pharmacology"]
-    },
-    {
-      "email": "emp06@demo.staffscheduler.local", "firstName": "Fabio",  "lastName": "Demo", "role": "employee", "employeeId": "DEMO-E006",
-      "departments": ["Surgery"], "skillsByName": ["Surgery Assist", "Pharmacology"]
-    },
-    {
-      "email": "emp07@demo.staffscheduler.local", "firstName": "Giulia", "lastName": "Demo", "role": "employee", "employeeId": "DEMO-E007",
-      "departments": ["Surgery"], "skillsByName": ["Surgery Assist", "IV Therapy"]
-    },
-    {
-      "email": "emp08@demo.staffscheduler.local", "firstName": "Hugo",   "lastName": "Demo", "role": "employee", "employeeId": "DEMO-E008",
-      "departments": ["Surgery"], "skillsByName": ["Surgery Assist", "Pharmacology", "CPR Certified"]
-    },
-    {
-      "email": "emp09@demo.staffscheduler.local", "firstName": "Ilaria", "lastName": "Demo", "role": "employee", "employeeId": "DEMO-E009",
-      "departments": ["Surgery", "Nursing"], "skillsByName": ["Surgery Assist"]
-    },
-    {
-      "email": "emp10@demo.staffscheduler.local", "firstName": "Jacopo", "lastName": "Demo", "role": "employee", "employeeId": "DEMO-E010",
-      "departments": ["Surgery"], "skillsByName": ["Surgery Assist", "Pharmacology"]
-    },
-    {
-      "email": "emp11@demo.staffscheduler.local", "firstName": "Klara",  "lastName": "Demo", "role": "employee", "employeeId": "DEMO-E011",
-      "departments": ["Pediatrics"], "skillsByName": ["Pediatric Care", "Mental Health Support"]
-    },
-    {
-      "email": "emp12@demo.staffscheduler.local", "firstName": "Luca",   "lastName": "Demo", "role": "employee", "employeeId": "DEMO-E012",
-      "departments": ["Pediatrics"], "skillsByName": ["Pediatric Care", "CPR Certified"]
-    },
-    {
-      "email": "emp13@demo.staffscheduler.local", "firstName": "Marta",  "lastName": "Demo", "role": "employee", "employeeId": "DEMO-E013",
-      "departments": ["Pediatrics"], "skillsByName": ["Pediatric Care", "IV Therapy"]
-    },
-    {
-      "email": "emp14@demo.staffscheduler.local", "firstName": "Nicola", "lastName": "Demo", "role": "employee", "employeeId": "DEMO-E014",
-      "departments": ["Pediatrics", "Nursing"], "skillsByName": ["Pediatric Care", "Mental Health Support"]
-    },
-    {
-      "email": "emp15@demo.staffscheduler.local", "firstName": "Olga",   "lastName": "Demo", "role": "employee", "employeeId": "DEMO-E015",
-      "departments": ["Pediatrics"], "skillsByName": ["Pediatric Care"]
-    },
-    {
-      "email": "emp16@demo.staffscheduler.local", "firstName": "Paolo",  "lastName": "Demo", "role": "employee", "employeeId": "DEMO-E016",
-      "departments": ["Nursing"], "skillsByName": ["IV Therapy", "CPR Certified"]
-    },
-    {
-      "email": "emp17@demo.staffscheduler.local", "firstName": "Quirina","lastName": "Demo", "role": "employee", "employeeId": "DEMO-E017",
-      "departments": ["Nursing"], "skillsByName": ["IV Therapy", "Pharmacology"]
-    },
-    {
-      "email": "emp18@demo.staffscheduler.local", "firstName": "Roberto","lastName": "Demo", "role": "employee", "employeeId": "DEMO-E018",
-      "departments": ["Nursing"], "skillsByName": ["CPR Certified", "Cardiac Care"]
-    },
-    {
-      "email": "emp19@demo.staffscheduler.local", "firstName": "Sara",   "lastName": "Demo", "role": "employee", "employeeId": "DEMO-E019",
-      "departments": ["Nursing"], "skillsByName": ["IV Therapy"]
-    },
-    {
-      "email": "emp20@demo.staffscheduler.local", "firstName": "Teo",    "lastName": "Demo", "role": "employee", "employeeId": "DEMO-E020",
-      "departments": ["Emergency", "Nursing"], "skillsByName": ["Triage", "IV Therapy"]
-    },
-    {
-      "email": "emp21@demo.staffscheduler.local", "firstName": "Ursula", "lastName": "Demo", "role": "employee", "employeeId": "DEMO-E021",
-      "departments": ["Emergency"], "skillsByName": ["Triage", "Cardiac Care", "CPR Certified"]
-    },
-    {
-      "email": "emp22@demo.staffscheduler.local", "firstName": "Valter", "lastName": "Demo", "role": "employee", "employeeId": "DEMO-E022",
-      "departments": ["Surgery"], "skillsByName": ["Surgery Assist", "CPR Certified"]
-    },
-    {
-      "email": "emp23@demo.staffscheduler.local", "firstName": "Wanda",  "lastName": "Demo", "role": "employee", "employeeId": "DEMO-E023",
-      "departments": ["Pediatrics"], "skillsByName": ["Pediatric Care", "Mental Health Support"]
-    },
-    {
-      "email": "emp24@demo.staffscheduler.local", "firstName": "Xeno",   "lastName": "Demo", "role": "employee", "employeeId": "DEMO-E024",
-      "departments": ["Surgery", "Emergency"], "skillsByName": ["Surgery Assist", "Triage"]
-    },
-    {
-      "email": "emp25@demo.staffscheduler.local", "firstName": "Yara",   "lastName": "Demo", "role": "employee", "employeeId": "DEMO-E025",
-      "departments": ["Nursing", "Pediatrics"], "skillsByName": ["IV Therapy", "Pediatric Care"]
+      "delegatorEmail": "pediatrics.manager@demo.staffscheduler.local",
+      "delegateeEmail": "emp11@demo.staffscheduler.local",
+      "permissionCodes": ["timeoff.approve"],
+      "daysFromNow": -1,
+      "note": "Expired: pediatrics manager delegation to emp11 (ended yesterday)"
     }
   ],
   "shiftTemplates": [
-    { "name": "Emergency Morning",   "department": "Emergency",  "startTime": "07:00", "endTime": "15:00", "minStaff": 3, "maxStaff": 6, "skillsByName": ["Triage"] },
-    { "name": "Emergency Afternoon", "department": "Emergency",  "startTime": "15:00", "endTime": "23:00", "minStaff": 3, "maxStaff": 6, "skillsByName": ["Triage", "CPR Certified"] },
-    { "name": "Emergency Night",     "department": "Emergency",  "startTime": "23:00", "endTime": "07:00", "minStaff": 2, "maxStaff": 4, "skillsByName": ["Triage", "CPR Certified"] },
-    { "name": "Surgery Morning",     "department": "Surgery",    "startTime": "07:00", "endTime": "15:00", "minStaff": 3, "maxStaff": 5, "skillsByName": ["Surgery Assist"] },
-    { "name": "Surgery Afternoon",   "department": "Surgery",    "startTime": "15:00", "endTime": "23:00", "minStaff": 2, "maxStaff": 4, "skillsByName": ["Surgery Assist"] },
-    { "name": "Pediatrics Day",      "department": "Pediatrics", "startTime": "08:00", "endTime": "20:00", "minStaff": 2, "maxStaff": 4, "skillsByName": ["Pediatric Care"] }
+    { "name": "Emergency Morning",    "department": "Emergency",  "startTime": "07:00", "endTime": "15:00", "minStaff": 3, "maxStaff": 6, "skillsByName": ["Triage"] },
+    { "name": "Emergency Afternoon",  "department": "Emergency",  "startTime": "15:00", "endTime": "23:00", "minStaff": 3, "maxStaff": 6, "skillsByName": ["Triage", "CPR Certified"] },
+    { "name": "Emergency Night",      "department": "Emergency",  "startTime": "23:00", "endTime": "07:00", "minStaff": 2, "maxStaff": 4, "skillsByName": ["Triage", "CPR Certified"] },
+    { "name": "Surgery Morning",      "department": "Surgery",    "startTime": "07:00", "endTime": "15:00", "minStaff": 3, "maxStaff": 5, "skillsByName": ["Surgery Assist"] },
+    { "name": "Surgery Afternoon",    "department": "Surgery",    "startTime": "15:00", "endTime": "23:00", "minStaff": 2, "maxStaff": 4, "skillsByName": ["Surgery Assist"] },
+    { "name": "Pediatrics Day",       "department": "Pediatrics", "startTime": "08:00", "endTime": "20:00", "minStaff": 2, "maxStaff": 4, "skillsByName": ["Pediatric Care"] },
+    { "name": "Pediatrics Night",     "department": "Pediatrics", "startTime": "20:00", "endTime": "08:00", "minStaff": 1, "maxStaff": 3, "skillsByName": ["Pediatric Care", "Mental Health Support"] },
+    { "name": "Nursing Day",          "department": "Nursing",    "startTime": "07:00", "endTime": "19:00", "minStaff": 2, "maxStaff": 5, "skillsByName": ["IV Therapy"] },
+    { "name": "Nursing Night",        "department": "Nursing",    "startTime": "19:00", "endTime": "07:00", "minStaff": 1, "maxStaff": 3, "skillsByName": ["CPR Certified"] }
   ],
-  "schedule": {
-    "name": "Demo Schedule — current month",
-    "department": "Emergency",
-    "status": "published",
-    "shiftsForDays": 14,
-    "assignmentsPerShift": { "min": 2, "max": 4 }
-  },
+  "schedules": [
+    {
+      "name": "Emergency — Last Month [DEMO]",
+      "department": "Emergency",
+      "status": "archived",
+      "startDayOffset": -35,
+      "endDayOffset":   -6,
+      "templates": ["Emergency Morning", "Emergency Afternoon", "Emergency Night"]
+    },
+    {
+      "name": "Emergency — Current Month [DEMO]",
+      "department": "Emergency",
+      "status": "published",
+      "startDayOffset": -5,
+      "endDayOffset":   25,
+      "templates": ["Emergency Morning", "Emergency Afternoon", "Emergency Night"]
+    },
+    {
+      "name": "Emergency — Next Month [DEMO]",
+      "department": "Emergency",
+      "status": "draft",
+      "startDayOffset": 26,
+      "endDayOffset":   55,
+      "templates": ["Emergency Morning", "Emergency Afternoon", "Emergency Night"]
+    },
+    {
+      "name": "Surgery — Current Month [DEMO]",
+      "department": "Surgery",
+      "status": "published",
+      "startDayOffset": -5,
+      "endDayOffset":   25,
+      "templates": ["Surgery Morning", "Surgery Afternoon"]
+    },
+    {
+      "name": "Pediatrics — Current Month [DEMO]",
+      "department": "Pediatrics",
+      "status": "draft",
+      "startDayOffset": 0,
+      "endDayOffset":   20,
+      "templates": ["Pediatrics Day", "Pediatrics Night"]
+    }
+  ],
   "unavailability": [
-    { "userEmail": "emp03@demo.staffscheduler.local", "daysFromNow": [3, 4],  "reason": "[DEMO] Personal" },
+    { "userEmail": "emp03@demo.staffscheduler.local", "daysFromNow": [3, 4],    "reason": "[DEMO] Personal" },
     { "userEmail": "emp08@demo.staffscheduler.local", "daysFromNow": [7, 8, 9], "reason": "[DEMO] Conference" },
-    { "userEmail": "emp14@demo.staffscheduler.local", "daysFromNow": [10, 11], "reason": "[DEMO] Vacation" }
+    { "userEmail": "emp14@demo.staffscheduler.local", "daysFromNow": [10, 11],  "reason": "[DEMO] Vacation" }
   ],
   "preferences": [
     { "userEmail": "emp01@demo.staffscheduler.local", "maxHoursPerWeek": 40, "minHoursPerWeek": 24, "maxConsecutiveDays": 5 },
     { "userEmail": "emp06@demo.staffscheduler.local", "maxHoursPerWeek": 36, "minHoursPerWeek": 20, "maxConsecutiveDays": 4 },
     { "userEmail": "emp11@demo.staffscheduler.local", "maxHoursPerWeek": 32, "minHoursPerWeek": 16, "maxConsecutiveDays": 4 },
     { "userEmail": "emp16@demo.staffscheduler.local", "maxHoursPerWeek": 40, "minHoursPerWeek": 32, "maxConsecutiveDays": 6 },
-    { "userEmail": "emp20@demo.staffscheduler.local", "maxHoursPerWeek": 38, "minHoursPerWeek": 20, "maxConsecutiveDays": 5 }
+    { "userEmail": "emp20@demo.staffscheduler.local", "maxHoursPerWeek": 38, "minHoursPerWeek": 20, "maxConsecutiveDays": 5 },
+    { "userEmail": "emp02@demo.staffscheduler.local", "maxHoursPerWeek": 40, "minHoursPerWeek": 24, "maxConsecutiveDays": 5 },
+    { "userEmail": "emp07@demo.staffscheduler.local", "maxHoursPerWeek": 38, "minHoursPerWeek": 24, "maxConsecutiveDays": 5 },
+    { "userEmail": "emp12@demo.staffscheduler.local", "maxHoursPerWeek": 36, "minHoursPerWeek": 20, "maxConsecutiveDays": 4 }
   ]
 }

--- a/backend/scripts/fixtures/production/config.template.json
+++ b/backend/scripts/fixtures/production/config.template.json
@@ -1,0 +1,68 @@
+{
+  "_instructions": [
+    "Copy this file to config.json in the same directory.",
+    "Fill in every field marked with TODO — remove the comment lines before running the seed.",
+    "config.json is gitignored and never committed.",
+    "Run: npm run db:seed:production"
+  ],
+  "admin": {
+    "email": "TODO_admin@yourhospital.com",
+    "firstName": "TODO_Admin",
+    "lastName": "TODO_Surname",
+    "employeeId": "ADM001",
+    "password": "TODO_change_me_immediately"
+  },
+  "organization": {
+    "name": "TODO_Hospital Name",
+    "timezone": "Europe/Rome"
+  },
+  "departments": [
+    {
+      "name": "TODO_Department 1",
+      "code": "DEPT1",
+      "description": "TODO_Short description"
+    },
+    {
+      "name": "TODO_Department 2",
+      "code": "DEPT2",
+      "description": "TODO_Short description"
+    }
+  ],
+  "skills": [
+    { "name": "TODO_Skill 1", "description": "TODO_Description" },
+    { "name": "TODO_Skill 2", "description": "TODO_Description" }
+  ],
+  "shiftTemplates": [
+    {
+      "name": "TODO_Morning Shift",
+      "department": "TODO_Department 1",
+      "startTime": "07:00",
+      "endTime": "15:00",
+      "requiredStaff": 3,
+      "color": "#3498db"
+    },
+    {
+      "name": "TODO_Afternoon Shift",
+      "department": "TODO_Department 1",
+      "startTime": "15:00",
+      "endTime": "23:00",
+      "requiredStaff": 2,
+      "color": "#2ecc71"
+    },
+    {
+      "name": "TODO_Night Shift",
+      "department": "TODO_Department 1",
+      "startTime": "23:00",
+      "endTime": "07:00",
+      "requiredStaff": 1,
+      "color": "#9b59b6"
+    }
+  ],
+  "systemSettings": [
+    { "category": "general", "key": "hospital_name", "value": "TODO_Hospital Name" },
+    { "category": "general", "key": "default_timezone", "value": "Europe/Rome" },
+    { "category": "schedule", "key": "max_hours_per_week", "value": "40" },
+    { "category": "schedule", "key": "min_rest_hours_between_shifts", "value": "11" },
+    { "category": "notifications", "key": "email_enabled", "value": "true" }
+  ]
+}

--- a/backend/scripts/seed-demo.ts
+++ b/backend/scripts/seed-demo.ts
@@ -848,12 +848,14 @@ const insertOnCallCoverage = async (
     );
 
     if (entry.status === 'assigned') {
+      // LIMIT/OFFSET literals — mysql2 prepared statements do not support ? in LIMIT/OFFSET.
+      const offset = entry.daysFromNow;
       const [usersRes] = await conn.execute<mysql.RowDataPacket[]>(
         `SELECT u.id FROM users u
          JOIN user_departments ud ON ud.user_id = u.id
          WHERE ud.department_id = ?
-         ORDER BY u.id ASC LIMIT 1 OFFSET ?`,
-        [emergencyId, entry.daysFromNow]
+         ORDER BY u.id ASC LIMIT 1 OFFSET ${offset}`,
+        [emergencyId]
       );
       const userId = (usersRes[0] as { id?: number } | undefined)?.id;
       if (userId) {

--- a/backend/scripts/seed-demo.ts
+++ b/backend/scripts/seed-demo.ts
@@ -3,8 +3,23 @@
  * Demo seed script.
  *
  * Populates the database with a deterministic, obviously-fake dataset so the
- * app feels alive out of the box. Idempotent: every run wipes the demo rows
- * (matched by the `[DEMO]` markers it inserts) and re-creates them, so it is
+ * app feels alive out of the box. Covers every implemented feature:
+ *   - Multiple schedules per department (archived / published / draft)
+ *   - Shifts, assignments (confirmed + pending)
+ *   - Time-off requests (pending / approved / rejected)
+ *   - Shift swap requests (pending / approved)
+ *   - On-call periods and assignments
+ *   - Employee loans (approved / pending)
+ *   - Org-unit tree with memberships
+ *   - Policies and policy exceptions
+ *   - Delegations (active + expired)
+ *   - User preferences and unavailability
+ *   - User custom fields (directory)
+ *   - Calendar tokens (with readable raw tokens printed to console)
+ *   - In-app notifications
+ *   - Audit log entries
+ *
+ * Idempotent: every run wipes the demo rows and re-creates them, so it is
  * safe to call repeatedly.
  *
  * Marks the runtime mode as `demo` in `system_settings(category='runtime',
@@ -32,6 +47,8 @@ dotenv.config();
 const DEMO_PASSWORD = 'demo1234';
 const FIXTURE_PATH = path.join(__dirname, 'fixtures', 'demo', 'data.json');
 
+// ── Types ───────────────────────────────────────────────────────────────────
+
 interface DemoUser {
   email: string;
   firstName: string;
@@ -41,6 +58,24 @@ interface DemoUser {
   departments: string[];
   managesDepartment?: string;
   skillsByName: string[];
+  position?: string;
+  phone?: string;
+  hourlyRate?: number;
+}
+
+interface DemoCustomField {
+  userEmail: string;
+  key: string;
+  value: string;
+  isPublic: boolean;
+}
+
+interface DemoDelegation {
+  delegatorEmail: string;
+  delegateeEmail: string;
+  permissionCodes: string[];
+  daysFromNow: number;
+  note: string;
 }
 
 interface DemoShiftTemplate {
@@ -53,18 +88,23 @@ interface DemoShiftTemplate {
   skillsByName: string[];
 }
 
+interface DemoSchedule {
+  name: string;
+  department: string;
+  status: 'draft' | 'published' | 'archived';
+  startDayOffset: number;
+  endDayOffset: number;
+  templates: string[];
+}
+
 interface DemoFixture {
   departments: { name: string; description: string }[];
   skills: { name: string; description: string }[];
   users: DemoUser[];
+  customFields: DemoCustomField[];
+  delegations: DemoDelegation[];
   shiftTemplates: DemoShiftTemplate[];
-  schedule: {
-    name: string;
-    department: string;
-    status: 'draft' | 'published' | 'archived';
-    shiftsForDays: number;
-    assignmentsPerShift: { min: number; max: number };
-  };
+  schedules: DemoSchedule[];
   unavailability: { userEmail: string; daysFromNow: number[]; reason: string }[];
   preferences: {
     userEmail: string;
@@ -74,6 +114,8 @@ interface DemoFixture {
   }[];
 }
 
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
 const dbConfig = {
   host: process.env.DB_HOST || 'localhost',
   port: Number(process.env.DB_PORT || 3306),
@@ -82,16 +124,18 @@ const dbConfig = {
   database: process.env.DB_NAME || 'staff_scheduler',
 };
 
-/** Returns today's date as `YYYY-MM-DD`, optionally offset by `daysFromNow`. */
 const dateOffset = (daysFromNow = 0): string => {
   const d = new Date();
   d.setDate(d.getDate() + daysFromNow);
   return d.toISOString().slice(0, 10);
 };
 
-/** Wipes every row in the right (children-first) order so re-running is safe. */
+const sha256 = (raw: string): string =>
+  crypto.createHash('sha256').update(raw).digest('hex');
+
+// ── Wipe ─────────────────────────────────────────────────────────────────────
+
 const wipeAll = async (conn: mysql.Connection): Promise<void> => {
-  // Disable FK checks for the duration of the wipe; this is local-only seeding.
   await conn.query('SET FOREIGN_KEY_CHECKS = 0');
   const tables = [
     'audit_logs',
@@ -113,6 +157,7 @@ const wipeAll = async (conn: mysql.Connection): Promise<void> => {
     'user_skills',
     'user_departments',
     'user_roles',
+    'delegations',
     'policy_exception_requests',
     'policies',
     'employee_loans',
@@ -121,15 +166,41 @@ const wipeAll = async (conn: mysql.Connection): Promise<void> => {
     'skills',
     'departments',
     'users',
-    // Keep system_settings as-is; we set the mode key explicitly below.
-    // Keep approval_matrix, roles, permissions and role_permissions as-is;
-    // they are seeded by init.sql and are configuration, not demo data.
   ];
   for (const table of tables) {
     await conn.query(`TRUNCATE TABLE \`${table}\``);
   }
   await conn.query('SET FOREIGN_KEY_CHECKS = 1');
 };
+
+// ── Role helpers ─────────────────────────────────────────────────────────────
+
+const ROLE_NAME_BY_KEY: Record<DemoUser['role'], string> = {
+  admin: 'Administrator',
+  manager: 'Manager',
+  employee: 'Employee',
+};
+
+const loadRoleIds = async (conn: mysql.Connection): Promise<Map<string, number>> => {
+  const [rows] = await conn.execute<mysql.RowDataPacket[]>('SELECT id, name FROM roles');
+  const map = new Map<string, number>();
+  for (const row of rows as Array<{ id: number; name: string }>) map.set(row.name, row.id);
+  return map;
+};
+
+const assignRole = async (
+  conn: mysql.Connection,
+  userId: number,
+  roleId: number | undefined
+): Promise<void> => {
+  if (!roleId) return;
+  await conn.execute(
+    'INSERT IGNORE INTO user_roles (user_id, role_id, scope_org_unit_id) VALUES (?, ?, NULL)',
+    [userId, roleId]
+  );
+};
+
+// ── Core inserts ─────────────────────────────────────────────────────────────
 
 const insertDepartments = async (
   conn: mysql.Connection,
@@ -161,112 +232,6 @@ const insertSkills = async (
   return map;
 };
 
-/**
- * Synthetic department + employee generator.
- *
- * Creates one extra department called `Operations` and `BULK_EMPLOYEE_COUNT`
- * synthetic employees (Employee 001..050) attached to it. Used for stress-
- * test demos / "what does the UI look like with a real-sized department"
- * use cases. All rows still receive the `[DEMO]` markers used by the
- * idempotent wipe step.
- */
-const BULK_DEPT_NAME = 'Operations';
-const BULK_DEPT_DESCRIPTION = '[DEMO] Operations department (50 employees)';
-const BULK_EMPLOYEE_COUNT = 50;
-const BULK_PASSWORD = 'demo1234';
-
-const insertBulkOperationsDepartment = async (
-  conn: mysql.Connection,
-  deptIds: Map<string, number>,
-  skillIds: Map<string, number>,
-  userIds: Map<string, number>,
-  roleIds: Map<string, number>
-): Promise<void> => {
-  // 1. Department
-  const [deptRes] = await conn.execute<mysql.ResultSetHeader>(
-    'INSERT INTO departments (name, description, is_active) VALUES (?, ?, 1)',
-    [BULK_DEPT_NAME, BULK_DEPT_DESCRIPTION]
-  );
-  const deptId = deptRes.insertId;
-  deptIds.set(BULK_DEPT_NAME, deptId);
-
-  // 2. Single hash reused for every synthetic employee
-  const passwordHash = await bcrypt.hash(BULK_PASSWORD, 4);
-
-  // 3. Round-robin a small skill subset across employees so the directory
-  //    looks alive without any one employee being suspiciously specific.
-  const skillRotation = [
-    skillIds.get('IV Therapy'),
-    skillIds.get('CPR Certified'),
-    skillIds.get('Pharmacology'),
-  ].filter((id): id is number => typeof id === 'number');
-
-  for (let i = 1; i <= BULK_EMPLOYEE_COUNT; i++) {
-    const padded = String(i).padStart(3, '0');
-    const email = `ops${padded}@demo.staffscheduler.local`;
-    const employeeId = `DEMO-OPS-${padded}`;
-    const firstName = `Employee`;
-    const lastName = padded;
-
-    const [userRes] = await conn.execute<mysql.ResultSetHeader>(
-      `INSERT INTO users (email, password_hash, first_name, last_name,
-                          employee_id, position, phone, is_active)
-       VALUES (?, ?, ?, ?, ?, '[DEMO] Operations', '+39 000 0000000', 1)`,
-      [email, passwordHash, firstName, lastName, employeeId]
-    );
-    const userId = userRes.insertId;
-    userIds.set(email, userId);
-    await assignRole(conn, userId, roleIds.get('Employee'));
-
-    await conn.execute(
-      'INSERT INTO user_departments (user_id, department_id) VALUES (?, ?)',
-      [userId, deptId]
-    );
-
-    if (skillRotation.length > 0) {
-      const skillId = skillRotation[i % skillRotation.length];
-      await conn.execute(
-        'INSERT INTO user_skills (user_id, skill_id, proficiency_level) VALUES (?, ?, 3)',
-        [userId, skillId]
-      );
-    }
-  }
-
-  logger.info(
-    `Demo seed: synthetic department "${BULK_DEPT_NAME}" with ${BULK_EMPLOYEE_COUNT} employees inserted.`
-  );
-};
-
-/**
- * Maps the fixture's shorthand role keys to the seeded role names created by
- * init.sql. Roles are data, so the seed assigns users to roles by name.
- */
-const ROLE_NAME_BY_KEY: Record<DemoUser['role'], string> = {
-  admin: 'Administrator',
-  manager: 'Manager',
-  employee: 'Employee',
-};
-
-/** Resolves seeded role ids by name so the demo can assign user_roles rows. */
-const loadRoleIds = async (conn: mysql.Connection): Promise<Map<string, number>> => {
-  const [rows] = await conn.execute<mysql.RowDataPacket[]>('SELECT id, name FROM roles');
-  const map = new Map<string, number>();
-  for (const row of rows as Array<{ id: number; name: string }>) map.set(row.name, row.id);
-  return map;
-};
-
-const assignRole = async (
-  conn: mysql.Connection,
-  userId: number,
-  roleId: number | undefined
-): Promise<void> => {
-  if (!roleId) return;
-  await conn.execute(
-    'INSERT IGNORE INTO user_roles (user_id, role_id, scope_org_unit_id) VALUES (?, ?, NULL)',
-    [userId, roleId]
-  );
-};
-
 const insertUsers = async (
   conn: mysql.Connection,
   fixture: DemoFixture,
@@ -279,10 +244,16 @@ const insertUsers = async (
 
   for (const user of fixture.users) {
     const [res] = await conn.execute<mysql.ResultSetHeader>(
-      `INSERT INTO users (email, password_hash, first_name, last_name,
-                          employee_id, position, phone, is_active)
-       VALUES (?, ?, ?, ?, ?, '[DEMO]', '+39 000 0000000', 1)`,
-      [user.email, passwordHash, user.firstName, user.lastName, user.employeeId]
+      `INSERT INTO users
+         (email, password_hash, first_name, last_name, employee_id,
+          position, phone, hourly_rate, is_active)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1)`,
+      [
+        user.email, passwordHash, user.firstName, user.lastName, user.employeeId,
+        user.position ?? '[DEMO]',
+        user.phone ?? '+39 000 0000000',
+        user.hourlyRate ?? 0,
+      ]
     );
     const userId = res.insertId;
     map.set(user.email, userId);
@@ -307,7 +278,6 @@ const insertUsers = async (
     }
   }
 
-  // Wire managers to their departments.
   for (const user of fixture.users) {
     if (!user.managesDepartment) continue;
     const userId = map.get(user.email)!;
@@ -318,6 +288,125 @@ const insertUsers = async (
 
   return map;
 };
+
+/**
+ * Synthetic department + employee generator.
+ * Creates an `Operations` department with 50 synthetic employees.
+ */
+const BULK_DEPT_NAME = 'Operations';
+const BULK_DEPT_DESCRIPTION = '[DEMO] Operations department (50 employees)';
+const BULK_EMPLOYEE_COUNT = 50;
+
+const insertBulkOperationsDepartment = async (
+  conn: mysql.Connection,
+  deptIds: Map<string, number>,
+  skillIds: Map<string, number>,
+  userIds: Map<string, number>,
+  roleIds: Map<string, number>
+): Promise<void> => {
+  const [deptRes] = await conn.execute<mysql.ResultSetHeader>(
+    'INSERT INTO departments (name, description, is_active) VALUES (?, ?, 1)',
+    [BULK_DEPT_NAME, BULK_DEPT_DESCRIPTION]
+  );
+  const deptId = deptRes.insertId;
+  deptIds.set(BULK_DEPT_NAME, deptId);
+
+  const passwordHash = await bcrypt.hash(DEMO_PASSWORD, 4);
+
+  const skillRotation = [
+    skillIds.get('IV Therapy'),
+    skillIds.get('CPR Certified'),
+    skillIds.get('Pharmacology'),
+  ].filter((id): id is number => typeof id === 'number');
+
+  for (let i = 1; i <= BULK_EMPLOYEE_COUNT; i++) {
+    const padded = String(i).padStart(3, '0');
+    const email = `ops${padded}@demo.staffscheduler.local`;
+    const employeeId = `DEMO-OPS-${padded}`;
+
+    const [userRes] = await conn.execute<mysql.ResultSetHeader>(
+      `INSERT INTO users
+         (email, password_hash, first_name, last_name, employee_id,
+          position, phone, hourly_rate, is_active)
+       VALUES (?, ?, 'Employee', ?, ?, '[DEMO] Operations', '+39 000 0000000', 25.00, 1)`,
+      [email, passwordHash, padded, employeeId]
+    );
+    const userId = userRes.insertId;
+    userIds.set(email, userId);
+    await assignRole(conn, userId, roleIds.get('Employee'));
+
+    await conn.execute(
+      'INSERT INTO user_departments (user_id, department_id) VALUES (?, ?)',
+      [userId, deptId]
+    );
+
+    if (skillRotation.length > 0) {
+      const skillId = skillRotation[i % skillRotation.length];
+      await conn.execute(
+        'INSERT INTO user_skills (user_id, skill_id, proficiency_level) VALUES (?, ?, 3)',
+        [userId, skillId]
+      );
+    }
+  }
+
+  logger.info(
+    `Demo seed: synthetic department "${BULK_DEPT_NAME}" with ${BULK_EMPLOYEE_COUNT} employees inserted.`
+  );
+};
+
+// ── Custom fields ─────────────────────────────────────────────────────────────
+
+const insertCustomFields = async (
+  conn: mysql.Connection,
+  fixture: DemoFixture,
+  userIds: Map<string, number>
+): Promise<void> => {
+  for (const field of fixture.customFields) {
+    const userId = userIds.get(field.userEmail);
+    if (!userId) continue;
+    await conn.execute(
+      `INSERT INTO user_custom_fields (user_id, field_key, field_value, is_public)
+       VALUES (?, ?, ?, ?)`,
+      [userId, field.key, field.value, field.isPublic ? 1 : 0]
+    );
+  }
+  logger.info(`Demo seed: ${fixture.customFields.length} user custom fields inserted.`);
+};
+
+// ── Delegations ───────────────────────────────────────────────────────────────
+
+const insertDelegations = async (
+  conn: mysql.Connection,
+  fixture: DemoFixture,
+  userIds: Map<string, number>
+): Promise<void> => {
+  for (const delegation of fixture.delegations) {
+    const delegatorId = userIds.get(delegation.delegatorEmail);
+    const delegateeId = userIds.get(delegation.delegateeEmail);
+    if (!delegatorId || !delegateeId) continue;
+
+    const expiresAt = new Date();
+    expiresAt.setDate(expiresAt.getDate() + delegation.daysFromNow);
+
+    const isActive = delegation.daysFromNow > 0;
+
+    await conn.execute(
+      `INSERT INTO delegations
+         (delegator_id, delegatee_id, permission_codes, expires_at, is_active)
+       VALUES (?, ?, ?, ?, ?)`,
+      [
+        delegatorId,
+        delegateeId,
+        JSON.stringify(delegation.permissionCodes),
+        expiresAt.toISOString().slice(0, 19).replace('T', ' '),
+        isActive ? 1 : 0,
+      ]
+    );
+  }
+  logger.info(`Demo seed: ${fixture.delegations.length} delegations inserted.`);
+};
+
+// ── Shift templates ───────────────────────────────────────────────────────────
 
 const insertShiftTemplates = async (
   conn: mysql.Connection,
@@ -330,8 +419,9 @@ const insertShiftTemplates = async (
     const deptId = deptIds.get(tpl.department);
     if (!deptId) throw new Error(`Unknown department for template: ${tpl.department}`);
     const [res] = await conn.execute<mysql.ResultSetHeader>(
-      `INSERT INTO shift_templates (name, description, department_id,
-                                    start_time, end_time, min_staff, max_staff, is_active)
+      `INSERT INTO shift_templates
+         (name, description, department_id, start_time, end_time,
+          min_staff, max_staff, is_active)
        VALUES (?, ?, ?, ?, ?, ?, ?, 1)`,
       [tpl.name, `[DEMO] ${tpl.name}`, deptId, tpl.startTime, tpl.endTime, tpl.minStaff, tpl.maxStaff]
     );
@@ -349,7 +439,17 @@ const insertShiftTemplates = async (
   return map;
 };
 
-const insertScheduleWithShifts = async (
+// ── Schedules + shifts + assignments ─────────────────────────────────────────
+
+/**
+ * Builds all schedules defined in the fixture. Each schedule entry specifies:
+ *   - department, status, day offsets, which templates to use
+ *
+ * For archived and published schedules, shifts are created and assignments
+ * are added round-robin. Draft schedules get shifts but no assignments,
+ * simulating a schedule still being built.
+ */
+const insertAllSchedules = async (
   conn: mysql.Connection,
   fixture: DemoFixture,
   deptIds: Map<string, number>,
@@ -357,80 +457,101 @@ const insertScheduleWithShifts = async (
   userIds: Map<string, number>,
   adminEmail: string
 ): Promise<void> => {
-  const sched = fixture.schedule;
-  const deptId = deptIds.get(sched.department);
-  const adminId = userIds.get(adminEmail);
-  if (!deptId || !adminId) throw new Error('Schedule prerequisites missing');
+  const adminId = userIds.get(adminEmail)!;
 
-  const startDate = dateOffset(0);
-  const endDate = dateOffset(sched.shiftsForDays - 1);
-
-  const [res] = await conn.execute<mysql.ResultSetHeader>(
-    `INSERT INTO schedules (name, description, department_id, start_date, end_date,
-                            status, created_by, published_at, notes)
-     VALUES (?, '[DEMO] Demo schedule', ?, ?, ?, ?, ?, NOW(), '[DEMO]')`,
-    [sched.name, deptId, startDate, endDate, sched.status, adminId]
-  );
-  const scheduleId = res.insertId;
-
-  // Build shifts: one of each Emergency template per day for the first
-  // schedule.shiftsForDays days. Assignments are deterministically picked
-  // round-robin from users that belong to the relevant department.
-  const allUsers = await conn.execute<mysql.RowDataPacket[]>(
-    `SELECT u.id, u.email, GROUP_CONCAT(d.name) AS dept_names
+  const allUsersRes = await conn.execute<mysql.RowDataPacket[]>(
+    `SELECT u.id, GROUP_CONCAT(d.name) AS dept_names
      FROM users u
      LEFT JOIN user_departments ud ON u.id = ud.user_id
      LEFT JOIN departments d ON ud.department_id = d.id
      GROUP BY u.id`
   );
   const usersByDept = new Map<string, number[]>();
-  for (const row of allUsers[0] as Array<{ id: number; dept_names: string | null }>) {
-    const names = (row.dept_names || '').split(',');
-    for (const name of names) {
+  for (const row of allUsersRes[0] as Array<{ id: number; dept_names: string | null }>) {
+    for (const name of (row.dept_names || '').split(',')) {
       if (!name) continue;
       if (!usersByDept.has(name)) usersByDept.set(name, []);
       usersByDept.get(name)!.push(row.id);
     }
   }
 
-  let assignedTotal = 0;
-  let shiftCounter = 0;
-  for (let dayOffset = 0; dayOffset < sched.shiftsForDays; dayOffset++) {
-    const day = dateOffset(dayOffset);
-    for (const tpl of fixture.shiftTemplates) {
-      const tplId = templateIds.get(tpl.name);
-      const tplDeptId = deptIds.get(tpl.department)!;
-      if (!tplId) continue;
+  let totalSchedules = 0;
+  let totalShifts = 0;
+  let totalAssignments = 0;
 
-      const [shiftRes] = await conn.execute<mysql.ResultSetHeader>(
-        `INSERT INTO shifts (schedule_id, department_id, template_id, date,
-                             start_time, end_time, min_staff, max_staff, status, notes)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'open', '[DEMO]')`,
-        [scheduleId, tplDeptId, tplId, day, tpl.startTime, tpl.endTime, tpl.minStaff, tpl.maxStaff]
-      );
-      const shiftId = shiftRes.insertId;
-      shiftCounter++;
+  for (const sched of fixture.schedules) {
+    const deptId = deptIds.get(sched.department);
+    if (!deptId) throw new Error(`Unknown department for schedule: ${sched.department}`);
 
-      const candidates = usersByDept.get(tpl.department) || [];
-      const targetCount = Math.min(tpl.minStaff + 1, tpl.maxStaff, candidates.length);
-      for (let i = 0; i < targetCount; i++) {
-        const userId = candidates[(shiftCounter + i) % candidates.length];
-        // Round-robin can collide on the unique (shift_id, user_id) constraint
-        // for very small candidate pools; INSERT IGNORE keeps the seed robust.
-        await conn.execute(
-          `INSERT IGNORE INTO shift_assignments (shift_id, user_id, status, assigned_by)
-           VALUES (?, ?, ?, ?)`,
-          [shiftId, userId, i % 2 === 0 ? 'confirmed' : 'pending', adminId]
+    const startDate = dateOffset(sched.startDayOffset);
+    const endDate = dateOffset(sched.endDayOffset);
+
+    const [res] = await conn.execute<mysql.ResultSetHeader>(
+      `INSERT INTO schedules
+         (name, description, department_id, start_date, end_date,
+          status, created_by, published_at, notes)
+       VALUES (?, '[DEMO]', ?, ?, ?, ?, ?,
+               ${sched.status !== 'draft' ? 'NOW()' : 'NULL'},
+               '[DEMO]')`,
+      [sched.name, deptId, startDate, endDate, sched.status, adminId]
+    );
+    const scheduleId = res.insertId;
+    totalSchedules++;
+
+    const days = sched.endDayOffset - sched.startDayOffset + 1;
+    let shiftCounter = 0;
+
+    for (let dayIdx = 0; dayIdx < days; dayIdx++) {
+      const day = dateOffset(sched.startDayOffset + dayIdx);
+
+      for (const tplName of sched.templates) {
+        const tpl = fixture.shiftTemplates.find((t) => t.name === tplName);
+        if (!tpl) continue;
+        const tplId = templateIds.get(tplName);
+        const tplDeptId = deptIds.get(tpl.department)!;
+        if (!tplId) continue;
+
+        const [shiftRes] = await conn.execute<mysql.ResultSetHeader>(
+          `INSERT INTO shifts
+             (schedule_id, department_id, template_id, date,
+              start_time, end_time, min_staff, max_staff, status, notes)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'open', '[DEMO]')`,
+          [scheduleId, tplDeptId, tplId, day, tpl.startTime, tpl.endTime, tpl.minStaff, tpl.maxStaff]
         );
-        assignedTotal++;
+        const shiftId = shiftRes.insertId;
+        totalShifts++;
+        shiftCounter++;
+
+        // Draft schedules get no assignments — they're still being planned.
+        if (sched.status === 'draft') continue;
+
+        const candidates = usersByDept.get(tpl.department) || [];
+        if (candidates.length === 0) continue;
+        const targetCount = Math.min(tpl.minStaff + 1, tpl.maxStaff, candidates.length);
+
+        for (let i = 0; i < targetCount; i++) {
+          const userId = candidates[(shiftCounter + i) % candidates.length];
+          const status = sched.status === 'archived'
+            ? 'confirmed'
+            : (i % 2 === 0 ? 'confirmed' : 'pending');
+          await conn.execute(
+            `INSERT IGNORE INTO shift_assignments
+               (shift_id, user_id, status, assigned_by)
+             VALUES (?, ?, ?, ?)`,
+            [shiftId, userId, status, adminId]
+          );
+          totalAssignments++;
+        }
       }
     }
   }
 
   logger.info(
-    `Demo schedule seeded: schedule=${scheduleId}, shifts=${shiftCounter}, assignments≈${assignedTotal}`
+    `Demo seed: ${totalSchedules} schedules, ${totalShifts} shifts, ~${totalAssignments} assignments.`
   );
 };
+
+// ── Unavailability + preferences ──────────────────────────────────────────────
 
 const insertUnavailability = async (
   conn: mysql.Connection,
@@ -458,23 +579,21 @@ const insertPreferences = async (
     const userId = userIds.get(pref.userEmail);
     if (!userId) continue;
     await conn.execute(
-      `INSERT INTO user_preferences (user_id, max_hours_per_week, min_hours_per_week,
-                                     max_consecutive_days, notes)
+      `INSERT INTO user_preferences
+         (user_id, max_hours_per_week, min_hours_per_week, max_consecutive_days, notes)
        VALUES (?, ?, ?, ?, '[DEMO]')`,
       [userId, pref.maxHoursPerWeek, pref.minHoursPerWeek, pref.maxConsecutiveDays]
     );
   }
 };
 
+// ── Org tree + policies ───────────────────────────────────────────────────────
+
 /**
- * Seeds the org tree, memberships, policies, loans and policy exceptions so
- * the new `Organization` and `Policies` pages have data to interact with on
- * the very first run.
- *
  * Tree shape (3 levels):
  *   Hospital
  *   ├─ Clinical Area
- *   │   ├─ Emergency Department  (managed by manager@…)
+ *   │   ├─ Emergency Department  (managed by emergency.manager)
  *   │   └─ ICU
  *   └─ Operations Area
  *       └─ Operations
@@ -490,8 +609,7 @@ const insertOrgTreeAndPolicies = async (
     userIds.get('surgery.manager@demo.staffscheduler.local') ??
     adminId;
   const employeeId = userIds.get('emp01@demo.staffscheduler.local') ?? null;
-  const opsLeadEmail = 'ops001@demo.staffscheduler.local';
-  const opsLeadId = userIds.get(opsLeadEmail) ?? null;
+  const opsLeadId = userIds.get('ops001@demo.staffscheduler.local') ?? null;
 
   const insertUnit = async (
     name: string,
@@ -506,85 +624,80 @@ const insertOrgTreeAndPolicies = async (
     return res.insertId;
   };
 
-  const hospitalId = await insertUnit('Hospital', null, adminId);
-  const clinicalId = await insertUnit('Clinical Area', hospitalId, adminId);
-  const operationsAreaId = await insertUnit('Operations Area', hospitalId, adminId);
-  const emergencyId = await insertUnit('Emergency Department', clinicalId, managerId);
-  const icuId = await insertUnit('ICU', clinicalId, managerId);
-  const operationsId = await insertUnit('Operations', operationsAreaId, opsLeadId ?? adminId);
+  const hospitalId        = await insertUnit('Hospital', null, adminId);
+  const clinicalId        = await insertUnit('Clinical Area', hospitalId, adminId);
+  const operationsAreaId  = await insertUnit('Operations Area', hospitalId, adminId);
+  const emergencyUnitId   = await insertUnit('Emergency Department', clinicalId, managerId);
+  const icuId             = await insertUnit('ICU', clinicalId, managerId);
+  const operationsUnitId  = await insertUnit('Operations', operationsAreaId, opsLeadId ?? adminId);
 
-  // Memberships: every demo user gets a primary unit aligned with their main
-  // department, plus a few cross-area memberships to exercise the UI.
   const memberships: Array<[number, number, boolean]> = [
     [adminId, hospitalId, true],
-    [managerId, emergencyId, true],
+    [managerId, emergencyUnitId, true],
     [managerId, icuId, false],
   ];
-  if (employeeId) memberships.push([employeeId, emergencyId, true]);
-  for (const [userId, unitId, isPrimary] of memberships) {
+  if (employeeId) memberships.push([employeeId, emergencyUnitId, true]);
+  for (const [uid, unitId, isPrimary] of memberships) {
     await conn.execute(
-      `INSERT INTO user_org_units (user_id, org_unit_id, is_primary) VALUES (?, ?, ?)`,
-      [userId, unitId, isPrimary ? 1 : 0]
+      'INSERT INTO user_org_units (user_id, org_unit_id, is_primary) VALUES (?, ?, ?)',
+      [uid, unitId, isPrimary ? 1 : 0]
     );
   }
   if (opsLeadId) {
     await conn.execute(
-      `INSERT INTO user_org_units (user_id, org_unit_id, is_primary) VALUES (?, ?, 1)`,
-      [opsLeadId, operationsId]
+      'INSERT INTO user_org_units (user_id, org_unit_id, is_primary) VALUES (?, ?, 1)',
+      [opsLeadId, operationsUnitId]
     );
   }
 
-  // Place every Operations synthetic employee in the Operations unit.
-  for (let i = 1; i <= 50; i++) {
+  for (let i = 2; i <= 50; i++) {
     const padded = String(i).padStart(3, '0');
-    const opsEmail = `ops${padded}@demo.staffscheduler.local`;
-    const opsUserId = userIds.get(opsEmail);
-    if (!opsUserId || opsUserId === opsLeadId) continue;
+    const uid = userIds.get(`ops${padded}@demo.staffscheduler.local`);
+    if (!uid) continue;
     await conn.execute(
-      `INSERT INTO user_org_units (user_id, org_unit_id, is_primary) VALUES (?, ?, 1)`,
-      [opsUserId, operationsId]
+      'INSERT INTO user_org_units (user_id, org_unit_id, is_primary) VALUES (?, ?, 1)',
+      [uid, operationsUnitId]
     );
   }
 
-  // Policies (admin imposes both):
-  //   - global min_rest_hours = 11 (informational)
-  //   - org_unit-scoped max_hours_week = 48 on Emergency Department
   await conn.execute(
-    `INSERT INTO policies (scope_type, scope_id, policy_key, policy_value, description, imposed_by_user_id, is_active)
+    `INSERT INTO policies
+       (scope_type, scope_id, policy_key, policy_value, description,
+        imposed_by_user_id, is_active)
      VALUES ('global', NULL, 'min_rest_hours', ?, '[DEMO] Minimum rest hours between shifts', ?, 1)`,
     [JSON.stringify({ hours: 11 }), adminId]
   );
   const [maxHoursRes] = await conn.execute<mysql.ResultSetHeader>(
-    `INSERT INTO policies (scope_type, scope_id, policy_key, policy_value, description, imposed_by_user_id, is_active)
+    `INSERT INTO policies
+       (scope_type, scope_id, policy_key, policy_value, description,
+        imposed_by_user_id, is_active)
      VALUES ('org_unit', ?, 'max_hours_week', ?, '[DEMO] Cap weekly hours in Emergency', ?, 1)`,
-    [emergencyId, JSON.stringify({ hours: 48 }), adminId]
+    [emergencyUnitId, JSON.stringify({ hours: 48 }), adminId]
   );
   const maxHoursPolicyId = maxHoursRes.insertId;
 
-  // Sample loans: one approved (manager borrows from Operations) and one pending.
   const opsBorrowed = userIds.get('ops002@demo.staffscheduler.local');
   if (opsBorrowed) {
     await conn.execute(
       `INSERT INTO employee_loans
-         (user_id, from_org_unit_id, to_org_unit_id, start_date, end_date, reason,
-          status, requested_by, approver_user_id, reviewed_at, review_notes)
+         (user_id, from_org_unit_id, to_org_unit_id, start_date, end_date,
+          reason, status, requested_by, approver_user_id, reviewed_at, review_notes)
        VALUES (?, ?, ?, ?, ?, '[DEMO] Cover ICU peak', 'approved', ?, ?, NOW(),
-               '[DEMO] auto-approved at seed time')`,
-      [opsBorrowed, operationsId, icuId, dateOffset(0), dateOffset(7), managerId, managerId]
+               '[DEMO] Approved at seed time')`,
+      [opsBorrowed, operationsUnitId, icuId, dateOffset(0), dateOffset(7), managerId, managerId]
     );
   }
   const opsPending = userIds.get('ops003@demo.staffscheduler.local');
   if (opsPending) {
     await conn.execute(
       `INSERT INTO employee_loans
-         (user_id, from_org_unit_id, to_org_unit_id, start_date, end_date, reason,
-          status, requested_by, approver_user_id)
+         (user_id, from_org_unit_id, to_org_unit_id, start_date, end_date,
+          reason, status, requested_by, approver_user_id)
        VALUES (?, ?, ?, ?, ?, '[DEMO] Awaiting approval', 'pending', ?, ?)`,
-      [opsPending, operationsId, emergencyId, dateOffset(2), dateOffset(5), managerId, managerId]
+      [opsPending, operationsUnitId, emergencyUnitId, dateOffset(2), dateOffset(5), managerId, managerId]
     );
   }
 
-  // Sample policy exception: one pending, one approved (auto-approved by owner).
   await conn.execute(
     `INSERT INTO policy_exception_requests
        (policy_id, target_type, target_id, reason, status, requested_by_user_id)
@@ -593,155 +706,67 @@ const insertOrgTreeAndPolicies = async (
   );
   await conn.execute(
     `INSERT INTO policy_exception_requests
-       (policy_id, target_type, target_id, reason, status, requested_by_user_id, reviewer_user_id, reviewed_at, review_notes)
-     VALUES (?, 'shift_assignment', 2, '[DEMO] Pre-approved by admin', 'approved', ?, ?, NOW(),
-             '[DEMO] auto-approved (actor is policy owner)')`,
+       (policy_id, target_type, target_id, reason, status,
+        requested_by_user_id, reviewer_user_id, reviewed_at, review_notes)
+     VALUES (?, 'shift_assignment', 2, '[DEMO] Pre-approved by admin', 'approved',
+             ?, ?, NOW(), '[DEMO] auto-approved (actor is policy owner)')`,
     [maxHoursPolicyId, adminId, adminId]
   );
 
-  logger.info(
-    'Demo seed: org tree (6 units), memberships, 2 policies, 2 loans, 2 exception requests inserted.'
-  );
-
-  // Reference deptIds to keep the signature stable for callers; not used here
-  // because departments and org_units are independent in this demo.
+  logger.info('Demo seed: org tree, memberships, policies, loans, exceptions inserted.');
   void deptIds;
 };
 
-/**
- * Seeds in-app notifications across roles so the bell icon and notification
- * pages always have something to show in demos.
- */
-const insertNotifications = async (
-  conn: mysql.Connection,
-  userIds: Map<string, number>
-): Promise<void> => {
-  const adminId = userIds.get('admin@demo.staffscheduler.local');
-  const managerId =
-    userIds.get('emergency.manager@demo.staffscheduler.local') ??
-    userIds.get('surgery.manager@demo.staffscheduler.local') ??
-    adminId ??
-    null;
-  const employeeId = userIds.get('emp01@demo.staffscheduler.local') ?? null;
+// ── Time-off requests ─────────────────────────────────────────────────────────
 
-  type Notif = { userId: number; type: string; title: string; body: string; isRead: boolean };
-  const notifs: Notif[] = [];
-
-  if (adminId) {
-    notifs.push(
-      {
-        userId: adminId,
-        type: 'system',
-        title: '[DEMO] Welcome to Staff Scheduler',
-        body: 'This is a demo notification. Explore the app, no real data is stored.',
-        isRead: false,
-      },
-      {
-        userId: adminId,
-        type: 'approval',
-        title: '[DEMO] Loan request awaiting approval',
-        body: 'Operations to Emergency loan request from the seeded data.',
-        isRead: false,
-      }
-    );
-  }
-  if (managerId) {
-    notifs.push(
-      {
-        userId: managerId,
-        type: 'schedule',
-        title: '[DEMO] New schedule published',
-        body: 'A demo schedule was published in your department.',
-        isRead: false,
-      },
-      {
-        userId: managerId,
-        type: 'time_off',
-        title: '[DEMO] Time-off request to review',
-        body: 'A demo employee requested vacation next week.',
-        isRead: true,
-      }
-    );
-  }
-  if (employeeId) {
-    notifs.push(
-      {
-        userId: employeeId,
-        type: 'shift',
-        title: '[DEMO] You were assigned a new shift',
-        body: 'Demo morning shift assignment.',
-        isRead: false,
-      },
-      {
-        userId: employeeId,
-        type: 'swap',
-        title: '[DEMO] Swap request answered',
-        body: 'A demo swap request you sent is awaiting manager review.',
-        isRead: false,
-      }
-    );
-  }
-
-  for (const n of notifs) {
-    await conn.execute(
-      `INSERT INTO notifications (user_id, type, title, body, link, is_read)
-       VALUES (?, ?, ?, ?, NULL, ?)`,
-      [n.userId, n.type, n.title, n.body, n.isRead ? 1 : 0]
-    );
-  }
-};
-
-/**
- * Seeds time-off requests covering the typical statuses (pending, approved,
- * rejected) so the manager review queue is non-empty.
- */
 const insertTimeOffRequests = async (
   conn: mysql.Connection,
   userIds: Map<string, number>
 ): Promise<void> => {
   const employee1 = userIds.get('emp01@demo.staffscheduler.local');
   const employee2 = userIds.get('emp02@demo.staffscheduler.local') ?? employee1;
-  const employee3 = userIds.get('ops004@demo.staffscheduler.local');
-  const reviewer =
+  const employee3 = userIds.get('emp05@demo.staffscheduler.local');
+  const employee4 = userIds.get('emp07@demo.staffscheduler.local');
+  const ops004    = userIds.get('ops004@demo.staffscheduler.local');
+  const reviewer  =
     userIds.get('emergency.manager@demo.staffscheduler.local') ??
     userIds.get('admin@demo.staffscheduler.local')!;
+  const surgeryReviewer =
+    userIds.get('surgery.manager@demo.staffscheduler.local') ?? reviewer;
 
-  if (employee1) {
+  const requests: Array<[number | undefined, string, number, number, string, string, number | null, string | null]> = [
+    // userId, type, startOffset, endOffset, reason, status, reviewerId, reviewNotes
+    [employee1, 'vacation', 10, 14,  '[DEMO] Family trip',                'pending',  reviewer,        null],
+    [employee2, 'sick',     -3, -1,  '[DEMO] Flu recovery',               'approved', reviewer,        '[DEMO] Approved — replacement scheduled'],
+    [employee3, 'personal', 5,   5,  '[DEMO] Personal appointment',       'pending',  reviewer,        null],
+    [employee4, 'vacation', 20, 27,  '[DEMO] Summer holiday',             'approved', surgeryReviewer, '[DEMO] Approved'],
+    [ops004,    'personal', 20, 20,  '[DEMO] Personal day',               'rejected', reviewer,        '[DEMO] Coverage unavailable'],
+  ];
+
+  for (const [userId, type, startOff, endOff, reason, status, reviewerId, reviewNotes] of requests) {
+    if (!userId) continue;
+    const isReviewed = status !== 'pending';
     await conn.execute(
       `INSERT INTO time_off_requests
-         (user_id, start_date, end_date, type, reason, status, reviewer_id)
-       VALUES (?, ?, ?, 'vacation', '[DEMO] Family trip', 'pending', ?)`,
-      [employee1, dateOffset(10), dateOffset(14), reviewer]
+         (user_id, start_date, end_date, type, reason, status,
+          reviewer_id, reviewed_at, review_notes)
+       VALUES (?, ?, ?, ?, ?, ?, ?,
+               ${isReviewed ? 'NOW()' : 'NULL'},
+               ?)`,
+      [userId, dateOffset(startOff), dateOffset(endOff), type, reason, status, reviewerId, reviewNotes]
     );
   }
-  if (employee2 && employee2 !== employee1) {
-    await conn.execute(
-      `INSERT INTO time_off_requests
-         (user_id, start_date, end_date, type, reason, status, reviewer_id, reviewed_at, review_notes)
-       VALUES (?, ?, ?, 'sick', '[DEMO] Flu recovery', 'approved', ?, NOW(), '[DEMO] Approved with replacement scheduled')`,
-      [employee2, dateOffset(-3), dateOffset(-1), reviewer]
-    );
-  }
-  if (employee3) {
-    await conn.execute(
-      `INSERT INTO time_off_requests
-         (user_id, start_date, end_date, type, reason, status, reviewer_id, reviewed_at, review_notes)
-       VALUES (?, ?, ?, 'personal', '[DEMO] Personal day', 'rejected', ?, NOW(), '[DEMO] Coverage unavailable on the requested day')`,
-      [employee3, dateOffset(20), dateOffset(20), reviewer]
-    );
-  }
+  logger.info(`Demo seed: ${requests.length} time-off requests inserted.`);
 };
 
-/**
- * Seeds two shift assignments and a swap request between them so the swap
- * marketplace UI has something to show.
- */
+// ── Shift swap requests ───────────────────────────────────────────────────────
+
 const insertSwapRequests = async (
   conn: mysql.Connection,
   userIds: Map<string, number>
 ): Promise<void> => {
   const [rows] = await conn.execute<mysql.RowDataPacket[]>(
-    `SELECT id, user_id FROM shift_assignments ORDER BY id ASC LIMIT 4`
+    `SELECT id, user_id FROM shift_assignments ORDER BY id ASC LIMIT 8`
   );
   const assignments = rows as Array<{ id: number; user_id: number }>;
   if (assignments.length < 2) return;
@@ -750,59 +775,76 @@ const insertSwapRequests = async (
     userIds.get('emergency.manager@demo.staffscheduler.local') ??
     userIds.get('admin@demo.staffscheduler.local')!;
 
-  const [a, b] = [assignments[0], assignments[1]];
-  if (a.user_id === b.user_id) return;
-  await conn.execute(
-    `INSERT INTO shift_swap_requests
-       (requester_user_id, requester_assignment_id, target_user_id, target_assignment_id,
-        status, notes)
-     VALUES (?, ?, ?, ?, 'pending', '[DEMO] Need to swap for a family event')`,
-    [a.user_id, a.id, b.user_id, b.id]
-  );
+  let inserted = 0;
+  const usedIds = new Set<number>();
 
-  if (assignments.length >= 4) {
-    const [c, d] = [assignments[2], assignments[3]];
-    if (c.user_id !== d.user_id) {
+  for (let i = 0; i + 1 < assignments.length && inserted < 3; i += 2) {
+    const a = assignments[i];
+    const b = assignments[i + 1];
+    if (a.user_id === b.user_id) continue;
+    if (usedIds.has(a.id) || usedIds.has(b.id)) continue;
+    usedIds.add(a.id);
+    usedIds.add(b.id);
+
+    if (inserted === 0) {
+      await conn.execute(
+        `INSERT INTO shift_swap_requests
+           (requester_user_id, requester_assignment_id, target_user_id, target_assignment_id,
+            status, notes)
+         VALUES (?, ?, ?, ?, 'pending', '[DEMO] Need to swap for a family event')`,
+        [a.user_id, a.id, b.user_id, b.id]
+      );
+    } else if (inserted === 1) {
       await conn.execute(
         `INSERT INTO shift_swap_requests
            (requester_user_id, requester_assignment_id, target_user_id, target_assignment_id,
             status, notes, reviewer_id, reviewed_at, review_notes)
          VALUES (?, ?, ?, ?, 'approved', '[DEMO] Approved swap',
                  ?, NOW(), '[DEMO] Approved by manager')`,
-        [c.user_id, c.id, d.user_id, d.id, reviewer]
+        [a.user_id, a.id, b.user_id, b.id, reviewer]
+      );
+    } else {
+      await conn.execute(
+        `INSERT INTO shift_swap_requests
+           (requester_user_id, requester_assignment_id, target_user_id, target_assignment_id,
+            status, notes, reviewer_id, reviewed_at, review_notes)
+         VALUES (?, ?, ?, ?, 'declined', '[DEMO] Could not accommodate',
+                 ?, NOW(), '[DEMO] Coverage insufficient')`,
+        [a.user_id, a.id, b.user_id, b.id, reviewer]
       );
     }
+    inserted++;
   }
+  logger.info(`Demo seed: ${inserted} shift swap requests inserted.`);
 };
 
-/**
- * Seeds on-call coverage for the next few days so the on-call view has data.
- */
+// ── On-call coverage ──────────────────────────────────────────────────────────
+
 const insertOnCallCoverage = async (
   conn: mysql.Connection,
   deptIds: Map<string, number>,
   userIds: Map<string, number>
 ): Promise<void> => {
-  const deptId =
+  const emergencyId =
+    deptIds.get('Emergency') ??
     deptIds.get('Emergency Medicine') ??
-    deptIds.get('Operations') ??
-    deptIds.values().next().value;
-  if (!deptId) return;
+    deptIds.values().next().value as number;
   const adminId = userIds.get('admin@demo.staffscheduler.local')!;
 
-  const periodEntries: Array<{ daysFromNow: number; status: 'open' | 'assigned' }> = [
-    { daysFromNow: 1, status: 'open' },
-    { daysFromNow: 2, status: 'assigned' },
-    { daysFromNow: 3, status: 'assigned' },
+  const entries: Array<{ daysFromNow: number; status: 'open' | 'assigned' }> = [
+    { daysFromNow: 0, status: 'assigned' },
+    { daysFromNow: 1, status: 'assigned' },
+    { daysFromNow: 2, status: 'open' },
+    { daysFromNow: 3, status: 'open' },
   ];
 
-  for (const entry of periodEntries) {
+  for (const entry of entries) {
     const [periodRes] = await conn.execute<mysql.ResultSetHeader>(
       `INSERT INTO on_call_periods
          (schedule_id, department_id, date, start_time, end_time,
           min_staff, max_staff, status, notes)
        VALUES (NULL, ?, ?, '20:00:00', '08:00:00', 1, 2, ?, '[DEMO] Overnight on-call')`,
-      [deptId, dateOffset(entry.daysFromNow), entry.status]
+      [emergencyId, dateOffset(entry.daysFromNow), entry.status]
     );
 
     if (entry.status === 'assigned') {
@@ -810,16 +852,15 @@ const insertOnCallCoverage = async (
         `SELECT u.id FROM users u
          JOIN user_departments ud ON ud.user_id = u.id
          WHERE ud.department_id = ?
-         ORDER BY u.id ASC
-         LIMIT 1`,
-        [deptId]
+         ORDER BY u.id ASC LIMIT 1 OFFSET ?`,
+        [emergencyId, entry.daysFromNow]
       );
-      const userId = (usersRes[0] as any)?.id;
+      const userId = (usersRes[0] as { id?: number } | undefined)?.id;
       if (userId) {
         await conn.execute(
           `INSERT INTO on_call_assignments
              (period_id, user_id, status, assigned_by, notes)
-           VALUES (?, ?, 'confirmed', ?, '[DEMO] Confirmed on-call assignment')`,
+           VALUES (?, ?, 'confirmed', ?, '[DEMO] Confirmed on-call')`,
           [periodRes.insertId, userId, adminId]
         );
       }
@@ -827,64 +868,128 @@ const insertOnCallCoverage = async (
   }
 };
 
+// ── Calendar tokens ───────────────────────────────────────────────────────────
+
 /**
- * Generates a stable opaque calendar token for every seeded user so the
- * .ics endpoint is testable without manual provisioning.
+ * Generates a readable raw token for every seeded user and stores its
+ * SHA-256 hash. The raw tokens are printed so demo users can immediately
+ * subscribe their calendar clients without going through the UI.
  */
 const insertCalendarTokens = async (
   conn: mysql.Connection,
   userIds: Map<string, number>
 ): Promise<void> => {
+  const feedSamples: string[] = [];
   let counter = 0;
-  for (const [, userId] of userIds) {
+  for (const [email, userId] of userIds) {
     counter += 1;
     const rawToken = `demo-${userId.toString().padStart(4, '0')}-${counter
       .toString(36)
       .padStart(6, '0')}`;
-    const tokenHash = crypto.createHash('sha256').update(rawToken).digest('hex');
+    const tokenHash = sha256(rawToken);
     await conn.execute(
-      `INSERT INTO user_calendar_tokens (user_id, token_hash) VALUES (?, ?)`,
+      'INSERT INTO user_calendar_tokens (user_id, token_hash) VALUES (?, ?)',
       [userId, tokenHash]
     );
+    if (counter <= 4) {
+      feedSamples.push(`  ${email}: /api/calendar/feed.ics?token=${rawToken}`);
+    }
   }
-};
-
-const writeDemoModeMarker = async (conn: mysql.Connection): Promise<void> => {
-  await conn.execute(
-    `INSERT INTO system_settings (category, \`key\`, value, type, default_value, description, is_editable)
-     VALUES ('runtime', 'mode', 'demo', 'string', 'production', 'Application runtime mode', 0)
-     ON DUPLICATE KEY UPDATE value = VALUES(value)`
+  logger.info(
+    `Demo seed: calendar tokens inserted. Sample feed URLs:\n${feedSamples.join('\n')}`
   );
 };
+
+// ── Notifications ─────────────────────────────────────────────────────────────
+
+const insertNotifications = async (
+  conn: mysql.Connection,
+  userIds: Map<string, number>
+): Promise<void> => {
+  const adminId    = userIds.get('admin@demo.staffscheduler.local');
+  const managerId  = userIds.get('emergency.manager@demo.staffscheduler.local') ?? adminId ?? null;
+  const employeeId = userIds.get('emp01@demo.staffscheduler.local') ?? null;
+
+  type N = { userId: number; type: string; title: string; body: string; isRead: boolean };
+  const notifs: N[] = [];
+
+  if (adminId) {
+    notifs.push(
+      { userId: adminId, type: 'system',   title: '[DEMO] Welcome to Staff Scheduler',        body: 'Explore the app — no real data is stored.',              isRead: false },
+      { userId: adminId, type: 'approval', title: '[DEMO] Loan request awaiting approval',     body: 'Operations→Emergency loan from the seeded data.',        isRead: false },
+      { userId: adminId, type: 'approval', title: '[DEMO] Policy exception pending',           body: 'One exception request is pending your review.',          isRead: true  }
+    );
+  }
+  if (managerId) {
+    notifs.push(
+      { userId: managerId, type: 'schedule', title: '[DEMO] New schedule published',    body: 'Emergency current-month schedule was published.', isRead: false },
+      { userId: managerId, type: 'time_off', title: '[DEMO] Time-off request to review', body: 'emp01 requested 5 days vacation next week.',       isRead: true  },
+      { userId: managerId, type: 'swap',     title: '[DEMO] Shift swap request',         body: 'A swap request between two Emergency nurses.',    isRead: false }
+    );
+  }
+  if (employeeId) {
+    notifs.push(
+      { userId: employeeId, type: 'shift',         title: '[DEMO] You were assigned a new shift', body: 'Emergency Morning shift — check your schedule.',    isRead: false },
+      { userId: employeeId, type: 'shiftswap.approved', title: '[DEMO] Swap request approved',   body: 'Your shift swap has been approved by the manager.', isRead: false },
+      { userId: employeeId, type: 'time_off',      title: '[DEMO] Time-off approved',             body: 'Your sick-leave request has been approved.',        isRead: true  }
+    );
+  }
+
+  for (const n of notifs) {
+    await conn.execute(
+      'INSERT INTO notifications (user_id, type, title, body, link, is_read) VALUES (?, ?, ?, ?, NULL, ?)',
+      [n.userId, n.type, n.title, n.body, n.isRead ? 1 : 0]
+    );
+  }
+  logger.info(`Demo seed: ${notifs.length} notifications inserted.`);
+};
+
+// ── Audit log ─────────────────────────────────────────────────────────────────
 
 const insertAuditLogs = async (
   conn: mysql.Connection,
   userIds: Map<string, number>
 ): Promise<void> => {
-  const adminId = userIds.get('admin@demo.staffscheduler.local')!;
-  const managerId =
-    userIds.get('emergency.manager@demo.staffscheduler.local') ??
-    userIds.get('surgery.manager@demo.staffscheduler.local') ??
-    adminId;
+  const adminId    = userIds.get('admin@demo.staffscheduler.local')!;
+  const managerId  = userIds.get('emergency.manager@demo.staffscheduler.local') ?? userIds.get('surgery.manager@demo.staffscheduler.local') ?? adminId;
   const employeeId = userIds.get('emp01@demo.staffscheduler.local') ?? adminId;
+
   const entries: Array<[number, string, string, number | null, string]> = [
-    [adminId, 'login', 'auth', null, '[DEMO] Demo admin signed in'],
-    [adminId, 'create_schedule', 'schedule', 1, '[DEMO] Created the demo schedule'],
-    [adminId, 'publish_schedule', 'schedule', 1, '[DEMO] Published the demo schedule'],
-    [managerId, 'approve_loan', 'employee_loan', 1, '[DEMO] Approved Operations→ICU loan'],
-    [managerId, 'approve_swap', 'shift_swap', 1, '[DEMO] Approved a swap request'],
-    [managerId, 'approve_time_off', 'time_off_request', 1, '[DEMO] Approved sick leave'],
-    [employeeId, 'login', 'auth', null, '[DEMO] Demo employee signed in'],
-    [employeeId, 'request_time_off', 'time_off_request', 1, '[DEMO] Requested vacation'],
+    [adminId,    'login',            'auth',                  null, '[DEMO] Admin signed in'],
+    [adminId,    'create_schedule',  'schedule',              1,    '[DEMO] Created Emergency — Current Month schedule'],
+    [adminId,    'publish_schedule', 'schedule',              1,    '[DEMO] Published Emergency — Current Month schedule'],
+    [adminId,    'create_schedule',  'schedule',              2,    '[DEMO] Created Surgery — Current Month schedule'],
+    [managerId,  'approve_loan',     'employee_loan',         1,    '[DEMO] Approved Operations→ICU loan'],
+    [managerId,  'approve_swap',     'shift_swap',            1,    '[DEMO] Approved swap request'],
+    [managerId,  'approve_time_off', 'time_off_request',      1,    '[DEMO] Approved sick-leave request'],
+    [managerId,  'login',            'auth',                  null, '[DEMO] Manager signed in'],
+    [employeeId, 'login',            'auth',                  null, '[DEMO] Employee signed in'],
+    [employeeId, 'request_time_off', 'time_off_request',      1,    '[DEMO] Requested vacation'],
+    [employeeId, 'confirm_assignment','shift_assignment',      1,    '[DEMO] Confirmed morning shift assignment'],
   ];
   for (const [userId, action, type, entityId, description] of entries) {
     await conn.execute(
-      `INSERT INTO audit_logs (user_id, action, entity_type, entity_id, description, ip_address)
+      `INSERT INTO audit_logs
+         (user_id, action, entity_type, entity_id, description, ip_address)
        VALUES (?, ?, ?, ?, ?, '127.0.0.1')`,
       [userId, action, type, entityId, description]
     );
   }
+  logger.info(`Demo seed: ${entries.length} audit log entries inserted.`);
 };
+
+// ── Demo mode marker ──────────────────────────────────────────────────────────
+
+const writeDemoModeMarker = async (conn: mysql.Connection): Promise<void> => {
+  await conn.execute(
+    `INSERT INTO system_settings
+       (category, \`key\`, value, type, default_value, description, is_editable)
+     VALUES ('runtime', 'mode', 'demo', 'string', 'production', 'Application runtime mode', 0)
+     ON DUPLICATE KEY UPDATE value = VALUES(value)`
+  );
+};
+
+// ── Entry point ───────────────────────────────────────────────────────────────
 
 export async function seedDemo(): Promise<void> {
   const fixture = JSON.parse(fs.readFileSync(FIXTURE_PATH, 'utf8')) as DemoFixture;
@@ -897,23 +1002,18 @@ export async function seedDemo(): Promise<void> {
 
     await wipeAll(conn);
 
-    const roleIds = await loadRoleIds(conn);
-    const deptIds = await insertDepartments(conn, fixture);
-    const skillIds = await insertSkills(conn, fixture);
-    const userIds = await insertUsers(conn, fixture, deptIds, skillIds, roleIds);
+    const roleIds     = await loadRoleIds(conn);
+    const deptIds     = await insertDepartments(conn, fixture);
+    const skillIds    = await insertSkills(conn, fixture);
+    const userIds     = await insertUsers(conn, fixture, deptIds, skillIds, roleIds);
     await insertBulkOperationsDepartment(conn, deptIds, skillIds, userIds, roleIds);
     const templateIds = await insertShiftTemplates(conn, fixture, deptIds, skillIds);
-    await insertScheduleWithShifts(
-      conn,
-      fixture,
-      deptIds,
-      templateIds,
-      userIds,
-      'admin@demo.staffscheduler.local'
-    );
+    await insertAllSchedules(conn, fixture, deptIds, templateIds, userIds, 'admin@demo.staffscheduler.local');
     await insertUnavailability(conn, fixture, userIds);
     await insertPreferences(conn, fixture, userIds);
     await insertOrgTreeAndPolicies(conn, deptIds, userIds);
+    await insertCustomFields(conn, fixture, userIds);
+    await insertDelegations(conn, fixture, userIds);
     await insertNotifications(conn, userIds);
     await insertTimeOffRequests(conn, userIds);
     await insertSwapRequests(conn, userIds);
@@ -923,13 +1023,11 @@ export async function seedDemo(): Promise<void> {
     await writeDemoModeMarker(conn);
 
     await conn.commit();
-    logger.info('Demo seed completed.');
-    logger.info(
-      `Sign in at the frontend with admin@demo.staffscheduler.local / ${DEMO_PASSWORD}`
-    );
+    logger.info('Demo seed completed successfully.');
+    logger.info(`Sign in: admin@demo.staffscheduler.local / ${DEMO_PASSWORD}`);
   } catch (err) {
     await conn.rollback();
-    logger.error('Demo seed failed; rolled back', err);
+    logger.error('Demo seed failed — rolled back', err);
     throw err;
   } finally {
     await conn.end();

--- a/backend/scripts/seed-production.ts
+++ b/backend/scripts/seed-production.ts
@@ -1,0 +1,262 @@
+#!/usr/bin/env ts-node
+/**
+ * Production seed script.
+ *
+ * Seeds a clean database with the minimal initial configuration required to
+ * start operating: one Administrator account, departments, skills, shift
+ * templates, and system settings.  No fake/demo data is inserted.
+ *
+ * Usage:
+ *   1. Copy scripts/fixtures/production/config.template.json
+ *          to scripts/fixtures/production/config.json
+ *   2. Fill in every TODO field and remove the "_instructions" key.
+ *   3. npm run db:seed:production
+ *
+ * The script is idempotent for departments, skills, shift templates, and
+ * system settings (INSERT IGNORE / ON DUPLICATE KEY UPDATE).  The admin user
+ * is created only when no user with that e-mail exists yet.
+ *
+ * Marks the runtime mode as `production` in system_settings so the app does
+ * not show the demo banner.
+ *
+ * @author Luca Ostinelli
+ */
+
+import dotenv from 'dotenv';
+import * as fs from 'fs';
+import * as path from 'path';
+import bcrypt from 'bcrypt';
+import mysql from 'mysql2/promise';
+import { logger } from '../src/config/logger';
+
+dotenv.config();
+
+const CONFIG_PATH = path.join(__dirname, 'fixtures', 'production', 'config.json');
+const BCRYPT_ROUNDS = parseInt(process.env.BCRYPT_ROUNDS ?? '12', 10);
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+interface ProductionAdmin {
+  email: string;
+  firstName: string;
+  lastName: string;
+  employeeId: string;
+  password: string;
+}
+
+interface ProductionOrganization {
+  name: string;
+  timezone: string;
+}
+
+interface ProductionDepartment {
+  name: string;
+  code: string;
+  description: string;
+}
+
+interface ProductionSkill {
+  name: string;
+  description: string;
+}
+
+interface ProductionShiftTemplate {
+  name: string;
+  department: string;
+  startTime: string;
+  endTime: string;
+  requiredStaff: number;
+  color?: string;
+}
+
+interface ProductionSystemSetting {
+  category: string;
+  key: string;
+  value: string;
+}
+
+interface ProductionConfig {
+  admin: ProductionAdmin;
+  organization: ProductionOrganization;
+  departments: ProductionDepartment[];
+  skills: ProductionSkill[];
+  shiftTemplates: ProductionShiftTemplate[];
+  systemSettings: ProductionSystemSetting[];
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function loadConfig(): ProductionConfig {
+  if (!fs.existsSync(CONFIG_PATH)) {
+    logger.error(
+      `Production config not found at ${CONFIG_PATH}. ` +
+      'Copy config.template.json to config.json and fill in your values.'
+    );
+    process.exit(1);
+  }
+  const raw = fs.readFileSync(CONFIG_PATH, 'utf-8');
+  const parsed = JSON.parse(raw) as Record<string, unknown>;
+
+  if ('_instructions' in parsed) {
+    logger.error(
+      'config.json still contains the "_instructions" key from the template. ' +
+      'Remove it before running this script.'
+    );
+    process.exit(1);
+  }
+
+  const hasTodo = raw.includes('TODO_');
+  if (hasTodo) {
+    logger.error(
+      'config.json contains unfilled TODO_ placeholders. ' +
+      'Replace every TODO_ value before seeding.'
+    );
+    process.exit(1);
+  }
+
+  return parsed as unknown as ProductionConfig;
+}
+
+// ── Seed functions ────────────────────────────────────────────────────────────
+
+async function ensureAdmin(pool: mysql.Pool, config: ProductionConfig): Promise<number> {
+  const { email, firstName, lastName, employeeId, password } = config.admin;
+  const [[existing]] = await pool.execute<mysql.RowDataPacket[]>(
+    'SELECT id FROM users WHERE email = ?', [email]
+  );
+  if (existing) {
+    logger.info(`Admin user already exists (${email}) — skipping creation`);
+    return (existing as { id: number }).id;
+  }
+
+  const hash = await bcrypt.hash(password, BCRYPT_ROUNDS);
+  const [result] = await pool.execute<mysql.ResultSetHeader>(
+    `INSERT INTO users (email, password_hash, first_name, last_name, employee_id, is_active)
+     VALUES (?, ?, ?, ?, ?, TRUE)`,
+    [email, hash, firstName, lastName, employeeId]
+  );
+  const adminId = result.insertId;
+  logger.info(`Created admin user: ${email} (id=${adminId})`);
+
+  // Grant the Administrator system role.
+  const [[adminRole]] = await pool.execute<mysql.RowDataPacket[]>(
+    "SELECT id FROM roles WHERE name = 'Administrator'"
+  );
+  if (adminRole) {
+    await pool.execute(
+      'INSERT IGNORE INTO user_roles (user_id, role_id) VALUES (?, ?)',
+      [adminId, (adminRole as { id: number }).id]
+    );
+    logger.info('Granted Administrator role to admin user');
+  } else {
+    logger.warn('Administrator role not found — run db:init first');
+  }
+
+  return adminId;
+}
+
+async function seedDepartments(pool: mysql.Pool, config: ProductionConfig): Promise<Map<string, number>> {
+  const map = new Map<string, number>();
+  for (const dept of config.departments) {
+    await pool.execute(
+      `INSERT INTO departments (name, description, is_active)
+       VALUES (?, ?, TRUE)
+       ON DUPLICATE KEY UPDATE description = VALUES(description)`,
+      [dept.name, dept.description]
+    );
+    const [[row]] = await pool.execute<mysql.RowDataPacket[]>(
+      'SELECT id FROM departments WHERE name = ?', [dept.name]
+    );
+    const id = (row as { id: number }).id;
+    map.set(dept.name, id);
+    logger.info(`Department: ${dept.name} (id=${id})`);
+  }
+  return map;
+}
+
+async function seedSkills(pool: mysql.Pool, config: ProductionConfig): Promise<void> {
+  for (const skill of config.skills) {
+    await pool.execute(
+      `INSERT INTO skills (name, description)
+       VALUES (?, ?)
+       ON DUPLICATE KEY UPDATE description = VALUES(description)`,
+      [skill.name, skill.description]
+    );
+    logger.info(`Skill: ${skill.name}`);
+  }
+}
+
+async function seedShiftTemplates(
+  pool: mysql.Pool,
+  config: ProductionConfig,
+  deptMap: Map<string, number>
+): Promise<void> {
+  for (const tmpl of config.shiftTemplates) {
+    const deptId = deptMap.get(tmpl.department);
+    if (!deptId) {
+      logger.warn(`Shift template "${tmpl.name}" references unknown department "${tmpl.department}" — skipping`);
+      continue;
+    }
+    await pool.execute(
+      `INSERT INTO shift_templates (name, department_id, start_time, end_time, min_staff, max_staff, is_active)
+       VALUES (?, ?, ?, ?, ?, ?, TRUE)
+       ON DUPLICATE KEY UPDATE start_time = VALUES(start_time), end_time = VALUES(end_time)`,
+      [tmpl.name, deptId, tmpl.startTime, tmpl.endTime, tmpl.requiredStaff, tmpl.requiredStaff]
+    );
+    logger.info(`Shift template: ${tmpl.name} (${tmpl.startTime}–${tmpl.endTime})`);
+  }
+}
+
+async function seedSystemSettings(pool: mysql.Pool, config: ProductionConfig): Promise<void> {
+  const rows: ProductionSystemSetting[] = [
+    // Built-in runtime mode marker — always set to production.
+    { category: 'runtime', key: 'mode', value: 'production' },
+    ...config.systemSettings,
+  ];
+  for (const s of rows) {
+    await pool.execute(
+      `INSERT INTO system_settings (category, \`key\`, value)
+       VALUES (?, ?, ?)
+       ON DUPLICATE KEY UPDATE value = VALUES(value)`,
+      [s.category, s.key, s.value]
+    );
+    logger.info(`System setting: ${s.category}.${s.key} = ${s.value}`);
+  }
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const config = loadConfig();
+
+  const pool = mysql.createPool({
+    host: process.env.DB_HOST ?? 'localhost',
+    port: parseInt(process.env.DB_PORT ?? '3306', 10),
+    user: process.env.DB_USER,
+    password: process.env.DB_PASSWORD,
+    database: process.env.DB_NAME,
+    multipleStatements: false,
+  });
+
+  try {
+    logger.info('=== Production seed starting ===');
+    logger.info(`Organization: ${config.organization.name}`);
+
+    await ensureAdmin(pool, config);
+    const deptMap = await seedDepartments(pool, config);
+    await seedSkills(pool, config);
+    await seedShiftTemplates(pool, config, deptMap);
+    await seedSystemSettings(pool, config);
+
+    logger.info('=== Production seed complete ===');
+    logger.info(`Admin login: ${config.admin.email}`);
+    logger.info('Remember to change the admin password after first login.');
+  } finally {
+    await pool.end();
+  }
+}
+
+main().catch((err) => {
+  logger.error('Production seed failed', { error: err });
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- **Demo seed** (`npm run db:seed:demo`) now covers every implemented feature: multi-status schedules per department, shift assignments, time-off/swap requests in all states, on-call periods, employee loans, org-unit tree, delegations (active + expired), user custom fields, calendar tokens with readable raw URLs printed to console, in-app notifications, and audit log entries. Idempotent: truncate + reinsert on every run.
- **Production seed** (`npm run db:seed:production`) reads from `scripts/fixtures/production/config.json` (gitignored) to create a clean first-deployment database: admin user, departments, skills, shift templates, and system settings. No fake data. Config template at `config.template.json`.
- Both seeds write `system_settings(runtime.mode)` so the SPA demo banner correctly appears or not.
- README documents both modes side by side with a comparison table and step-by-step instructions.
- CLAUDE.md updated with the two new `npm run` commands.

## Test plan

- [ ] `npm run db:seed:demo` completes without errors on a freshly initialized schema
- [ ] Re-running `npm run db:seed:demo` is idempotent (no duplicate key errors)
- [ ] `npm run db:seed:production` with `config.json` missing prints a clear error message
- [ ] `npm run db:seed:production` with an unfilled `TODO_` placeholder prints a clear error message
- [ ] `npm run db:seed:production` with a valid `config.json` creates the admin, departments, skills, templates, and system settings
- [ ] After demo seed, SPA shows the orange demo banner
- [ ] After production seed, SPA shows no demo banner
- [ ] `backend/scripts/fixtures/production/config.json` is gitignored and does not appear in `git status`