### PR TITLE
fix(tests): repair flaky timeout in assignment confirm/decline 404 test

### DIFF
--- a/backend/src/__tests__/routes.expanded.test.ts
+++ b/backend/src/__tests__/routes.expanded.test.ts
@@ -297,35 +297,57 @@ describe('assignments router (extended)', () => {
   for (const action of ['confirm', 'decline', 'complete'] as const) {
     describe(`PATCH /:id/${action}`, () => {
       const method = `${action}Assignment` as keyof typeof AssignmentService.prototype;
+
+      // confirm and decline do a pre-flight getAssignmentById check before calling
+      // the action method; complete calls the action method directly.
+      const hasPreFlight = action === 'confirm' || action === 'decline';
+
+      beforeEach(() => {
+        if (hasPreFlight) {
+          (AssignmentService.prototype.getAssignmentById as jest.Mock).mockResolvedValue({
+            id: 1,
+            userId: 1,
+          });
+        }
+        (AssignmentService.prototype[method] as jest.Mock).mockResolvedValue({ id: 1 });
+      });
+
       it('400 on NaN', async () => {
         const res = await request(app()).patch(`/api/assignments/abc/${action}`);
         expect(res.status).toBe(400);
       });
+
       it('200 success', async () => {
-        (AssignmentService.prototype[method] as jest.Mock) = jest.fn().mockResolvedValue({ id: 1 });
         const res = await request(app()).patch(`/api/assignments/1/${action}`);
         expect(res.status).toBe(200);
       });
+
       it('404 not found', async () => {
-        (AssignmentService.prototype[method] as jest.Mock) = jest
-          .fn()
-          .mockRejectedValue(new Error('Assignment not found'));
+        if (hasPreFlight) {
+          // Pre-flight returns null → route short-circuits with 404 before calling action.
+          (AssignmentService.prototype.getAssignmentById as jest.Mock).mockResolvedValue(null);
+        } else {
+          // complete has no pre-flight; trigger 404 via the action method.
+          (AssignmentService.prototype[method] as jest.Mock).mockRejectedValue(
+            new Error('Assignment not found')
+          );
+        }
         const res = await request(app()).patch(`/api/assignments/1/${action}`);
         expect(res.status).toBe(404);
       });
+
       if (action === 'confirm') {
         it('409 already confirmed', async () => {
-          (AssignmentService.prototype[method] as jest.Mock) = jest
-            .fn()
-            .mockRejectedValue(new Error('Already confirmed'));
+          (AssignmentService.prototype.confirmAssignment as jest.Mock).mockRejectedValue(
+            new Error('Already confirmed')
+          );
           const res = await request(app()).patch(`/api/assignments/1/${action}`);
           expect(res.status).toBe(409);
         });
       }
+
       it('500 on other error', async () => {
-        (AssignmentService.prototype[method] as jest.Mock) = jest
-          .fn()
-          .mockRejectedValue(new Error('boom'));
+        (AssignmentService.prototype[method] as jest.Mock).mockRejectedValue(new Error('boom'));
         const res = await request(app()).patch(`/api/assignments/1/${action}`);
         expect(res.status).toBe(500);
       });


### PR DESCRIPTION
## Summary

- `routes.expanded.test.ts`: il test `PATCH /:id/confirm 404 not found` andava in timeout (30 s) perché con `clearMocks + restoreMocks` nel `jest.config.json` il mock dell'action method veniva azzerato prima di ogni test, lasciando `getAssignmentById` in uno stato indeterminato.
- Fix: aggiunto un `beforeEach` scoped al `describe` che imposta esplicitamente i mock necessari; il test `404` ora mocka `getAssignmentById → null` per `confirm`/`decline` (che hanno un pre-flight check) e mocka l'action method per `complete` (che non ce l'ha).
- Nessuna modifica al codice applicativo.

## Test plan

- [ ] `npm test` passa 1664/1664 senza timeout
- [ ] I test `PATCH /:id/confirm`, `PATCH /:id/decline`, `PATCH /:id/complete` coprono: 400, 200, 404, 409 (solo confirm), 500

Closes #96