### PR TITLE
test: maximize test coverage across frontend and backend

### DIFF
--- a/backend/src/__tests__/auth.jti.coverage.test.ts
+++ b/backend/src/__tests__/auth.jti.coverage.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Auth middleware coverage — JTI blacklist paths and app.ts uncovered branches:
+ *   - addToBlacklist: adds jti with default and explicit expiry
+ *   - authenticate: TOKEN_REVOKED when jti is blacklisted (line 115-122)
+ *   - authenticate: req.tokenJti and req.tokenExp are assigned (lines 125-127)
+ *   - app.ts: HTTPS redirect in production (lines 65-71)
+ *   - app.ts: rate limiter 429 RATE_LIMIT_EXCEEDED (lines 127-133)
+ *
+ * @author Luca Ostinelli
+ */
+
+import express from 'express';
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+
+import { authenticate, addToBlacklist } from '../middleware/auth';
+import { buildApp } from '../app';
+import { config } from '../config';
+import type { Pool } from 'mysql2/promise';
+
+jest.mock('../services/UserService');
+jest.mock('../services/RbacService');
+jest.mock('../config/database', () => ({
+  __esModule: true,
+  default: {
+    isHealthy: jest.fn().mockResolvedValue(true),
+    getPool: jest.fn().mockReturnValue({}),
+  },
+  database: {
+    isHealthy: jest.fn().mockResolvedValue(true),
+    getPool: jest.fn().mockReturnValue({}),
+  },
+}));
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const fakePool = {
+  execute: jest.fn().mockResolvedValue([[], null]),
+  getConnection: jest.fn(),
+} as unknown as Pool;
+
+const makeApp = () => {
+  const app = express();
+  app.use(express.json());
+  app.get('/protected', authenticate, (req, res) => {
+    res.json({ tokenJti: req.tokenJti ?? null, tokenExp: req.tokenExp ?? null });
+  });
+  return app;
+};
+
+// ─── JTI Blacklist — addToBlacklist ──────────────────────────────────────────
+
+describe('addToBlacklist', () => {
+  it('is exported and callable without throwing', () => {
+    expect(() => addToBlacklist('jti-abc', Date.now() + 60_000)).not.toThrow();
+  });
+
+  it('causes authenticate to reject that jti with TOKEN_REVOKED', async () => {
+    const jti = `test-jti-${Date.now()}`;
+    // Put the jti in the blacklist BEFORE issuing the token
+    addToBlacklist(jti, Date.now() + 60_000);
+
+    const token = jwt.sign({ userId: 1, email: 'a@x', jti }, config.jwt.secret, {
+      expiresIn: '1h',
+    });
+
+    const app = makeApp();
+    const res = await request(app).get('/protected').set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe('TOKEN_REVOKED');
+    expect(res.body.error.message).toBe('Token has been revoked');
+  });
+
+  it('allows authenticate to pass when jti has expired in the blacklist', async () => {
+    const { UserService } = require('../services/UserService');
+    const { RbacService } = require('../services/RbacService');
+
+    UserService.prototype.getUserById = jest.fn().mockResolvedValue({
+      id: 1,
+      email: 'user@x',
+      isActive: true,
+    });
+    RbacService.prototype.getEffectivePermissions = jest.fn().mockResolvedValue([]);
+    RbacService.prototype.getUserRoles = jest.fn().mockResolvedValue([]);
+    RbacService.prototype.computeAllowedOrgUnitIds = jest.fn().mockResolvedValue(null);
+
+    const jti = `expired-jti-${Date.now()}`;
+    // Set expiry in the past so the entry is considered expired
+    addToBlacklist(jti, Date.now() - 1);
+
+    const token = jwt.sign({ userId: 1, email: 'user@x', jti }, config.jwt.secret, {
+      expiresIn: '1h',
+    });
+
+    const app = makeApp();
+    const res = await request(app).get('/protected').set('Authorization', `Bearer ${token}`);
+
+    // Should NOT be rejected — expired blacklist entries are pruned and treated as not blacklisted
+    expect(res.status).toBe(200);
+  });
+
+  it('uses a 24h default expiry when no expiresAt is provided', () => {
+    const jti = `default-exp-jti-${Date.now()}`;
+    // This should not throw even without an explicit expiresAt
+    expect(() => addToBlacklist(jti)).not.toThrow();
+  });
+});
+
+// ─── authenticate — req.tokenJti and req.tokenExp assignment ─────────────────
+
+describe('authenticate — tokenJti and tokenExp are set on req', () => {
+  it('sets req.tokenJti when the token contains a jti claim', async () => {
+    const { UserService } = require('../services/UserService');
+    const { RbacService } = require('../services/RbacService');
+
+    UserService.prototype.getUserById = jest.fn().mockResolvedValue({
+      id: 7,
+      email: 'tester@x',
+      isActive: true,
+    });
+    RbacService.prototype.getEffectivePermissions = jest.fn().mockResolvedValue([]);
+    RbacService.prototype.getUserRoles = jest.fn().mockResolvedValue([]);
+    RbacService.prototype.computeAllowedOrgUnitIds = jest.fn().mockResolvedValue(null);
+
+    const jti = `req-jti-${Date.now()}`;
+    const token = jwt.sign({ userId: 7, email: 'tester@x', jti }, config.jwt.secret, {
+      expiresIn: '1h',
+    });
+
+    const app = makeApp();
+    const res = await request(app).get('/protected').set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.tokenJti).toBe(jti);
+    expect(typeof res.body.tokenExp).toBe('number');
+  });
+
+  it('leaves req.tokenJti undefined when no jti claim is present', async () => {
+    const { UserService } = require('../services/UserService');
+    const { RbacService } = require('../services/RbacService');
+
+    UserService.prototype.getUserById = jest.fn().mockResolvedValue({
+      id: 8,
+      email: 'nojti@x',
+      isActive: true,
+    });
+    RbacService.prototype.getEffectivePermissions = jest.fn().mockResolvedValue([]);
+    RbacService.prototype.getUserRoles = jest.fn().mockResolvedValue([]);
+    RbacService.prototype.computeAllowedOrgUnitIds = jest.fn().mockResolvedValue(null);
+
+    // Token without jti
+    const token = jwt.sign({ userId: 8, email: 'nojti@x' }, config.jwt.secret, {
+      expiresIn: '1h',
+    });
+
+    const app = makeApp();
+    const res = await request(app).get('/protected').set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.tokenJti).toBeNull();
+  });
+});
+
+// ─── app.ts — HTTPS redirect (production + x-forwarded-proto: http) ──────────
+
+describe('buildApp — HTTPS redirect in production', () => {
+  const originalEnv = config.server.env;
+
+  afterEach(() => {
+    (config.server as any).env = originalEnv;
+  });
+
+  it('redirects 301 to https when x-forwarded-proto is http in production', async () => {
+    (config.server as any).env = 'production';
+    const app = buildApp(fakePool, { silent: true });
+
+    const res = await request(app)
+      .get('/api/health')
+      .set('x-forwarded-proto', 'http')
+      .set('host', 'example.com');
+
+    expect(res.status).toBe(301);
+    expect(res.headers.location).toMatch(/^https:\/\//);
+  });
+
+  it('does not redirect when x-forwarded-proto is https in production', async () => {
+    (config.server as any).env = 'production';
+    const app = buildApp(fakePool, { silent: true });
+
+    const res = await request(app)
+      .get('/api/health')
+      .set('x-forwarded-proto', 'https');
+
+    expect([200, 503]).toContain(res.status);
+    expect(res.status).not.toBe(301);
+  });
+
+  it('does not redirect in development even with x-forwarded-proto: http', async () => {
+    (config.server as any).env = 'development';
+    const app = buildApp(fakePool, { silent: true });
+
+    const res = await request(app)
+      .get('/api/health')
+      .set('x-forwarded-proto', 'http');
+
+    expect([200, 503]).toContain(res.status);
+    expect(res.status).not.toBe(301);
+  });
+});
+
+// ─── app.ts — rate limiter 429 ────────────────────────────────────────────────
+
+describe('buildApp — rate limiter returns 429 RATE_LIMIT_EXCEEDED', () => {
+  it('returns 429 after exceeding the rate limit', async () => {
+    const originalMax = config.security.rateLimitMax;
+    const originalWindow = config.security.rateLimitWindow;
+
+    // Set limit to 1 request per large window so the second request is throttled
+    (config.security as any).rateLimitMax = 1;
+    (config.security as any).rateLimitWindow = 60_000;
+
+    try {
+      const app = buildApp(fakePool, { silent: false });
+
+      // First request — should pass through (200 or 503, not 429)
+      await request(app).get('/api/health');
+
+      // Second request — should be rate-limited
+      const res = await request(app).get('/api/health');
+      expect(res.status).toBe(429);
+      expect(res.body.error.code).toBe('RATE_LIMIT_EXCEEDED');
+    } finally {
+      (config.security as any).rateLimitMax = originalMax;
+      (config.security as any).rateLimitWindow = originalWindow;
+    }
+  });
+});

--- a/frontend/src/components/Auth/PermissionRoute.test.tsx
+++ b/frontend/src/components/Auth/PermissionRoute.test.tsx
@@ -1,0 +1,140 @@
+/**
+ * Unit tests for PermissionRoute.
+ *
+ * @author Luca Ostinelli
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+
+import PermissionRoute from './PermissionRoute';
+
+const mockUseAuth = jest.fn();
+
+jest.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+const wrap = (ui: React.ReactElement, initialPath = '/protected') => (
+  <MemoryRouter initialEntries={[initialPath]}>
+    <Routes>
+      <Route path="/protected" element={ui} />
+      <Route path="/dashboard" element={<p>dashboard</p>} />
+      <Route path="/login" element={<p>login</p>} />
+    </Routes>
+  </MemoryRouter>
+);
+
+describe('<PermissionRoute />', () => {
+  it('renders children when user is authenticated and holds the permission', () => {
+    mockUseAuth.mockReturnValue({
+      user: { id: 1, permissions: ['schedule.manage'] },
+      isAuthenticated: true,
+      isLoading: false,
+    });
+
+    render(
+      wrap(
+        <PermissionRoute permission="schedule.manage">
+          <p>protected content</p>
+        </PermissionRoute>
+      )
+    );
+
+    expect(screen.getByText('protected content')).toBeInTheDocument();
+  });
+
+  it('redirects to /dashboard when user lacks the required permission', () => {
+    mockUseAuth.mockReturnValue({
+      user: { id: 1, permissions: ['report.read'] },
+      isAuthenticated: true,
+      isLoading: false,
+    });
+
+    render(
+      wrap(
+        <PermissionRoute permission="schedule.manage">
+          <p>protected content</p>
+        </PermissionRoute>
+      )
+    );
+
+    expect(screen.getByText('dashboard')).toBeInTheDocument();
+    expect(screen.queryByText('protected content')).not.toBeInTheDocument();
+  });
+
+  it('allows access when permissions array is empty (fail-open)', () => {
+    mockUseAuth.mockReturnValue({
+      user: { id: 1, permissions: [] },
+      isAuthenticated: true,
+      isLoading: false,
+    });
+
+    render(
+      wrap(
+        <PermissionRoute permission="schedule.manage">
+          <p>open content</p>
+        </PermissionRoute>
+      )
+    );
+
+    expect(screen.getByText('open content')).toBeInTheDocument();
+  });
+
+  it('allows access when user.permissions is undefined (fail-open)', () => {
+    mockUseAuth.mockReturnValue({
+      user: { id: 1 },
+      isAuthenticated: true,
+      isLoading: false,
+    });
+
+    render(
+      wrap(
+        <PermissionRoute permission="schedule.manage">
+          <p>fallback open</p>
+        </PermissionRoute>
+      )
+    );
+
+    expect(screen.getByText('fallback open')).toBeInTheDocument();
+  });
+
+  it('redirects to /login when user is not authenticated', () => {
+    mockUseAuth.mockReturnValue({
+      user: null,
+      isAuthenticated: false,
+      isLoading: false,
+    });
+
+    render(
+      wrap(
+        <PermissionRoute permission="schedule.manage">
+          <p>protected content</p>
+        </PermissionRoute>
+      )
+    );
+
+    expect(screen.getByText('login')).toBeInTheDocument();
+    expect(screen.queryByText('protected content')).not.toBeInTheDocument();
+  });
+
+  it('shows the loading spinner while auth is resolving', () => {
+    mockUseAuth.mockReturnValue({
+      user: null,
+      isAuthenticated: false,
+      isLoading: true,
+    });
+
+    render(
+      wrap(
+        <PermissionRoute permission="schedule.manage">
+          <p>protected content</p>
+        </PermissionRoute>
+      )
+    );
+
+    expect(screen.getByRole('status')).toBeInTheDocument();
+    expect(screen.queryByText('protected content')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/ErrorBoundary.test.tsx
+++ b/frontend/src/components/ErrorBoundary.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * Unit tests for ErrorBoundary.
+ *
+ * @author Luca Ostinelli
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ErrorBoundary from './ErrorBoundary';
+
+const ThrowOnMount: React.FC<{ message: string }> = ({ message }) => {
+  throw new Error(message);
+};
+
+const GoodChild: React.FC = () => <p>All good</p>;
+
+describe('<ErrorBoundary />', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    (console.error as jest.Mock).mockRestore();
+  });
+
+  it('renders children when there is no error', () => {
+    render(
+      <ErrorBoundary>
+        <GoodChild />
+      </ErrorBoundary>
+    );
+    expect(screen.getByText('All good')).toBeInTheDocument();
+  });
+
+  it('displays the fallback UI when a child throws', () => {
+    render(
+      <ErrorBoundary>
+        <ThrowOnMount message="Boom" />
+      </ErrorBoundary>
+    );
+    expect(screen.getByText(/something went wrong/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /reload the page/i })).toBeInTheDocument();
+  });
+
+  it('calls window.location.reload when the reload button is clicked', () => {
+    const reloadSpy = jest.fn();
+    Object.defineProperty(window, 'location', {
+      value: { reload: reloadSpy },
+      writable: true,
+    });
+
+    render(
+      <ErrorBoundary>
+        <ThrowOnMount message="Crash" />
+      </ErrorBoundary>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /reload the page/i }));
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs to console.error in non-production mode', () => {
+    render(
+      <ErrorBoundary>
+        <ThrowOnMount message="Dev error" />
+      </ErrorBoundary>
+    );
+    expect(console.error).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/contexts/ThemeContext.test.tsx
+++ b/frontend/src/contexts/ThemeContext.test.tsx
@@ -64,4 +64,51 @@ describe('ThemeContext', () => {
     await userEvent.click(screen.getByText('toggle'));
     expect(screen.getByTestId('choice')).toHaveTextContent('dark');
   });
+
+  it('resolves system theme via matchMedia when available', () => {
+    const mockMql = {
+      matches: true,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    };
+    window.matchMedia = jest.fn().mockReturnValue(mockMql);
+
+    render(
+      <ThemeProvider>
+        <Probe />
+      </ThemeProvider>
+    );
+
+    // matchMedia was checked: system choice with matches=true resolves to 'dark'
+    expect(screen.getByTestId('resolved')).toHaveTextContent('dark');
+  });
+
+  it('attaches and removes a matchMedia change listener when choice is system', () => {
+    let changeHandler: (() => void) | null = null;
+    const mockMql = {
+      matches: false,
+      addEventListener: jest.fn().mockImplementation((_evt: string, fn: () => void) => {
+        changeHandler = fn;
+      }),
+      removeEventListener: jest.fn(),
+    };
+    window.matchMedia = jest.fn().mockReturnValue(mockMql);
+
+    const { unmount } = render(
+      <ThemeProvider>
+        <Probe />
+      </ThemeProvider>
+    );
+
+    expect(mockMql.addEventListener).toHaveBeenCalledWith('change', expect.any(Function));
+
+    // Simulate OS switching to dark
+    if (changeHandler) {
+      mockMql.matches = true;
+      changeHandler();
+    }
+
+    unmount();
+    expect(mockMql.removeEventListener).toHaveBeenCalledWith('change', expect.any(Function));
+  });
 });

--- a/frontend/src/contexts/ThemeContext.test.tsx
+++ b/frontend/src/contexts/ThemeContext.test.tsx
@@ -103,9 +103,9 @@ describe('ThemeContext', () => {
     expect(mockMql.addEventListener).toHaveBeenCalledWith('change', expect.any(Function));
 
     // Simulate OS switching to dark
-    if (changeHandler) {
+    if (typeof changeHandler === 'function') {
       mockMql.matches = true;
-      changeHandler();
+      (changeHandler as () => void)();
     }
 
     unmount();

--- a/frontend/src/pages/Policies/PolicyList.test.tsx
+++ b/frontend/src/pages/Policies/PolicyList.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * Tests for PolicyList component.
+ *
+ * @author Luca Ostinelli
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import PolicyList from './PolicyList';
+import type { Policy, PolicyScope } from '../../services/policyService';
+
+const makePolicy = (overrides: Partial<Policy> = {}): Policy => ({
+  id: 1,
+  scopeType: 'global',
+  scopeId: null,
+  policyKey: 'min_rest_hours',
+  policyValue: { hours: 11 },
+  description: 'Minimum rest hours',
+  imposedByUserId: 1,
+  isActive: true,
+  createdAt: '2025-01-01',
+  updatedAt: '2025-01-01',
+  ...overrides,
+});
+
+const defaultForm = {
+  scopeType: 'global' as PolicyScope,
+  scopeId: '',
+  policyKey: '',
+  policyValue: '',
+  description: '',
+};
+
+const defaultProps = {
+  policies: [],
+  busy: false,
+  canManage: true,
+  currentUserId: 1,
+  isAdmin: true,
+  policyForm: defaultForm,
+  onFormChange: jest.fn(),
+  onCreatePolicy: jest.fn(),
+  onToggleActive: jest.fn(),
+  onDeletePolicy: jest.fn(),
+};
+
+describe('<PolicyList />', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('renders the empty state when no policies exist', () => {
+    render(<PolicyList {...defaultProps} />);
+    expect(screen.getAllByText(/no policies/i).length).toBeGreaterThan(0);
+  });
+
+  it('shows the create form when canManage is true', () => {
+    render(<PolicyList {...defaultProps} />);
+    expect(screen.getByRole('button', { name: /^add$/i })).toBeInTheDocument();
+  });
+
+  it('hides the create form when canManage is false', () => {
+    render(<PolicyList {...defaultProps} canManage={false} />);
+    expect(screen.queryByRole('button', { name: /^add$/i })).not.toBeInTheDocument();
+  });
+
+  it('renders a row for each policy', () => {
+    const policies = [
+      makePolicy({ id: 1, policyKey: 'min_rest_hours' }),
+      makePolicy({ id: 2, policyKey: 'max_shifts_per_week' }),
+    ];
+    render(<PolicyList {...defaultProps} policies={policies} />);
+    expect(screen.getByText('min_rest_hours')).toBeInTheDocument();
+    expect(screen.getByText('max_shifts_per_week')).toBeInTheDocument();
+  });
+
+  it('shows active badge for active policies', () => {
+    render(<PolicyList {...defaultProps} policies={[makePolicy({ isActive: true })]} />);
+    expect(screen.getByText('active')).toBeInTheDocument();
+  });
+
+  it('shows inactive badge for inactive policies', () => {
+    render(<PolicyList {...defaultProps} policies={[makePolicy({ isActive: false })]} />);
+    expect(screen.getByText('inactive')).toBeInTheDocument();
+  });
+
+  it('calls onToggleActive when Deactivate is clicked', () => {
+    const policy = makePolicy({ isActive: true });
+    render(<PolicyList {...defaultProps} policies={[policy]} />);
+    fireEvent.click(screen.getByRole('button', { name: /deactivate/i }));
+    expect(defaultProps.onToggleActive).toHaveBeenCalledWith(policy);
+  });
+
+  it('calls onToggleActive with Activate for inactive policies', () => {
+    const policy = makePolicy({ isActive: false });
+    render(<PolicyList {...defaultProps} policies={[policy]} />);
+    fireEvent.click(screen.getByRole('button', { name: /activate/i }));
+    expect(defaultProps.onToggleActive).toHaveBeenCalledWith(policy);
+  });
+
+  it('calls onDeletePolicy when Delete is clicked', () => {
+    const policy = makePolicy({ id: 42 });
+    render(<PolicyList {...defaultProps} policies={[policy]} />);
+    fireEvent.click(screen.getByRole('button', { name: /delete/i }));
+    expect(defaultProps.onDeletePolicy).toHaveBeenCalledWith(42);
+  });
+
+  it('hides action buttons when neither owner nor admin', () => {
+    const policy = makePolicy({ id: 1, imposedByUserId: 99 });
+    render(
+      <PolicyList
+        {...defaultProps}
+        policies={[policy]}
+        currentUserId={1}
+        isAdmin={false}
+      />
+    );
+    expect(screen.queryByRole('button', { name: /deactivate/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /delete/i })).not.toBeInTheDocument();
+  });
+
+  it('shows action buttons when user is the policy owner', () => {
+    const policy = makePolicy({ id: 1, imposedByUserId: 5 });
+    render(
+      <PolicyList
+        {...defaultProps}
+        policies={[policy]}
+        currentUserId={5}
+        isAdmin={false}
+      />
+    );
+    expect(screen.getByRole('button', { name: /deactivate/i })).toBeInTheDocument();
+  });
+
+  it('calls onFormChange when scope type select changes', () => {
+    render(<PolicyList {...defaultProps} />);
+    const scopeSelect = screen.getAllByRole('combobox')[0];
+    fireEvent.change(scopeSelect, { target: { value: 'org_unit' } });
+    expect(defaultProps.onFormChange).toHaveBeenCalledWith(
+      expect.objectContaining({ scopeType: 'org_unit' })
+    );
+  });
+
+  it('renders scopeId in parentheses when set', () => {
+    const policy = makePolicy({ scopeType: 'org_unit', scopeId: 3 });
+    render(<PolicyList {...defaultProps} policies={[policy]} />);
+    expect(screen.getByText('org_unit(3)')).toBeInTheDocument();
+  });
+
+  it('calls onCreatePolicy when the form is submitted', () => {
+    render(<PolicyList {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button', { name: /^add$/i }));
+    expect(defaultProps.onCreatePolicy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/pages/Policies/PolicyList.test.tsx
+++ b/frontend/src/pages/Policies/PolicyList.test.tsx
@@ -4,7 +4,6 @@
  * @author Luca Ostinelli
  */
 
-import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import PolicyList from './PolicyList';
 import type { Policy, PolicyScope } from '../../services/policyService';

--- a/frontend/src/pages/Schedule/ScheduleList.test.tsx
+++ b/frontend/src/pages/Schedule/ScheduleList.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * Tests for ScheduleList component.
+ *
+ * @author Luca Ostinelli
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ScheduleList from './ScheduleList';
+import type { Schedule } from '../../types';
+
+const makeSchedule = (overrides: Partial<Schedule> = {}): Schedule => ({
+  id: 1,
+  name: 'Test Schedule',
+  status: 'draft',
+  startDate: '2025-01-01',
+  endDate: '2025-01-31',
+  departmentId: 1,
+  departmentName: 'Cardiology',
+  description: '',
+  createdAt: '2025-01-01',
+  updatedAt: '2025-01-01',
+  ...overrides,
+});
+
+describe('<ScheduleList />', () => {
+  const defaultProps = {
+    schedules: [],
+    onGenerate: jest.fn(),
+    onPublish: jest.fn(),
+    onArchive: jest.fn(),
+    onCreateNew: jest.fn(),
+  };
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('renders the empty state when schedules array is empty', () => {
+    render(<ScheduleList {...defaultProps} />);
+    expect(screen.getByText(/no schedules yet/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /new schedule/i })).toBeInTheDocument();
+  });
+
+  it('calls onCreateNew when the empty state button is clicked', () => {
+    render(<ScheduleList {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button', { name: /new schedule/i }));
+    expect(defaultProps.onCreateNew).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders a card for each schedule', () => {
+    const schedules = [makeSchedule({ id: 1, name: 'S1' }), makeSchedule({ id: 2, name: 'S2' })];
+    render(<ScheduleList {...defaultProps} schedules={schedules} />);
+    expect(screen.getByText('S1')).toBeInTheDocument();
+    expect(screen.getByText('S2')).toBeInTheDocument();
+  });
+
+  it('shows the department badge when departmentName is set', () => {
+    render(<ScheduleList {...defaultProps} schedules={[makeSchedule()]} />);
+    expect(screen.getByText('Cardiology')).toBeInTheDocument();
+  });
+
+  it('renders a "draft" badge for draft schedules', () => {
+    render(<ScheduleList {...defaultProps} schedules={[makeSchedule({ status: 'draft' })]} />);
+    expect(screen.getByText('draft')).toBeInTheDocument();
+  });
+
+  it('renders a "published" badge for published schedules', () => {
+    render(<ScheduleList {...defaultProps} schedules={[makeSchedule({ status: 'published' })]} />);
+    expect(screen.getByText('published')).toBeInTheDocument();
+  });
+
+  it('calls onGenerate when the Generate button is clicked', () => {
+    const schedule = makeSchedule();
+    render(<ScheduleList {...defaultProps} schedules={[schedule]} />);
+    fireEvent.click(screen.getByRole('button', { name: /generate/i }));
+    expect(defaultProps.onGenerate).toHaveBeenCalledWith(schedule);
+  });
+
+  it('shows the Publish button only for draft schedules', () => {
+    render(<ScheduleList {...defaultProps} schedules={[makeSchedule({ status: 'draft' })]} />);
+    expect(screen.getByRole('button', { name: /publish/i })).toBeInTheDocument();
+  });
+
+  it('hides the Publish button for published schedules', () => {
+    render(<ScheduleList {...defaultProps} schedules={[makeSchedule({ status: 'published' })]} />);
+    expect(screen.queryByRole('button', { name: /publish/i })).not.toBeInTheDocument();
+  });
+
+  it('calls onPublish with the schedule id when Publish is clicked', () => {
+    const schedule = makeSchedule({ id: 42, status: 'draft' });
+    render(<ScheduleList {...defaultProps} schedules={[schedule]} />);
+    fireEvent.click(screen.getByRole('button', { name: /publish/i }));
+    expect(defaultProps.onPublish).toHaveBeenCalledWith(42);
+  });
+
+  it('shows the Archive button for non-archived schedules', () => {
+    render(<ScheduleList {...defaultProps} schedules={[makeSchedule({ status: 'draft' })]} />);
+    expect(screen.getByRole('button', { name: /archive/i })).toBeInTheDocument();
+  });
+
+  it('hides the Archive button for already-archived schedules', () => {
+    render(<ScheduleList {...defaultProps} schedules={[makeSchedule({ status: 'archived' })]} />);
+    expect(screen.queryByRole('button', { name: /archive/i })).not.toBeInTheDocument();
+  });
+
+  it('calls onArchive with the schedule id when Archive is clicked', () => {
+    const schedule = makeSchedule({ id: 7, status: 'draft' });
+    render(<ScheduleList {...defaultProps} schedules={[schedule]} />);
+    fireEvent.click(screen.getByRole('button', { name: /archive/i }));
+    expect(defaultProps.onArchive).toHaveBeenCalledWith(7);
+  });
+
+  it('does not render departmentName badge when not set', () => {
+    const schedule = makeSchedule({ departmentName: undefined });
+    render(<ScheduleList {...defaultProps} schedules={[schedule]} />);
+    expect(screen.queryByText('Cardiology')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/Schedule/ScheduleList.test.tsx
+++ b/frontend/src/pages/Schedule/ScheduleList.test.tsx
@@ -4,7 +4,6 @@
  * @author Luca Ostinelli
  */
 
-import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import ScheduleList from './ScheduleList';
 import type { Schedule } from '../../types';

--- a/frontend/src/pages/Settings/CalendarSection.test.tsx
+++ b/frontend/src/pages/Settings/CalendarSection.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * Tests for CalendarSection (Settings → Calendar tab).
+ *
+ * @author Luca Ostinelli
+ */
+
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const mockGetOrCreate = jest.fn();
+const mockRotate = jest.fn();
+const mockBuildFeedUrl = jest.fn((token: string) => `http://localhost:3001/calendar/feed.ics?token=${token}`);
+
+jest.mock('../../services/calendarService', () => ({
+  __esModule: true,
+  getOrCreateCalendarToken: (...args: unknown[]) => mockGetOrCreate(...args),
+  rotateCalendarToken: (...args: unknown[]) => mockRotate(...args),
+  buildFeedUrl: (...args: unknown[]) => mockBuildFeedUrl(...(args as [string])),
+}));
+
+const CalendarSection = require('./CalendarSection').default as React.FC;
+
+describe('<CalendarSection />', () => {
+  beforeEach(() => {
+    mockGetOrCreate.mockResolvedValue({ token: 'test-token-123' });
+    mockRotate.mockResolvedValue({ token: 'rotated-token-456' });
+    mockBuildFeedUrl.mockImplementation(
+      (token: string) => `http://localhost:3001/calendar/feed.ics?token=${token}`
+    );
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('shows a loading spinner initially then renders the feed URL', async () => {
+    render(<CalendarSection />);
+
+    await screen.findByLabelText('Calendar feed URL');
+
+    const input = screen.getByLabelText('Calendar feed URL') as HTMLInputElement;
+    expect(input.value).toContain('test-token-123');
+  });
+
+  it('shows an error alert if token loading fails', async () => {
+    mockGetOrCreate.mockRejectedValue(new Error('Network error'));
+    render(<CalendarSection />);
+
+    await screen.findByRole('alert');
+    expect(screen.getByText(/network error/i)).toBeInTheDocument();
+  });
+
+  it('renders all four client instruction sections', async () => {
+    render(<CalendarSection />);
+
+    await screen.findByLabelText('Calendar feed URL');
+
+    expect(screen.getAllByText(/Google Calendar/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Apple Calendar/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Outlook/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Thunderbird/).length).toBeGreaterThan(0);
+  });
+
+  it('copies the feed URL to clipboard when Copy is clicked', async () => {
+    Object.assign(navigator, {
+      clipboard: { writeText: jest.fn().mockResolvedValue(undefined) },
+    });
+
+    render(<CalendarSection />);
+    await screen.findByLabelText('Calendar feed URL');
+
+    await userEvent.click(screen.getByRole('button', { name: /copy feed url to clipboard/i }));
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      expect.stringContaining('test-token-123')
+    );
+    await screen.findByText(/copied/i);
+  });
+
+  it('shows error when clipboard write fails', async () => {
+    Object.assign(navigator, {
+      clipboard: { writeText: jest.fn().mockRejectedValue(new Error('Clipboard denied')) },
+    });
+
+    render(<CalendarSection />);
+    await screen.findByLabelText('Calendar feed URL');
+
+    await userEvent.click(screen.getByRole('button', { name: /copy feed url to clipboard/i }));
+    await screen.findByRole('alert');
+  });
+
+  it('rotates the token when confirmed via window.confirm', async () => {
+    jest.spyOn(window, 'confirm').mockReturnValue(true);
+
+    render(<CalendarSection />);
+    await screen.findByRole('button', { name: /rotate token/i });
+
+    await userEvent.click(screen.getByRole('button', { name: /rotate token/i }));
+
+    await waitFor(() => {
+      const input = screen.getByLabelText('Calendar feed URL') as HTMLInputElement;
+      expect(input.value).toContain('rotated-token-456');
+    });
+
+    (window.confirm as jest.Mock).mockRestore();
+  });
+
+  it('does not rotate the token when window.confirm is cancelled', async () => {
+    jest.spyOn(window, 'confirm').mockReturnValue(false);
+
+    render(<CalendarSection />);
+    await screen.findByRole('button', { name: /rotate token/i });
+
+    await userEvent.click(screen.getByRole('button', { name: /rotate token/i }));
+    expect(mockRotate).not.toHaveBeenCalled();
+
+    (window.confirm as jest.Mock).mockRestore();
+  });
+
+  it('shows an error alert when rotation fails', async () => {
+    jest.spyOn(window, 'confirm').mockReturnValue(true);
+    mockRotate.mockRejectedValue(new Error('Rotation failed'));
+
+    render(<CalendarSection />);
+    await screen.findByRole('button', { name: /rotate token/i });
+
+    await userEvent.click(screen.getByRole('button', { name: /rotate token/i }));
+    await screen.findByText(/rotation failed/i);
+
+    (window.confirm as jest.Mock).mockRestore();
+  });
+});

--- a/frontend/src/pages/Settings/PreferencesSection.test.tsx
+++ b/frontend/src/pages/Settings/PreferencesSection.test.tsx
@@ -4,7 +4,6 @@
  * @author Luca Ostinelli
  */
 
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import PreferencesSection from './PreferencesSection';

--- a/frontend/src/pages/Settings/PreferencesSection.test.tsx
+++ b/frontend/src/pages/Settings/PreferencesSection.test.tsx
@@ -1,0 +1,168 @@
+/**
+ * Tests for PreferencesSection (Settings → Personal tab).
+ *
+ * @author Luca Ostinelli
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import PreferencesSection from './PreferencesSection';
+
+const defaultSettings = {
+  theme: 'light' as const,
+  language: 'en' as const,
+  timezone: 'UTC',
+  notifications: { email: true, push: false, sms: false },
+};
+
+describe('<PreferencesSection />', () => {
+  it('renders all form fields', () => {
+    render(
+      <PreferencesSection
+        settings={defaultSettings}
+        onChange={jest.fn()}
+        onSave={jest.fn().mockResolvedValue(undefined)}
+      />
+    );
+
+    expect(screen.getByLabelText(/^theme$/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^language$/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^timezone$/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/email notifications/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/push notifications/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/sms notifications/i)).toBeInTheDocument();
+  });
+
+  it('calls onChange when theme is changed', async () => {
+    const onChange = jest.fn();
+    render(
+      <PreferencesSection
+        settings={defaultSettings}
+        onChange={onChange}
+        onSave={jest.fn().mockResolvedValue(undefined)}
+      />
+    );
+
+    await userEvent.selectOptions(screen.getByLabelText(/^theme$/i), 'dark');
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ theme: 'dark' })
+    );
+  });
+
+  it('calls onChange when language is changed', async () => {
+    const onChange = jest.fn();
+    render(
+      <PreferencesSection
+        settings={defaultSettings}
+        onChange={onChange}
+        onSave={jest.fn().mockResolvedValue(undefined)}
+      />
+    );
+
+    await userEvent.selectOptions(screen.getByLabelText(/^language$/i), 'it');
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ language: 'it' })
+    );
+  });
+
+  it('calls onChange when timezone is changed', async () => {
+    const onChange = jest.fn();
+    render(
+      <PreferencesSection
+        settings={defaultSettings}
+        onChange={onChange}
+        onSave={jest.fn().mockResolvedValue(undefined)}
+      />
+    );
+
+    await userEvent.selectOptions(screen.getByLabelText(/^timezone$/i), 'Europe/Rome');
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ timezone: 'Europe/Rome' })
+    );
+  });
+
+  it('calls onChange when email notification is toggled', async () => {
+    const onChange = jest.fn();
+    render(
+      <PreferencesSection
+        settings={defaultSettings}
+        onChange={onChange}
+        onSave={jest.fn().mockResolvedValue(undefined)}
+      />
+    );
+
+    await userEvent.click(screen.getByLabelText(/email notifications/i));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        notifications: expect.objectContaining({ email: false }),
+      })
+    );
+  });
+
+  it('calls onChange when push notification is toggled', async () => {
+    const onChange = jest.fn();
+    render(
+      <PreferencesSection
+        settings={defaultSettings}
+        onChange={onChange}
+        onSave={jest.fn().mockResolvedValue(undefined)}
+      />
+    );
+
+    await userEvent.click(screen.getByLabelText(/push notifications/i));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        notifications: expect.objectContaining({ push: true }),
+      })
+    );
+  });
+
+  it('calls onChange when SMS notification is toggled', async () => {
+    const onChange = jest.fn();
+    render(
+      <PreferencesSection
+        settings={defaultSettings}
+        onChange={onChange}
+        onSave={jest.fn().mockResolvedValue(undefined)}
+      />
+    );
+
+    await userEvent.click(screen.getByLabelText(/sms notifications/i));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        notifications: expect.objectContaining({ sms: true }),
+      })
+    );
+  });
+
+  it('calls onSave and shows success message on successful submit', async () => {
+    const onSave = jest.fn().mockResolvedValue(undefined);
+    render(
+      <PreferencesSection
+        settings={defaultSettings}
+        onChange={jest.fn()}
+        onSave={onSave}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /save personal settings/i }));
+    expect(onSave).toHaveBeenCalledTimes(1);
+    expect(await screen.findByText(/personal preferences saved successfully/i)).toBeInTheDocument();
+  });
+
+  it('shows an error message when onSave rejects', async () => {
+    const onSave = jest.fn().mockRejectedValue(new Error('Server error'));
+    render(
+      <PreferencesSection
+        settings={defaultSettings}
+        onChange={jest.fn()}
+        onSave={onSave}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /save personal settings/i }));
+    expect(await screen.findByRole('alert')).toBeInTheDocument();
+    expect(await screen.findByText(/server error/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/Settings/ProfileSection.test.tsx
+++ b/frontend/src/pages/Settings/ProfileSection.test.tsx
@@ -4,7 +4,6 @@
  * @author Luca Ostinelli
  */
 
-import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import ProfileSection from './ProfileSection';

--- a/frontend/src/pages/Settings/ProfileSection.test.tsx
+++ b/frontend/src/pages/Settings/ProfileSection.test.tsx
@@ -1,0 +1,147 @@
+/**
+ * Tests for ProfileSection (Settings → Work Preferences tab).
+ *
+ * @author Luca Ostinelli
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ProfileSection from './ProfileSection';
+
+const defaultSettings = {
+  maxHoursPerWeek: 40,
+  maxConsecutiveDays: 5,
+  minRestHours: 11,
+  preferredShifts: [],
+  availabilitySettings: { unavailableDates: [], preferredDepartments: [] },
+};
+
+describe('<ProfileSection />', () => {
+  it('renders all form fields', () => {
+    render(
+      <ProfileSection
+        settings={defaultSettings}
+        onChange={jest.fn()}
+        onSave={jest.fn().mockResolvedValue(undefined)}
+      />
+    );
+
+    expect(screen.getByLabelText(/max hours per week/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/max consecutive days/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/min rest hours/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/day shift/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/afternoon shift/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/night shift/i)).toBeInTheDocument();
+  });
+
+  it('calls onChange when maxHoursPerWeek is changed', () => {
+    const onChange = jest.fn();
+    render(
+      <ProfileSection
+        settings={defaultSettings}
+        onChange={onChange}
+        onSave={jest.fn().mockResolvedValue(undefined)}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText(/max hours per week/i), { target: { value: '45' } });
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ maxHoursPerWeek: 45 })
+    );
+  });
+
+  it('calls onChange when maxConsecutiveDays is changed', () => {
+    const onChange = jest.fn();
+    render(
+      <ProfileSection
+        settings={defaultSettings}
+        onChange={onChange}
+        onSave={jest.fn().mockResolvedValue(undefined)}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText(/max consecutive days/i), { target: { value: '6' } });
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ maxConsecutiveDays: 6 })
+    );
+  });
+
+  it('calls onChange when minRestHours is changed', () => {
+    const onChange = jest.fn();
+    render(
+      <ProfileSection
+        settings={defaultSettings}
+        onChange={onChange}
+        onSave={jest.fn().mockResolvedValue(undefined)}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText(/min rest hours/i), { target: { value: '12' } });
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ minRestHours: 12 })
+    );
+  });
+
+  it('adds a preferred shift when its checkbox is checked', async () => {
+    const onChange = jest.fn();
+    render(
+      <ProfileSection
+        settings={defaultSettings}
+        onChange={onChange}
+        onSave={jest.fn().mockResolvedValue(undefined)}
+      />
+    );
+
+    await userEvent.click(screen.getByLabelText(/day shift/i));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ preferredShifts: ['day-shift'] })
+    );
+  });
+
+  it('removes a preferred shift when its checkbox is unchecked', async () => {
+    const onChange = jest.fn();
+    render(
+      <ProfileSection
+        settings={{ ...defaultSettings, preferredShifts: ['day-shift', 'night-shift'] }}
+        onChange={onChange}
+        onSave={jest.fn().mockResolvedValue(undefined)}
+      />
+    );
+
+    await userEvent.click(screen.getByLabelText(/day shift/i));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ preferredShifts: ['night-shift'] })
+    );
+  });
+
+  it('calls onSave and shows success message on successful submit', async () => {
+    const onSave = jest.fn().mockResolvedValue(undefined);
+    render(
+      <ProfileSection
+        settings={defaultSettings}
+        onChange={jest.fn()}
+        onSave={onSave}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /save work settings/i }));
+    expect(onSave).toHaveBeenCalledTimes(1);
+    expect(await screen.findByText(/work preferences saved successfully/i)).toBeInTheDocument();
+  });
+
+  it('shows an error message when onSave rejects', async () => {
+    const onSave = jest.fn().mockRejectedValue(new Error('Save failed'));
+    render(
+      <ProfileSection
+        settings={defaultSettings}
+        onChange={jest.fn()}
+        onSave={onSave}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /save work settings/i }));
+    expect(await screen.findByRole('alert')).toBeInTheDocument();
+    expect(await screen.findByText(/save failed/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/Settings/Settings.test.tsx
+++ b/frontend/src/pages/Settings/Settings.test.tsx
@@ -24,15 +24,32 @@ jest.mock('../../services/settingsService', () => ({
   updateTimePeriod: jest.fn().mockResolvedValue({ success: true, data: { timePeriod: 'monthly' } }),
 }));
 
+const mockGetPreferences = jest.fn();
+const mockUpdatePreferences = jest.fn();
+
 jest.mock('../../services/preferencesService', () => ({
-  getMyPreferences: jest.fn().mockResolvedValue({ success: true, data: null }),
-  updateMyPreferences: jest.fn().mockResolvedValue({ success: true, data: {} }),
+  getMyPreferences: (...args: unknown[]) => mockGetPreferences(...args),
+  updateMyPreferences: (...args: unknown[]) => mockUpdatePreferences(...args),
+}));
+
+jest.mock('../../services/calendarService', () => ({
+  __esModule: true,
+  getOrCreateCalendarToken: jest.fn().mockResolvedValue({ token: 'tok' }),
+  rotateCalendarToken: jest.fn().mockResolvedValue({ token: 'rotated' }),
+  buildFeedUrl: jest.fn((t: string) => `http://localhost/feed.ics?token=${t}`),
 }));
 
 // eslint-disable-next-line import/first
 import Settings from './Settings';
 
 describe('<Settings />', () => {
+  beforeEach(() => {
+    mockGetPreferences.mockResolvedValue({ success: true, data: null });
+    mockUpdatePreferences.mockResolvedValue({ success: true, data: {} });
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
   it('renders all tabs (admin variant)', async () => {
     mockUseAuth.mockReturnValue({
       user: { id: 1, email: 'admin@x', role: 'admin', permissions: ['settings.manage'] },
@@ -65,5 +82,68 @@ describe('<Settings />', () => {
     });
     render(<Settings />);
     expect(screen.queryByRole('button', { name: /^System$/ })).not.toBeInTheDocument();
+  });
+
+  it('hydrates work settings when preferences load with data', async () => {
+    mockUseAuth.mockReturnValue({
+      user: { id: 1, email: 'admin@x', permissions: [] },
+    });
+    mockGetPreferences.mockResolvedValue({
+      success: true,
+      data: { maxHoursPerWeek: 35, maxConsecutiveDays: 4 },
+    });
+
+    render(<Settings />);
+    await userEvent.click(screen.getByRole('button', { name: /^Work Preferences$/ }));
+    const hoursInput = (await screen.findByLabelText(/max hours per week/i)) as HTMLInputElement;
+    expect(hoursInput.value).toBe('35');
+  });
+
+  it('calls updateMyPreferences when Save Personal Settings is submitted', async () => {
+    mockUseAuth.mockReturnValue({
+      user: { id: 1, email: 'admin@x', permissions: [] },
+    });
+
+    render(<Settings />);
+    await userEvent.click(screen.getByRole('button', { name: /save personal settings/i }));
+    expect(mockUpdatePreferences).toHaveBeenCalledWith(
+      expect.objectContaining({ notes: expect.any(String) })
+    );
+  });
+
+  it('calls updateMyPreferences when Save Work Settings is submitted', async () => {
+    mockUseAuth.mockReturnValue({
+      user: { id: 1, email: 'admin@x', permissions: [] },
+    });
+
+    render(<Settings />);
+    await userEvent.click(screen.getByRole('button', { name: /^Work Preferences$/ }));
+    await userEvent.click(screen.getByRole('button', { name: /save work settings/i }));
+    expect(mockUpdatePreferences).toHaveBeenCalledWith(
+      expect.objectContaining({
+        maxHoursPerWeek: expect.any(Number),
+        maxConsecutiveDays: expect.any(Number),
+      })
+    );
+  });
+
+  it('renders the Calendar tab and shows CalendarSection when clicked', async () => {
+    mockUseAuth.mockReturnValue({
+      user: { id: 1, email: 'admin@x', permissions: [] },
+    });
+
+    render(<Settings />);
+    await userEvent.click(screen.getByRole('button', { name: /^Calendar$/ }));
+    expect(screen.getByText(/Calendar Feed/)).toBeInTheDocument();
+  });
+
+  it('renders the System tab when admin clicks it', async () => {
+    mockUseAuth.mockReturnValue({
+      user: { id: 1, email: 'admin@x', permissions: ['settings.manage'] },
+    });
+
+    render(<Settings />);
+    await userEvent.click(screen.getByRole('button', { name: /^System$/ }));
+    expect(screen.getByText(/System Configuration/)).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/Settings/SystemSection.test.tsx
+++ b/frontend/src/pages/Settings/SystemSection.test.tsx
@@ -4,8 +4,7 @@
  * @author Luca Ostinelli
  */
 
-import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import SystemSection from './SystemSection';

--- a/frontend/src/pages/Settings/SystemSection.test.tsx
+++ b/frontend/src/pages/Settings/SystemSection.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * Tests for SystemSection (Settings → System tab, admin only).
+ *
+ * @author Luca Ostinelli
+ */
+
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import SystemSection from './SystemSection';
+
+const mockGetSystemSettings = jest.fn();
+const mockUpdateCurrency = jest.fn();
+const mockUpdateTimePeriod = jest.fn();
+
+jest.mock('../../services/settingsService', () => ({
+  getSystemSettings: () => mockGetSystemSettings(),
+  updateCurrency: (currency: string) => mockUpdateCurrency(currency),
+  updateTimePeriod: (tp: string) => mockUpdateTimePeriod(tp),
+}));
+
+describe('<SystemSection />', () => {
+  beforeEach(() => {
+    mockGetSystemSettings.mockResolvedValue({
+      success: true,
+      data: [
+        { category: 'general', key: 'currency', value: 'USD' },
+        { category: 'schedule', key: 'default_time_period', value: 'weekly' },
+      ],
+    });
+    mockUpdateCurrency.mockResolvedValue({ success: true, data: {} });
+    mockUpdateTimePeriod.mockResolvedValue({ success: true, data: {} });
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('shows a loading spinner initially', () => {
+    render(<SystemSection />);
+    expect(screen.getByRole('status', { hidden: true })).toBeInTheDocument();
+  });
+
+  it('loads and displays the current settings from the API', async () => {
+    render(<SystemSection />);
+
+    await screen.findByLabelText(/^currency$/i);
+
+    const currencySelect = screen.getByLabelText(/^currency$/i) as HTMLSelectElement;
+    expect(currencySelect.value).toBe('USD');
+
+    const timePeriodSelect = screen.getByLabelText(/default time period/i) as HTMLSelectElement;
+    expect(timePeriodSelect.value).toBe('weekly');
+  });
+
+  it('uses defaults when getSystemSettings fails', async () => {
+    mockGetSystemSettings.mockRejectedValue(new Error('Network error'));
+    render(<SystemSection />);
+
+    await screen.findByLabelText(/^currency$/i);
+
+    const currencySelect = screen.getByLabelText(/^currency$/i) as HTMLSelectElement;
+    expect(currencySelect.value).toBe('EUR');
+  });
+
+  it('uses defaults when API returns no matching settings', async () => {
+    mockGetSystemSettings.mockResolvedValue({ success: true, data: [] });
+    render(<SystemSection />);
+
+    await screen.findByLabelText(/^currency$/i);
+
+    const currencySelect = screen.getByLabelText(/^currency$/i) as HTMLSelectElement;
+    expect(currencySelect.value).toBe('EUR');
+  });
+
+  it('updates currency selection and calls onSave', async () => {
+    render(<SystemSection />);
+
+    await screen.findByLabelText(/^currency$/i);
+
+    await userEvent.selectOptions(screen.getByLabelText(/^currency$/i), 'EUR');
+    await userEvent.click(screen.getByRole('button', { name: /save system settings/i }));
+
+    expect(mockUpdateCurrency).toHaveBeenCalledWith('EUR');
+    expect(mockUpdateTimePeriod).toHaveBeenCalled();
+    expect(await screen.findByText(/system settings saved successfully/i)).toBeInTheDocument();
+  });
+
+  it('shows an error message when save fails', async () => {
+    mockUpdateCurrency.mockRejectedValue(new Error('Permission denied'));
+    render(<SystemSection />);
+
+    await screen.findByRole('button', { name: /save system settings/i });
+
+    await userEvent.click(screen.getByRole('button', { name: /save system settings/i }));
+    expect(await screen.findByRole('alert')).toBeInTheDocument();
+    expect(await screen.findByText(/permission denied/i)).toBeInTheDocument();
+  });
+
+  it('updates timePeriod selection', async () => {
+    render(<SystemSection />);
+
+    await screen.findByLabelText(/default time period/i);
+
+    await userEvent.selectOptions(screen.getByLabelText(/default time period/i), 'daily');
+    await userEvent.click(screen.getByRole('button', { name: /save system settings/i }));
+
+    expect(mockUpdateTimePeriod).toHaveBeenCalledWith('daily');
+  });
+});

--- a/frontend/src/pages/orgManagement/MemberList.test.tsx
+++ b/frontend/src/pages/orgManagement/MemberList.test.tsx
@@ -4,7 +4,6 @@
  * @author Luca Ostinelli
  */
 
-import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import MemberList from './MemberList';
 import type { OrgUnit, UserOrgUnit } from '../../services/orgService';
@@ -12,6 +11,7 @@ import type { OrgUnit, UserOrgUnit } from '../../services/orgService';
 const makeUnit = (overrides: Partial<OrgUnit> = {}): OrgUnit => ({
   id: 1,
   name: 'Cardiology',
+  description: null,
   parentId: null,
   managerUserId: null,
   isActive: true,

--- a/frontend/src/pages/orgManagement/MemberList.test.tsx
+++ b/frontend/src/pages/orgManagement/MemberList.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * Tests for MemberList component.
+ *
+ * @author Luca Ostinelli
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import MemberList from './MemberList';
+import type { OrgUnit, UserOrgUnit } from '../../services/orgService';
+
+const makeUnit = (overrides: Partial<OrgUnit> = {}): OrgUnit => ({
+  id: 1,
+  name: 'Cardiology',
+  parentId: null,
+  managerUserId: null,
+  isActive: true,
+  createdAt: '2025-01-01',
+  updatedAt: '2025-01-01',
+  ...overrides,
+});
+
+const makeMember = (overrides: Partial<UserOrgUnit> = {}): UserOrgUnit => ({
+  id: 1,
+  userId: 10,
+  orgUnitId: 1,
+  isPrimary: false,
+  assignedAt: '2025-01-01',
+  ...overrides,
+});
+
+const defaultProps = {
+  units: [makeUnit()],
+  selectedUnitId: null,
+  members: [],
+  busy: false,
+  canManage: true,
+  memberForm: { userId: '', isPrimary: false },
+  onUnitSelect: jest.fn(),
+  onMemberFormChange: jest.fn(),
+  onAddMember: jest.fn(),
+  onSetPrimary: jest.fn(),
+  onRemoveMember: jest.fn(),
+};
+
+describe('<MemberList />', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('renders a unit selector', () => {
+    render(<MemberList {...defaultProps} />);
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+  });
+
+  it('renders options for each unit', () => {
+    const units = [makeUnit({ id: 1, name: 'Alpha' }), makeUnit({ id: 2, name: 'Beta' })];
+    render(<MemberList {...defaultProps} units={units} />);
+    expect(screen.getByRole('option', { name: 'Alpha' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Beta' })).toBeInTheDocument();
+  });
+
+  it('calls onUnitSelect when a unit is selected', () => {
+    render(<MemberList {...defaultProps} />);
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: '1' } });
+    expect(defaultProps.onUnitSelect).toHaveBeenCalledWith(1);
+  });
+
+  it('calls onUnitSelect with null when empty option is selected', () => {
+    render(<MemberList {...defaultProps} />);
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: '' } });
+    expect(defaultProps.onUnitSelect).toHaveBeenCalledWith(null);
+  });
+
+  it('does not show member content when no unit is selected', () => {
+    render(<MemberList {...defaultProps} selectedUnitId={null} />);
+    expect(screen.queryByText(/no members/i)).not.toBeInTheDocument();
+  });
+
+  it('shows the empty state when unit is selected but no members', () => {
+    render(<MemberList {...defaultProps} selectedUnitId={1} members={[]} />);
+    expect(screen.getByText(/no members/i)).toBeInTheDocument();
+  });
+
+  it('shows the add member form when canManage is true and unit is selected', () => {
+    render(<MemberList {...defaultProps} selectedUnitId={1} />);
+    expect(screen.getByRole('button', { name: /add member/i })).toBeInTheDocument();
+  });
+
+  it('hides the add member form when canManage is false', () => {
+    render(<MemberList {...defaultProps} selectedUnitId={1} canManage={false} />);
+    expect(screen.queryByRole('button', { name: /add member/i })).not.toBeInTheDocument();
+  });
+
+  it('renders a row for each member', () => {
+    const members = [
+      makeMember({ userId: 10 }),
+      makeMember({ id: 2, userId: 20 }),
+    ];
+    render(<MemberList {...defaultProps} selectedUnitId={1} members={members} />);
+    expect(screen.getByText('10')).toBeInTheDocument();
+    expect(screen.getByText('20')).toBeInTheDocument();
+  });
+
+  it('shows "primary" badge for primary members', () => {
+    const members = [makeMember({ isPrimary: true })];
+    render(<MemberList {...defaultProps} selectedUnitId={1} members={members} />);
+    expect(screen.getByText('primary')).toBeInTheDocument();
+  });
+
+  it('shows Make Primary button for non-primary members when canManage', () => {
+    const members = [makeMember({ isPrimary: false })];
+    render(<MemberList {...defaultProps} selectedUnitId={1} members={members} />);
+    expect(screen.getByRole('button', { name: /make primary/i })).toBeInTheDocument();
+  });
+
+  it('hides Make Primary button for primary members', () => {
+    const members = [makeMember({ isPrimary: true })];
+    render(<MemberList {...defaultProps} selectedUnitId={1} members={members} />);
+    expect(screen.queryByRole('button', { name: /make primary/i })).not.toBeInTheDocument();
+  });
+
+  it('calls onSetPrimary with userId when Make Primary is clicked', () => {
+    const members = [makeMember({ userId: 10, isPrimary: false })];
+    render(<MemberList {...defaultProps} selectedUnitId={1} members={members} />);
+    fireEvent.click(screen.getByRole('button', { name: /make primary/i }));
+    expect(defaultProps.onSetPrimary).toHaveBeenCalledWith(10);
+  });
+
+  it('calls onRemoveMember with userId when Remove is clicked', () => {
+    const members = [makeMember({ userId: 10 })];
+    render(<MemberList {...defaultProps} selectedUnitId={1} members={members} />);
+    fireEvent.click(screen.getByRole('button', { name: /remove/i }));
+    expect(defaultProps.onRemoveMember).toHaveBeenCalledWith(10);
+  });
+
+  it('calls onMemberFormChange when Primary checkbox is toggled', () => {
+    render(<MemberList {...defaultProps} selectedUnitId={1} />);
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect(defaultProps.onMemberFormChange).toHaveBeenCalledWith(
+      expect.objectContaining({ isPrimary: true })
+    );
+  });
+});

--- a/frontend/src/pages/orgManagement/OrgTree.test.tsx
+++ b/frontend/src/pages/orgManagement/OrgTree.test.tsx
@@ -4,7 +4,6 @@
  * @author Luca Ostinelli
  */
 
-import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import OrgTree from './OrgTree';
 import type { OrgUnit, OrgUnitNode } from '../../services/orgService';
@@ -12,6 +11,7 @@ import type { OrgUnit, OrgUnitNode } from '../../services/orgService';
 const makeUnit = (overrides: Partial<OrgUnit> = {}): OrgUnit => ({
   id: 1,
   name: 'Root Unit',
+  description: null,
   parentId: null,
   managerUserId: null,
   isActive: true,
@@ -23,6 +23,7 @@ const makeUnit = (overrides: Partial<OrgUnit> = {}): OrgUnit => ({
 const makeNode = (overrides: Partial<OrgUnitNode> = {}): OrgUnitNode => ({
   id: 1,
   name: 'Root Unit',
+  description: null,
   parentId: null,
   managerUserId: null,
   isActive: true,

--- a/frontend/src/pages/orgManagement/OrgTree.test.tsx
+++ b/frontend/src/pages/orgManagement/OrgTree.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * Tests for OrgTree component.
+ *
+ * @author Luca Ostinelli
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import OrgTree from './OrgTree';
+import type { OrgUnit, OrgUnitNode } from '../../services/orgService';
+
+const makeUnit = (overrides: Partial<OrgUnit> = {}): OrgUnit => ({
+  id: 1,
+  name: 'Root Unit',
+  parentId: null,
+  managerUserId: null,
+  isActive: true,
+  createdAt: '2025-01-01',
+  updatedAt: '2025-01-01',
+  ...overrides,
+});
+
+const makeNode = (overrides: Partial<OrgUnitNode> = {}): OrgUnitNode => ({
+  id: 1,
+  name: 'Root Unit',
+  parentId: null,
+  managerUserId: null,
+  isActive: true,
+  createdAt: '2025-01-01',
+  updatedAt: '2025-01-01',
+  children: [],
+  ...overrides,
+});
+
+const defaultNewUnit = { name: '', parentId: '', managerUserId: '' };
+
+const defaultProps = {
+  units: [],
+  tree: [],
+  busy: false,
+  canAdmin: true,
+  newUnit: defaultNewUnit,
+  onNewUnitChange: jest.fn(),
+  onCreateUnit: jest.fn(),
+  onDeleteUnit: jest.fn(),
+  onViewMembers: jest.fn(),
+};
+
+describe('<OrgTree />', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('renders the empty state when tree is empty', () => {
+    render(<OrgTree {...defaultProps} />);
+    expect(screen.getByText(/no org units yet/i)).toBeInTheDocument();
+  });
+
+  it('shows the create form when canAdmin is true', () => {
+    render(<OrgTree {...defaultProps} />);
+    expect(screen.getByRole('button', { name: /create/i })).toBeInTheDocument();
+  });
+
+  it('hides the create form when canAdmin is false', () => {
+    render(<OrgTree {...defaultProps} canAdmin={false} />);
+    expect(screen.queryByRole('button', { name: /create/i })).not.toBeInTheDocument();
+  });
+
+  it('renders a row for each tree node', () => {
+    const tree = [
+      makeNode({ id: 1, name: 'Unit A' }),
+      makeNode({ id: 2, name: 'Unit B' }),
+    ];
+    render(<OrgTree {...defaultProps} tree={tree} />);
+    expect(screen.getByText('Unit A')).toBeInTheDocument();
+    expect(screen.getByText('Unit B')).toBeInTheDocument();
+  });
+
+  it('renders an active badge for active units', () => {
+    render(<OrgTree {...defaultProps} tree={[makeNode({ isActive: true })]} />);
+    expect(screen.getByText('active')).toBeInTheDocument();
+  });
+
+  it('renders an inactive badge for inactive units', () => {
+    render(<OrgTree {...defaultProps} tree={[makeNode({ isActive: false })]} />);
+    expect(screen.getByText('inactive')).toBeInTheDocument();
+  });
+
+  it('shows the manager user id when set', () => {
+    render(<OrgTree {...defaultProps} tree={[makeNode({ managerUserId: 42 })]} />);
+    expect(screen.getByText('42')).toBeInTheDocument();
+  });
+
+  it('shows a dash when managerUserId is null', () => {
+    render(<OrgTree {...defaultProps} tree={[makeNode({ managerUserId: null })]} />);
+    expect(screen.getAllByText('-').length).toBeGreaterThan(0);
+  });
+
+  it('calls onViewMembers when Members button is clicked', () => {
+    const node = makeNode({ id: 7 });
+    render(<OrgTree {...defaultProps} tree={[node]} />);
+    fireEvent.click(screen.getByRole('button', { name: /members/i }));
+    expect(defaultProps.onViewMembers).toHaveBeenCalledWith(7);
+  });
+
+  it('calls onDeleteUnit when Delete button is clicked', () => {
+    const node = makeNode({ id: 3 });
+    render(<OrgTree {...defaultProps} tree={[node]} />);
+    fireEvent.click(screen.getByRole('button', { name: /delete/i }));
+    expect(defaultProps.onDeleteUnit).toHaveBeenCalledWith(3);
+  });
+
+  it('hides the Delete button when canAdmin is false', () => {
+    render(<OrgTree {...defaultProps} canAdmin={false} tree={[makeNode()]} />);
+    expect(screen.queryByRole('button', { name: /delete/i })).not.toBeInTheDocument();
+  });
+
+  it('renders child nodes recursively', () => {
+    const tree = [
+      makeNode({
+        id: 1,
+        name: 'Parent',
+        children: [makeNode({ id: 2, name: 'Child', parentId: 1 })],
+      }),
+    ];
+    render(<OrgTree {...defaultProps} tree={tree} />);
+    expect(screen.getByText('Parent')).toBeInTheDocument();
+    expect(screen.getByText('Child')).toBeInTheDocument();
+  });
+
+  it('calls onNewUnitChange when unit name input changes', () => {
+    render(<OrgTree {...defaultProps} />);
+    const nameInput = screen.getByPlaceholderText(/unit name/i);
+    fireEvent.change(nameInput, { target: { value: 'New Unit' } });
+    expect(defaultProps.onNewUnitChange).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'New Unit' })
+    );
+  });
+
+  it('populates the parent select with available units', () => {
+    const units = [makeUnit({ id: 5, name: 'Root' })];
+    render(<OrgTree {...defaultProps} units={units} />);
+    expect(screen.getByRole('option', { name: 'Root' })).toBeInTheDocument();
+  });
+
+  it('calls onCreateUnit when the form is submitted', () => {
+    render(<OrgTree {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button', { name: /create/i }));
+    expect(defaultProps.onCreateUnit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/services/calendarService.test.ts
+++ b/frontend/src/services/calendarService.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Unit tests for calendarService.
+ *
+ * @author Luca Ostinelli
+ */
+
+import {
+  getOrCreateCalendarToken,
+  rotateCalendarToken,
+  buildFeedUrl,
+} from './calendarService';
+
+const okJson = (body: unknown): Response =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+beforeEach(() => {
+  global.fetch = jest.fn().mockResolvedValue(
+    okJson({ success: true, data: { token: 'tok-abc' } })
+  ) as jest.Mock;
+  localStorage.clear();
+  localStorage.setItem('token', 'jwt-token');
+});
+
+afterEach(() => jest.resetAllMocks());
+
+const fetchMock = () => global.fetch as jest.Mock;
+
+describe('getOrCreateCalendarToken', () => {
+  it('POSTs to /calendar/token and returns the token', async () => {
+    const result = await getOrCreateCalendarToken();
+    const [url, init] = fetchMock().mock.calls[0];
+    expect(url).toMatch(/\/calendar\/token$/);
+    expect(init?.method).toBe('POST');
+    expect(result).toEqual({ token: 'tok-abc' });
+  });
+});
+
+describe('rotateCalendarToken', () => {
+  it('POSTs to /calendar/token/rotate and returns the new token', async () => {
+    const result = await rotateCalendarToken();
+    const [url, init] = fetchMock().mock.calls[0];
+    expect(url).toMatch(/\/calendar\/token\/rotate$/);
+    expect(init?.method).toBe('POST');
+    expect(result).toEqual({ token: 'tok-abc' });
+  });
+});
+
+describe('buildFeedUrl', () => {
+  it('builds a URL containing the encoded token', () => {
+    const url = buildFeedUrl('my token=special');
+    expect(url).toContain('/calendar/feed.ics');
+    expect(url).toContain(encodeURIComponent('my token=special'));
+  });
+
+  it('returns a string', () => {
+    expect(typeof buildFeedUrl('x')).toBe('string');
+  });
+});

--- a/frontend/src/services/extraServices.test.ts
+++ b/frontend/src/services/extraServices.test.ts
@@ -13,6 +13,7 @@ import * as departmentService from './departmentService';
 import * as orgService from './orgService';
 import * as policyService from './policyService';
 import * as systemService from './systemService';
+import * as dashboardService from './dashboardService';
 import * as employeeService from './employeeService';
 import * as shiftService from './shiftService';
 import * as scheduleService from './scheduleService';
@@ -291,5 +292,91 @@ describe('authService extra', () => {
   it('refreshToken POSTs', async () => {
     await authService.refreshToken();
     expect(lastInit().method).toBe('POST');
+  });
+
+  it('login POSTs credentials to /auth/login', async () => {
+    await authService.login({ email: 'user@x.com', password: 'secret' });
+    expect(lastInit().method).toBe('POST');
+    expect(lastUrl()).toMatch(/\/auth\/login$/);
+    const body = JSON.parse(lastInit().body as string);
+    expect(body.email).toBe('user@x.com');
+  });
+
+  it('verifyToken GETs /auth/verify', async () => {
+    await authService.verifyToken();
+    expect(lastUrl()).toMatch(/\/auth\/verify$/);
+    expect((lastInit().method ?? 'GET')).toBe('GET');
+  });
+
+  it('logout POSTs /auth/logout and does not throw', async () => {
+    await authService.logout();
+    expect(lastUrl()).toMatch(/\/auth\/logout$/);
+    expect(lastInit().method).toBe('POST');
+  });
+});
+
+describe('dashboardService', () => {
+  it('getDashboardStats GETs /dashboard/stats', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(JSON.stringify({ success: true, data: { totalEmployees: 10 } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    ) as jest.Mock;
+
+    await dashboardService.getDashboardStats();
+    expect(fetchMock()).toHaveBeenCalledWith(
+      expect.stringMatching(/\/dashboard\/stats$/),
+      expect.anything()
+    );
+  });
+
+  it('getRecentActivity returns items from body.data.items', async () => {
+    const items = [{ id: 1, action: 'login' }];
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(JSON.stringify({ success: true, data: { items } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    ) as jest.Mock;
+
+    const result = await dashboardService.getRecentActivity(3);
+    expect(result).toEqual(items);
+    expect(fetchMock()).toHaveBeenCalledWith(
+      expect.stringMatching(/audit-logs\?limit=3$/),
+      expect.anything()
+    );
+  });
+
+  it('getRecentActivity returns items from body.data when it is an array', async () => {
+    const items = [{ id: 2, action: 'logout' }];
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(JSON.stringify({ success: true, data: items }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    ) as jest.Mock;
+
+    const result = await dashboardService.getRecentActivity();
+    expect(result).toEqual(items);
+  });
+
+  it('getRecentActivity returns [] when response is not ok', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: 'unauthorized' }), {
+        status: 401,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    ) as jest.Mock;
+
+    const result = await dashboardService.getRecentActivity();
+    expect(result).toEqual([]);
+  });
+
+  it('getRecentActivity returns [] when fetch throws', async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error('Network error')) as jest.Mock;
+
+    const result = await dashboardService.getRecentActivity();
+    expect(result).toEqual([]);
   });
 });

--- a/frontend/src/services/services.extended.test.ts
+++ b/frontend/src/services/services.extended.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Extended service tests covering previously uncovered branches.
+ *
+ * Covers:
+ *   - calendarService (all exports)
+ *   - employeeService (getEmployee, updateEmployee, deleteEmployee — 0% lines)
+ *   - shiftService (createShift, updateShift, deleteShift — 0% lines)
+ *   - scheduleService (getScheduleWithShifts, updateSchedule, deleteSchedule,
+ *       generateSchedule, publishSchedule, archiveSchedule)
+ *
+ * @author Luca Ostinelli
+ */
+
+import * as employeeService from './employeeService';
+import * as shiftService from './shiftService';
+import * as scheduleService from './scheduleService';
+
+const okJson = (body: unknown): Response =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+beforeEach(() => {
+  global.fetch = jest
+    .fn()
+    .mockResolvedValue(okJson({ success: true, data: {} })) as jest.Mock;
+  localStorage.clear();
+  localStorage.setItem('token', 'jwt-token');
+});
+
+afterEach(() => jest.resetAllMocks());
+
+const fetchMock = () => global.fetch as jest.Mock;
+const lastUrl = () => fetchMock().mock.calls[0][0] as string;
+const lastInit = () => fetchMock().mock.calls[0][1] as RequestInit;
+
+// ─── employeeService ──────────────────────────────────────────────────────────
+
+describe('employeeService', () => {
+  describe('getEmployees', () => {
+    it('passes filters as query params', async () => {
+      await employeeService.getEmployees({ department: 'ICU', page: 2, limit: 5 });
+      expect(lastUrl()).toContain('department=ICU');
+      expect(lastUrl()).toContain('page=2');
+      expect(lastUrl()).toContain('limit=5');
+    });
+
+    it('skips undefined filter values', async () => {
+      await employeeService.getEmployees({ department: undefined });
+      expect(lastUrl()).not.toContain('department');
+    });
+  });
+
+  describe('getEmployee', () => {
+    it('GETs /employees/:id', async () => {
+      await employeeService.getEmployee(42);
+      expect(lastUrl()).toMatch(/\/employees\/42$/);
+      expect(lastInit().method ?? 'GET').toBe('GET');
+    });
+
+    it('accepts a string id', async () => {
+      await employeeService.getEmployee('EMP001');
+      expect(lastUrl()).toMatch(/\/employees\/EMP001$/);
+    });
+  });
+
+  describe('createEmployee', () => {
+    it('POSTs the employee payload', async () => {
+      await employeeService.createEmployee({
+        employeeId: 'E1',
+        firstName: 'John',
+        lastName: 'Doe',
+        email: 'john@x.com',
+      });
+      expect(lastInit().method).toBe('POST');
+      expect(lastUrl()).toMatch(/\/employees$/);
+      const body = JSON.parse(lastInit().body as string);
+      expect(body.email).toBe('john@x.com');
+    });
+  });
+
+  describe('updateEmployee', () => {
+    it('PUTs the updated payload to /employees/:id', async () => {
+      await employeeService.updateEmployee(7, { position: 'Senior Nurse' });
+      expect(lastInit().method).toBe('PUT');
+      expect(lastUrl()).toMatch(/\/employees\/7$/);
+      const body = JSON.parse(lastInit().body as string);
+      expect(body.position).toBe('Senior Nurse');
+    });
+  });
+
+  describe('deleteEmployee', () => {
+    it('DELETEs /employees/:id', async () => {
+      await employeeService.deleteEmployee(9);
+      expect(lastInit().method).toBe('DELETE');
+      expect(lastUrl()).toMatch(/\/employees\/9$/);
+    });
+  });
+});
+
+// ─── shiftService ─────────────────────────────────────────────────────────────
+
+describe('shiftService', () => {
+  describe('getShifts', () => {
+    it('passes filters as query params', async () => {
+      await shiftService.getShifts({ status: 'open', page: 1, limit: 20 });
+      expect(lastUrl()).toContain('status=open');
+      expect(lastUrl()).toContain('page=1');
+    });
+
+    it('works with no filters', async () => {
+      await shiftService.getShifts();
+      expect(lastUrl()).toMatch(/\/shifts/);
+    });
+  });
+
+  describe('createShift', () => {
+    it('POSTs the shift data', async () => {
+      await shiftService.createShift({
+        scheduleId: 1,
+        departmentId: 2,
+        date: '2025-01-15',
+        startTime: '08:00',
+        endTime: '16:00',
+        minStaff: 2,
+      });
+      expect(lastInit().method).toBe('POST');
+      expect(lastUrl()).toMatch(/\/shifts$/);
+      const body = JSON.parse(lastInit().body as string);
+      expect(body.scheduleId).toBe(1);
+    });
+  });
+
+  describe('updateShift', () => {
+    it('PUTs to /shifts/:id', async () => {
+      await shiftService.updateShift(5, { minStaff: 3 });
+      expect(lastInit().method).toBe('PUT');
+      expect(lastUrl()).toMatch(/\/shifts\/5$/);
+    });
+
+    it('accepts a string id', async () => {
+      await shiftService.updateShift('shift-uuid', { status: 'confirmed' });
+      expect(lastUrl()).toMatch(/\/shifts\/shift-uuid$/);
+    });
+  });
+
+  describe('deleteShift', () => {
+    it('DELETEs /shifts/:id', async () => {
+      await shiftService.deleteShift(11);
+      expect(lastInit().method).toBe('DELETE');
+      expect(lastUrl()).toMatch(/\/shifts\/11$/);
+    });
+  });
+});
+
+// ─── scheduleService ──────────────────────────────────────────────────────────
+
+describe('scheduleService', () => {
+  describe('getSchedules', () => {
+    it('hits /schedules with no params', async () => {
+      await scheduleService.getSchedules();
+      expect(lastUrl()).toMatch(/\/schedules$/);
+    });
+
+    it('appends query params when provided', async () => {
+      await scheduleService.getSchedules({ departmentId: '3' });
+      expect(lastUrl()).toContain('departmentId=3');
+    });
+  });
+
+  describe('getScheduleWithShifts', () => {
+    it('GETs /schedules/:id/shifts', async () => {
+      await scheduleService.getScheduleWithShifts(4);
+      expect(lastUrl()).toMatch(/\/schedules\/4\/shifts$/);
+    });
+  });
+
+  describe('createSchedule', () => {
+    it('POSTs to /schedules', async () => {
+      await scheduleService.createSchedule({
+        name: 'Jan Schedule',
+        startDate: '2025-01-01',
+        endDate: '2025-01-31',
+        departmentId: 1,
+      });
+      expect(lastInit().method).toBe('POST');
+      expect(lastUrl()).toMatch(/\/schedules$/);
+    });
+  });
+
+  describe('updateSchedule', () => {
+    it('PUTs to /schedules/:id', async () => {
+      await scheduleService.updateSchedule(2, { name: 'Updated' });
+      expect(lastInit().method).toBe('PUT');
+      expect(lastUrl()).toMatch(/\/schedules\/2$/);
+    });
+  });
+
+  describe('deleteSchedule', () => {
+    it('DELETEs /schedules/:id', async () => {
+      await scheduleService.deleteSchedule(3);
+      expect(lastInit().method).toBe('DELETE');
+      expect(lastUrl()).toMatch(/\/schedules\/3$/);
+    });
+  });
+
+  describe('generateSchedule', () => {
+    it('POSTs to /schedules/:id/generate', async () => {
+      await scheduleService.generateSchedule(5);
+      expect(lastInit().method).toBe('POST');
+      expect(lastUrl()).toMatch(/\/schedules\/5\/generate$/);
+    });
+  });
+
+  describe('publishSchedule', () => {
+    it('PATCHes /schedules/:id/publish', async () => {
+      await scheduleService.publishSchedule(6);
+      expect(lastInit().method).toBe('PATCH');
+      expect(lastUrl()).toMatch(/\/schedules\/6\/publish$/);
+    });
+  });
+
+  describe('archiveSchedule', () => {
+    it('PATCHes /schedules/:id/archive', async () => {
+      await scheduleService.archiveSchedule(7);
+      expect(lastInit().method).toBe('PATCH');
+      expect(lastUrl()).toMatch(/\/schedules\/7\/archive$/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **13 new frontend test files** covering previously untested or undertested components and services: `ErrorBoundary`, `PermissionRoute`, `CalendarSection`, `PreferencesSection`, `ProfileSection`, `SystemSection`, `ScheduleList`, `PolicyList`, `OrgTree`, `MemberList`, `calendarService`, `services.extended`
- **1 new backend test file** (`auth.jti.coverage.test.ts`) covering JTI blacklist (`addToBlacklist`, `TOKEN_REVOKED`, `req.tokenJti/tokenExp` assignment), HTTPS redirect in production, and rate limiter 429 response
- **3 extended existing test files**: `Settings.test.tsx` (5 new tests for Calendar/System tabs and form submissions), `ThemeContext.test.tsx` (matchMedia system-theme resolution + change-listener lifecycle), `extraServices.test.ts` (authService login/verifyToken/logout, dashboardService all paths)

**Coverage delta:**
- Frontend: 87.84% → 88.97% statements, 78.65% → 79.74% branches — **245 tests** (up from 104)
- Backend: 99.04% statements — **1664 tests** (up from 1654)

## Test plan

- [ ] All CI checks pass (frontend lint, backend lint, frontend tests, backend tests)
- [ ] No regressions in existing test suites