### PR TITLE
fix: resolve all project-review findings

### DIFF
--- a/backend/src/routes/dashboard.ts
+++ b/backend/src/routes/dashboard.ts
@@ -87,8 +87,28 @@ router.get('/stats', authenticate, async (_req: Request, res: Response) => {
         AND YEAR(s.date) = YEAR(CURDATE())
     `;
 
-    // The seven aggregates are independent, so run them concurrently instead
-    // of serially — the endpoint latency becomes the slowest query, not the sum.
+    // Preference-match satisfaction: ratio of this month's assignments where the
+    // assigned shift appears in the employee's preferred_shifts list.
+    const satisfactionQuery = `
+      SELECT
+        COUNT(*) AS total_assignments,
+        SUM(
+          CASE
+            WHEN up.preferred_shifts IS NOT NULL
+              AND JSON_LENGTH(up.preferred_shifts) > 0
+              AND JSON_CONTAINS(up.preferred_shifts, CAST(sa.shift_id AS JSON))
+            THEN 1 ELSE 0
+          END
+        ) AS preferred_assignments
+      FROM shift_assignments sa
+      JOIN shifts s ON sa.shift_id = s.id
+      LEFT JOIN user_preferences up ON up.user_id = sa.user_id
+      WHERE MONTH(s.date) = MONTH(CURDATE())
+        AND YEAR(s.date) = YEAR(CURDATE())
+        AND sa.status IN ('confirmed', 'completed')
+    `;
+
+    // The eight aggregates are independent, so run them concurrently.
     const [
       totalEmployees,
       activeSchedules,
@@ -97,6 +117,7 @@ router.get('/stats', authenticate, async (_req: Request, res: Response) => {
       monthlyHoursResult,
       monthlyCostResult,
       coverageResult,
+      satisfactionResult,
     ] = await Promise.all([
       database.queryOne<{ count: number }>(totalEmployeesQuery),
       database.queryOne<{ count: number }>(activeSchedulesQuery),
@@ -105,6 +126,7 @@ router.get('/stats', authenticate, async (_req: Request, res: Response) => {
       database.queryOne<{ total_hours: number }>(monthlyHoursQuery),
       database.queryOne<{ total_cost: number }>(monthlyCostQuery),
       database.queryOne<{ total_shifts: number; covered_shifts: number }>(coverageQuery),
+      database.queryOne<{ total_assignments: number; preferred_assignments: number }>(satisfactionQuery),
     ]);
 
     const monthlyHours = monthlyHoursResult?.total_hours || 0;
@@ -112,10 +134,10 @@ router.get('/stats', authenticate, async (_req: Request, res: Response) => {
     const coverageRate = coverageResult && coverageResult.total_shifts > 0
       ? (coverageResult.covered_shifts / coverageResult.total_shifts) * 100
       : 0;
-
-    // Preference-match satisfaction scoring is not implemented yet; report 0
-    // rather than a fabricated value.
-    const employeeSatisfaction = 0;
+    const employeeSatisfaction =
+      satisfactionResult && satisfactionResult.total_assignments > 0
+        ? (satisfactionResult.preferred_assignments / satisfactionResult.total_assignments) * 100
+        : 0;
 
     const stats = {
       totalEmployees: totalEmployees?.count || 0,
@@ -125,7 +147,7 @@ router.get('/stats', authenticate, async (_req: Request, res: Response) => {
       monthlyHours: Math.round(monthlyHours),
       monthlyCost: Math.round(monthlyCost * 100) / 100,
       coverageRate: Math.round(coverageRate * 10) / 10,
-      employeeSatisfaction: Math.round(employeeSatisfaction * 10) / 10
+      employeeSatisfaction: Math.round(employeeSatisfaction * 10) / 10,
     };
 
     res.json({
@@ -134,14 +156,9 @@ router.get('/stats', authenticate, async (_req: Request, res: Response) => {
     });
   } catch (error) {
     logger.error('Dashboard stats error:', error);
-    
     res.status(500).json({
       success: false,
-      error: {
-        code: 'INTERNAL_ERROR',
-        message: 'Failed to fetch dashboard statistics',
-        details: error instanceof Error ? error.message : 'Unknown error'
-      }
+      error: { code: 'INTERNAL_ERROR', message: 'Failed to fetch dashboard statistics' },
     });
   }
 });
@@ -188,11 +205,7 @@ router.get('/activities', authenticate, async (_req: Request, res: Response) => 
     logger.error('Dashboard activities error:', error);
     res.status(500).json({
       success: false,
-      error: {
-        code: 'INTERNAL_ERROR',
-        message: 'Failed to load recent activities',
-        details: error instanceof Error ? error.message : 'Unknown error'
-      }
+      error: { code: 'INTERNAL_ERROR', message: 'Failed to load recent activities' },
     });
   }
 });
@@ -251,11 +264,7 @@ router.get('/upcoming-shifts', authenticate, async (_req: Request, res: Response
     
     res.status(500).json({
       success: false,
-      error: {
-        code: 'INTERNAL_ERROR',
-        message: 'Failed to load upcoming shifts',
-        details: error instanceof Error ? error.message : 'Unknown error'
-      }
+      error: { code: 'INTERNAL_ERROR', message: 'Failed to load upcoming shifts' },
     });
   }
 });
@@ -308,11 +317,7 @@ router.get('/departments', authenticate, async (_req: Request, res: Response) =>
     
     res.status(500).json({
       success: false,
-      error: {
-        code: 'INTERNAL_ERROR',
-        message: 'Failed to load department overview',
-        details: error instanceof Error ? error.message : 'Unknown error'
-      }
+      error: { code: 'INTERNAL_ERROR', message: 'Failed to load department overview' },
     });
   }
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -39,6 +39,7 @@ import { I18nProvider } from './i18n/I18nContext';
 
 // Chrome
 import DemoBanner from './components/DemoBanner';
+import LoadingSpinner from './components/LoadingSpinner';
 
 // Lazily loaded page components — split into separate chunks
 const Dashboard = lazy(() => import('./pages/Dashboard/Dashboard'));
@@ -75,7 +76,7 @@ const App: React.FC = () => {
       <AuthProvider>
         <DemoBanner />
         <ErrorBoundary>
-        <Suspense fallback={null}>
+        <Suspense fallback={<LoadingSpinner />}>
         <Routes>
         {/* Public Routes - Accessible without authentication */}
         <Route path="/login" element={<Login />} />

--- a/frontend/src/components/Layout/Sidebar.tsx
+++ b/frontend/src/components/Layout/Sidebar.tsx
@@ -112,22 +112,23 @@ const Sidebar: React.FC<SidebarProps> = ({ collapsed }) => {
   return (
     <div className={`sidebar ${collapsed ? 'collapsed' : ''}`}>
       <div className="sidebar-brand">
-        <i className="bi bi-calendar-check-fill me-2"></i>
+        <i className="bi bi-calendar-check-fill me-2" aria-hidden="true"></i>
         {!collapsed && 'Staff Scheduler'}
       </div>
-      
+
       <nav aria-label="Main navigation">
         <ul className="sidebar-nav">
           {filteredMenuItems.map((item) => (
             <li key={item.path} className="sidebar-nav-item">
               <NavLink
                 to={item.path}
+                title={collapsed ? item.label : undefined}
                 className={({ isActive }) =>
                   `sidebar-nav-link ${isActive ? 'active' : ''}`
                 }
               >
-                <i className={item.icon}></i>
-                {!collapsed && item.label}
+                <i className={item.icon} aria-hidden="true"></i>
+                <span className={collapsed ? 'visually-hidden' : ''}>{item.label}</span>
               </NavLink>
             </li>
           ))}
@@ -135,7 +136,7 @@ const Sidebar: React.FC<SidebarProps> = ({ collapsed }) => {
       </nav>
 
       <div className="mt-auto p-3 border-top">
-        {user && (
+        {user && !collapsed && (
           <div className="text-body mb-2">
             <small>
               {user.email}
@@ -148,9 +149,11 @@ const Sidebar: React.FC<SidebarProps> = ({ collapsed }) => {
           className="btn btn-outline-secondary btn-sm w-100"
           type="button"
           onClick={handleLogout}
+          title={collapsed ? 'Logout' : undefined}
+          aria-label="Logout"
         >
-          <i className="bi bi-box-arrow-right me-1"></i>
-          {!collapsed && 'Logout'}
+          <i className="bi bi-box-arrow-right me-1" aria-hidden="true"></i>
+          {!collapsed && <span>Logout</span>}
         </button>
       </div>
     </div>

--- a/frontend/src/pages/Dashboard/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard/Dashboard.tsx
@@ -23,7 +23,7 @@
  */
 
 import React, { useState, useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, Link } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import { DashboardStats, AuditLogEntry } from '../../types';
 import { getDashboardStats, getRecentActivity } from '../../services/dashboardService';
@@ -119,7 +119,7 @@ const Dashboard: React.FC = () => {
       {/* Permission denied banner — shown when redirected from a guarded route */}
       {permissionDenied && (
         <div className="alert alert-warning alert-dismissible fade show mb-4" role="alert">
-          <i className="bi bi-shield-exclamation me-2"></i>
+          <i className="bi bi-shield-exclamation me-2" aria-hidden="true"></i>
           <strong>Access denied.</strong> You do not have permission to view that page.
           <button
             type="button"
@@ -158,7 +158,7 @@ const Dashboard: React.FC = () => {
                 <div className="d-flex align-items-center">
                   <div className="flex-shrink-0">
                     <div className="bg-primary bg-opacity-10 rounded-3 p-3">
-                      <i className="bi bi-people fs-4 text-primary"></i>
+                      <i className="bi bi-people fs-4 text-primary" aria-hidden="true"></i>
                     </div>
                   </div>
                   <div className="flex-grow-1 ms-3">
@@ -176,7 +176,7 @@ const Dashboard: React.FC = () => {
                 <div className="d-flex align-items-center">
                   <div className="flex-shrink-0">
                     <div className="bg-success bg-opacity-10 rounded-3 p-3">
-                      <i className="bi bi-calendar3 fs-4 text-success"></i>
+                      <i className="bi bi-calendar3 fs-4 text-success" aria-hidden="true"></i>
                     </div>
                   </div>
                   <div className="flex-grow-1 ms-3">
@@ -194,7 +194,7 @@ const Dashboard: React.FC = () => {
                 <div className="d-flex align-items-center">
                   <div className="flex-shrink-0">
                     <div className="bg-info bg-opacity-10 rounded-3 p-3">
-                      <i className="bi bi-clock fs-4 text-info"></i>
+                      <i className="bi bi-clock fs-4 text-info" aria-hidden="true"></i>
                     </div>
                   </div>
                   <div className="flex-grow-1 ms-3">
@@ -212,7 +212,7 @@ const Dashboard: React.FC = () => {
                 <div className="d-flex align-items-center">
                   <div className="flex-shrink-0">
                     <div className="bg-warning bg-opacity-10 rounded-3 p-3">
-                      <i className="bi bi-exclamation-triangle fs-4 text-warning"></i>
+                      <i className="bi bi-exclamation-triangle fs-4 text-warning" aria-hidden="true"></i>
                     </div>
                   </div>
                   <div className="flex-grow-1 ms-3">
@@ -280,22 +280,30 @@ const Dashboard: React.FC = () => {
             </div>
             <div className="card-body">
               <div className="d-grid gap-3">
-                <button className="btn btn-outline-primary text-start">
-                  <i className="bi bi-plus-circle me-2"></i>
-                  Create New Shift
-                </button>
-                <button className="btn btn-outline-success text-start">
-                  <i className="bi bi-person-plus me-2"></i>
-                  Add Employee
-                </button>
-                <button className="btn btn-outline-info text-start">
-                  <i className="bi bi-calendar-plus me-2"></i>
-                  Generate Schedule
-                </button>
-                <button className="btn btn-outline-warning text-start">
-                  <i className="bi bi-graph-up me-2"></i>
-                  View Reports
-                </button>
+                {user?.permissions?.includes('shift.manage') && (
+                  <Link to="/shifts" className="btn btn-outline-primary text-start">
+                    <i className="bi bi-plus-circle me-2" aria-hidden="true"></i>
+                    Create New Shift
+                  </Link>
+                )}
+                {user?.permissions?.includes('employee.read') && (
+                  <Link to="/employees" className="btn btn-outline-success text-start">
+                    <i className="bi bi-person-plus me-2" aria-hidden="true"></i>
+                    Add Employee
+                  </Link>
+                )}
+                {user?.permissions?.includes('schedule.read') && (
+                  <Link to="/schedule" className="btn btn-outline-info text-start">
+                    <i className="bi bi-calendar-plus me-2" aria-hidden="true"></i>
+                    Generate Schedule
+                  </Link>
+                )}
+                {user?.permissions?.includes('report.read') && (
+                  <Link to="/reports" className="btn btn-outline-warning text-start">
+                    <i className="bi bi-graph-up me-2" aria-hidden="true"></i>
+                    View Reports
+                  </Link>
+                )}
               </div>
             </div>
           </div>
@@ -310,7 +318,7 @@ const Dashboard: React.FC = () => {
               {recentActivity.length === 0 ? (
                 <div className="d-flex align-items-center justify-content-center text-center py-5 text-muted">
                   <div>
-                    <i className="bi bi-clock-history fs-3 mb-2 d-block"></i>
+                    <i className="bi bi-clock-history fs-3 mb-2 d-block" aria-hidden="true"></i>
                     <p className="mb-0">No recent activity.</p>
                   </div>
                 </div>

--- a/frontend/src/pages/Employees/Employees.tsx
+++ b/frontend/src/pages/Employees/Employees.tsx
@@ -152,7 +152,7 @@ const Employees: React.FC = () => {
               className="btn btn-primary"
               onClick={() => setShowAddModal(true)}
             >
-              <i className="bi bi-plus-lg me-2"></i>
+              <i className="bi bi-plus-lg me-2" aria-hidden="true"></i>
               Add Employee
             </button>
           </div>
@@ -164,7 +164,7 @@ const Employees: React.FC = () => {
         <div className="col-md-6">
           <div className="input-group">
             <span className="input-group-text">
-              <i className="bi bi-search"></i>
+              <i className="bi bi-search" aria-hidden="true"></i>
             </span>
             <input
               type="text"
@@ -200,7 +200,7 @@ const Employees: React.FC = () => {
       {/* Error Alert */}
       {error && (
         <div className="alert alert-warning alert-dismissible fade show" role="alert">
-          <i className="bi bi-exclamation-triangle me-2"></i>
+          <i className="bi bi-exclamation-triangle me-2" aria-hidden="true"></i>
           {error} - Showing sample data
           <button 
             type="button" 
@@ -231,7 +231,7 @@ const Employees: React.FC = () => {
                     <td>
                       <div className="d-flex align-items-center">
                         <div className="bg-primary bg-opacity-10 rounded-circle p-2 me-3">
-                          <i className="bi bi-person text-primary"></i>
+                          <i className="bi bi-person text-primary" aria-hidden="true"></i>
                         </div>
                         <div>
                           <div className="fw-medium">
@@ -263,7 +263,7 @@ const Employees: React.FC = () => {
                           title="Edit Employee"
                           aria-label="Edit employee"
                         >
-                          <i className="bi bi-pencil"></i>
+                          <i className="bi bi-pencil" aria-hidden="true"></i>
                         </button>
                         <button
                           className="btn btn-outline-danger"
@@ -271,7 +271,7 @@ const Employees: React.FC = () => {
                           title="Delete Employee"
                           aria-label="Delete employee"
                         >
-                          <i className="bi bi-trash"></i>
+                          <i className="bi bi-trash" aria-hidden="true"></i>
                         </button>
                       </div>
                     </td>
@@ -283,7 +283,7 @@ const Employees: React.FC = () => {
 
           {filteredEmployees.length === 0 && (
             <div className="text-center py-5">
-              <i className="bi bi-people text-muted" style={{ fontSize: '3rem' }}></i>
+              <i className="bi bi-people text-muted" style={{ fontSize: '3rem' }} aria-hidden="true"></i>
               <h5 className="mt-3">No employees found</h5>
               <p className="text-muted">
                 {searchTerm || selectedDepartment 

--- a/frontend/src/pages/Reports/Reports.tsx
+++ b/frontend/src/pages/Reports/Reports.tsx
@@ -4,17 +4,25 @@
  * Wires the reports API exposed by the backend (`/api/reports/*`):
  *   - hours-worked: total hours per user in a date range
  *   - cost-by-department: hours and labour cost rolled up by department
+ *   - fairness: workload distribution stats for a selected schedule
  *
- * The user picks a date range; both reports refresh together. Errors are
- * surfaced inline. Output is a couple of tables — sufficient as a v1 UI
- * on top of the API; richer charts can land later without changing the
- * service.
+ * The user picks a date range; the first two reports refresh together.
+ * The fairness section requires selecting a schedule.
  *
  * @author Luca Ostinelli
  */
 
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { hoursWorked, costByDepartment, HoursWorkedRow, CostByDepartmentRow } from '../../services/reportsService';
+import {
+  hoursWorked,
+  costByDepartment,
+  fairnessReport,
+  HoursWorkedRow,
+  CostByDepartmentRow,
+  FairnessReport,
+} from '../../services/reportsService';
+import { getSchedules } from '../../services/scheduleService';
+import { Schedule } from '../../types';
 import { formatCurrency } from '../../utils/format';
 import { errorMessage } from '../../utils/notify';
 
@@ -32,6 +40,18 @@ const Reports: React.FC = () => {
   const [cost, setCost] = useState<CostByDepartmentRow[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  const [schedules, setSchedules] = useState<Schedule[]>([]);
+  const [selectedScheduleId, setSelectedScheduleId] = useState<number | null>(null);
+  const [fairness, setFairness] = useState<FairnessReport | null>(null);
+  const [fairnessLoading, setFairnessLoading] = useState(false);
+  const [fairnessError, setFairnessError] = useState<string | null>(null);
+
+  useEffect(() => {
+    getSchedules().then((res) => {
+      if (res.success && res.data) setSchedules(res.data);
+    });
+  }, []);
 
   const reload = useCallback(async () => {
     setLoading(true);
@@ -53,6 +73,21 @@ const Reports: React.FC = () => {
   useEffect(() => {
     reload();
   }, [reload]);
+
+  useEffect(() => {
+    if (selectedScheduleId === null) {
+      setFairness(null);
+      return;
+    }
+    setFairnessLoading(true);
+    setFairnessError(null);
+    fairnessReport(selectedScheduleId)
+      .then((res) => {
+        if (res.success && res.data) setFairness(res.data);
+      })
+      .catch((err) => setFairnessError(errorMessage(err, 'Failed to load fairness report')))
+      .finally(() => setFairnessLoading(false));
+  }, [selectedScheduleId]);
 
   const totalCost = useMemo(() => cost.reduce((acc, r) => acc + (r.cost || 0), 0), [cost]);
 
@@ -98,7 +133,7 @@ const Reports: React.FC = () => {
         <div className="alert alert-danger" role="alert">{error}</div>
       )}
 
-      <div className="row g-4">
+      <div className="row g-4 mb-4">
         <div className="col-lg-6">
           <div className="card h-100">
             <div className="card-header">Hours worked by user</div>
@@ -163,6 +198,79 @@ const Reports: React.FC = () => {
             </div>
           </div>
         </div>
+      </div>
+
+      {/* Fairness report */}
+      <div className="card">
+        <div className="card-header d-flex align-items-center gap-3">
+          <span className="fw-semibold">Workload fairness by schedule</span>
+          <select
+            className="form-select form-select-sm w-auto"
+            value={selectedScheduleId ?? ''}
+            onChange={(e) =>
+              setSelectedScheduleId(e.target.value ? Number(e.target.value) : null)
+            }
+            aria-label="Select schedule for fairness report"
+          >
+            <option value="">— select a schedule —</option>
+            {schedules.map((s) => (
+              <option key={s.id} value={s.id}>
+                {s.name}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {selectedScheduleId === null ? (
+          <div className="card-body text-muted">
+            Select a schedule above to see workload distribution statistics.
+          </div>
+        ) : fairnessLoading ? (
+          <div className="card-body text-muted">Loading…</div>
+        ) : fairnessError ? (
+          <div className="card-body">
+            <div className="alert alert-danger mb-0" role="alert">{fairnessError}</div>
+          </div>
+        ) : fairness && fairness.perUser.length === 0 ? (
+          <div className="card-body text-muted">No assignments in this schedule yet.</div>
+        ) : fairness ? (
+          <div className="card-body">
+            <div className="row g-3 mb-3">
+              {[
+                { label: 'Employees', value: fairness.stats.count },
+                { label: 'Min hours', value: fairness.stats.min.toFixed(1) },
+                { label: 'Max hours', value: fairness.stats.max.toFixed(1) },
+                { label: 'Mean hours', value: fairness.stats.mean.toFixed(1) },
+                { label: 'Std dev', value: fairness.stats.stddev.toFixed(2) },
+              ].map(({ label, value }) => (
+                <div key={label} className="col-auto">
+                  <div className="border rounded p-2 text-center" style={{ minWidth: '90px' }}>
+                    <div className="fw-semibold">{value}</div>
+                    <small className="text-muted">{label}</small>
+                  </div>
+                </div>
+              ))}
+            </div>
+            <div className="table-responsive">
+              <table className="table table-sm mb-0">
+                <thead>
+                  <tr>
+                    <th scope="col">User</th>
+                    <th scope="col" className="text-end">Hours</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {fairness.perUser.map((row) => (
+                    <tr key={row.userId}>
+                      <td>{row.fullName}</td>
+                      <td className="text-end">{row.hours.toFixed(1)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        ) : null}
       </div>
     </div>
   );

--- a/frontend/src/pages/Schedule/CreateScheduleModal.tsx
+++ b/frontend/src/pages/Schedule/CreateScheduleModal.tsx
@@ -152,7 +152,7 @@ const CreateScheduleModal: React.FC<Props> = ({
                   </>
                 ) : (
                   <>
-                    <i className="bi bi-plus-lg me-2"></i>Create Schedule
+                    <i className="bi bi-plus-lg me-2" aria-hidden="true"></i>Create Schedule
                   </>
                 )}
               </button>

--- a/frontend/src/pages/Schedule/Schedule.tsx
+++ b/frontend/src/pages/Schedule/Schedule.tsx
@@ -313,7 +313,7 @@ const Schedule: React.FC = () => {
                 }}
                 data-testid="open-create-schedule"
               >
-                <i className="bi bi-plus-lg me-2"></i>
+                <i className="bi bi-plus-lg me-2" aria-hidden="true"></i>
                 New Schedule
               </button>
               <button
@@ -326,7 +326,7 @@ const Schedule: React.FC = () => {
                   setShowGenerateModal(true);
                 }}
               >
-                <i className="bi bi-magic me-2"></i>
+                <i className="bi bi-magic me-2" aria-hidden="true"></i>
                 Generate
               </button>
               <div className="btn-group" role="group">
@@ -360,7 +360,7 @@ const Schedule: React.FC = () => {
               type="button"
               onClick={() => navigateWeek('prev')}
             >
-              <i className="bi bi-chevron-left"></i>
+              <i className="bi bi-chevron-left" aria-hidden="true"></i>
             </button>
             <h5 className="mb-0">
               {viewMode === 'week'
@@ -375,7 +375,7 @@ const Schedule: React.FC = () => {
               type="button"
               onClick={() => navigateWeek('next')}
             >
-              <i className="bi bi-chevron-right"></i>
+              <i className="bi bi-chevron-right" aria-hidden="true"></i>
             </button>
           </div>
         </div>

--- a/frontend/src/pages/Shifts/ShiftTable.tsx
+++ b/frontend/src/pages/Shifts/ShiftTable.tsx
@@ -88,7 +88,7 @@ const ShiftTable: React.FC<Props> = ({
                     aria-label="Shift actions"
                     data-bs-toggle="dropdown"
                   >
-                    <i className="bi bi-three-dots"></i>
+                    <i className="bi bi-three-dots" aria-hidden="true"></i>
                   </button>
                   <ul className="dropdown-menu">
                     <li>
@@ -97,7 +97,7 @@ const ShiftTable: React.FC<Props> = ({
                         type="button"
                         onClick={() => onEdit(shift)}
                       >
-                        <i className="bi bi-pencil me-2"></i>Edit
+                        <i className="bi bi-pencil me-2" aria-hidden="true"></i>Edit
                       </button>
                     </li>
                     <li>
@@ -109,7 +109,7 @@ const ShiftTable: React.FC<Props> = ({
                         type="button"
                         onClick={() => onDelete(shift.id!)}
                       >
-                        <i className="bi bi-trash me-2"></i>Delete
+                        <i className="bi bi-trash me-2" aria-hidden="true"></i>Delete
                       </button>
                     </li>
                   </ul>

--- a/frontend/src/pages/Shifts/Shifts.tsx
+++ b/frontend/src/pages/Shifts/Shifts.tsx
@@ -227,7 +227,7 @@ const Shifts: React.FC = () => {
                 setShowAddModal(true);
               }}
             >
-              <i className="bi bi-plus-lg me-2"></i>
+              <i className="bi bi-plus-lg me-2" aria-hidden="true"></i>
               Add New Shift
             </button>
           </div>
@@ -238,7 +238,7 @@ const Shifts: React.FC = () => {
         <div className="col-md-6">
           <div className="input-group">
             <span className="input-group-text">
-              <i className="bi bi-search"></i>
+              <i className="bi bi-search" aria-hidden="true"></i>
             </span>
             <input
               type="text"
@@ -273,13 +273,13 @@ const Shifts: React.FC = () => {
 
       {error && (
         <div className="alert alert-danger" role="alert">
-          <i className="bi bi-exclamation-triangle me-2"></i>
+          <i className="bi bi-exclamation-triangle me-2" aria-hidden="true"></i>
           {error}
         </div>
       )}
       {info && (
         <div className="alert alert-success" role="alert">
-          <i className="bi bi-check-circle me-2"></i>
+          <i className="bi bi-check-circle me-2" aria-hidden="true"></i>
           {info}
         </div>
       )}

--- a/frontend/src/services/reportsService.ts
+++ b/frontend/src/services/reportsService.ts
@@ -37,3 +37,20 @@ export const hoursWorked = (start: string, end: string, departmentId?: number) =
 
 export const costByDepartment = (start: string, end: string) =>
   request<CostByDepartmentRow[]>(`/reports/cost-by-department?start=${start}&end=${end}`);
+
+export interface FairnessStats {
+  count: number;
+  min: number;
+  max: number;
+  mean: number;
+  stddev: number;
+}
+
+export interface FairnessReport {
+  scheduleId: number;
+  perUser: HoursWorkedRow[];
+  stats: FairnessStats;
+}
+
+export const fairnessReport = (scheduleId: number) =>
+  request<FairnessReport>(`/reports/fairness/${scheduleId}`);

--- a/frontend/src/services/reportsService.ts
+++ b/frontend/src/services/reportsService.ts
@@ -38,18 +38,10 @@ export const hoursWorked = (start: string, end: string, departmentId?: number) =
 export const costByDepartment = (start: string, end: string) =>
   request<CostByDepartmentRow[]>(`/reports/cost-by-department?start=${start}&end=${end}`);
 
-export interface FairnessStats {
-  count: number;
-  min: number;
-  max: number;
-  mean: number;
-  stddev: number;
-}
-
 export interface FairnessReport {
   scheduleId: number;
   perUser: HoursWorkedRow[];
-  stats: FairnessStats;
+  stats: { count: number; min: number; max: number; mean: number; stddev: number };
 }
 
 export const fairnessReport = (scheduleId: number) =>


### PR DESCRIPTION
## Summary

- **[High] Security**: Remove `details` field from all four dashboard error handlers — prevented raw SQL errors and service-layer exceptions from leaking to clients in production.
- **[Medium] Accessibility**: Sidebar NavLinks now always include label text in the DOM (toggled to `visually-hidden` when collapsed + `title` tooltip), icons get `aria-hidden="true"`.
- **[Medium] Feature**: Dashboard Quick Actions converted from non-functional `<button>` elements to permission-aware `<Link>` components that navigate to `/shifts`, `/employees`, `/schedule`, `/reports`. Items are hidden when the user lacks the required permission.
- **[Low] UX**: `<Suspense fallback={null}>` replaced with `<LoadingSpinner />` so lazy-loaded pages show a spinner during initial load.
- **[Low] Accessibility**: Added `aria-hidden="true"` to all decorative Bootstrap icons in Dashboard, Employees, Shifts, ShiftTable, Schedule, CreateScheduleModal.
- **[Low] Feature**: Implemented employee satisfaction metric in dashboard stats — uses `JSON_CONTAINS` to compute the ratio of this month's confirmed/completed assignments that match each assignee's `preferred_shifts` preferences.
- **[Low] Feature**: Added `fairnessReport(scheduleId)` to `reportsService` and wired a full Fairness section in the Reports page (schedule selector + stat tiles + per-user hours table).

## Test plan

- [ ] `cd backend && npx tsc --noEmit` — zero errors
- [ ] `cd frontend && npx tsc --noEmit` — zero errors
- [ ] `cd backend && npm test` — all 1664 tests pass
- [ ] Dashboard: Quick Actions buttons navigate to correct pages; hidden for users without permission
- [ ] Sidebar: collapse it, verify tooltip appears on hover; verify screen-reader-visible text via DOM inspection
- [ ] Reports page: select a schedule, verify fairness stats and per-user table load
- [ ] Dashboard stats: `employeeSatisfaction` is now a real percentage (0–100) when assignments exist