### PR TITLE
feat(audit): enhance audit_logs with justification, on_behalf_of and request_id

### DIFF
--- a/backend/database/init.sql
+++ b/backend/database/init.sql
@@ -577,24 +577,34 @@ CREATE TABLE IF NOT EXISTS modules (
 CREATE TABLE IF NOT EXISTS audit_logs (
     id INT PRIMARY KEY AUTO_INCREMENT,
     user_id INT NULL,
+    -- When the action was performed on behalf of another user (proxy / approval).
+    on_behalf_of_user_id INT NULL,
     action VARCHAR(100) NOT NULL,
     entity_type VARCHAR(50),
     entity_id INT,
     description TEXT,
+    -- Optional free-text reason supplied by the actor at the time of the action.
+    justification TEXT NULL,
     -- JSON snapshots of the entity state before and after a mutation.
     -- Populated for sensitive changes: role grants, policy edits, user updates.
     before_snapshot JSON NULL,
     after_snapshot JSON NULL,
     ip_address VARCHAR(45),
     user_agent TEXT,
+    -- Correlation ID from the X-Request-Id header; links the log entry back to
+    -- the HTTP request that triggered it.
+    request_id VARCHAR(36) NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
 
     INDEX idx_user (user_id),
+    INDEX idx_on_behalf_of (on_behalf_of_user_id),
     INDEX idx_action (action),
     INDEX idx_entity (entity_type, entity_id),
     INDEX idx_created (created_at),
+    INDEX idx_request_id (request_id),
 
-    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL,
+    FOREIGN KEY (on_behalf_of_user_id) REFERENCES users(id) ON DELETE SET NULL
 );
 
 -- ================================================================

--- a/backend/src/__tests__/audit.service.test.ts
+++ b/backend/src/__tests__/audit.service.test.ts
@@ -7,6 +7,8 @@
  *   - write: serialises before/after snapshots as JSON
  *   - list: returns paginated results with total count
  *   - getById: returns null for unknown id
+ *
+ * @author Luca Ostinelli
  */
 
 import { AuditLogService } from '../services/AuditLogService';
@@ -15,6 +17,20 @@ const makePool = () => {
   const execute = jest.fn();
   return { pool: { execute } as never, execute };
 };
+
+// INSERT column order:
+// [0]  user_id (actorId)
+// [1]  on_behalf_of_user_id
+// [2]  action
+// [3]  entity_type
+// [4]  entity_id
+// [5]  description
+// [6]  justification
+// [7]  before_snapshot
+// [8]  after_snapshot
+// [9]  ip_address
+// [10] user_agent
+// [11] request_id
 
 describe('AuditLogService.write', () => {
   it('inserts a row with the supplied fields', async () => {
@@ -33,8 +49,15 @@ describe('AuditLogService.write', () => {
 
     expect(execute).toHaveBeenCalledWith(
       expect.stringContaining('INSERT INTO audit_logs'),
-      [5, 'user.create', 'user', 10, 'test', null, JSON.stringify({ email: 'x@x.com' })]
+      expect.arrayContaining([5, 'user.create', 'user', 10, 'test'])
     );
+    const params = execute.mock.calls[0][1] as unknown[];
+    expect(params[0]).toBe(5);               // user_id
+    expect(params[2]).toBe('user.create');   // action
+    expect(params[3]).toBe('user');          // entity_type
+    expect(params[4]).toBe(10);             // entity_id
+    expect(params[5]).toBe('test');          // description
+    expect(params[8]).toBe(JSON.stringify({ email: 'x@x.com' })); // after_snapshot
   });
 
   it('silently swallows DB errors without throwing', async () => {
@@ -56,8 +79,8 @@ describe('AuditLogService.write', () => {
     await svc.write({ actorId: 1, action: 'schedule.publish', before, after });
 
     const callArgs = execute.mock.calls[0][1] as unknown[];
-    expect(callArgs[5]).toBe(JSON.stringify(before));
-    expect(callArgs[6]).toBe(JSON.stringify(after));
+    expect(callArgs[7]).toBe(JSON.stringify(before));  // before_snapshot
+    expect(callArgs[8]).toBe(JSON.stringify(after));   // after_snapshot
   });
 
   it('passes null for before/after when not provided', async () => {
@@ -68,8 +91,8 @@ describe('AuditLogService.write', () => {
     await svc.write({ actorId: 2, action: 'user.delete', entityType: 'user', entityId: 99 });
 
     const callArgs = execute.mock.calls[0][1] as unknown[];
-    expect(callArgs[5]).toBeNull();
-    expect(callArgs[6]).toBeNull();
+    expect(callArgs[7]).toBeNull();  // before_snapshot
+    expect(callArgs[8]).toBeNull();  // after_snapshot
   });
 });
 
@@ -77,11 +100,15 @@ describe('AuditLogService.list', () => {
   it('returns total and items from paginated query', async () => {
     const { pool, execute } = makePool();
     execute
-      .mockResolvedValueOnce([[{ c: 3 }], null])  // COUNT query
+      .mockResolvedValueOnce([[{ c: 3 }], null])
       .mockResolvedValueOnce([[
-        { id: 1, user_id: 5, action: 'user.create', entity_type: 'user', entity_id: 10,
-          description: null, before_snapshot: null, after_snapshot: null,
-          ip_address: null, user_agent: null, created_at: '2026-01-01T00:00:00Z' },
+        {
+          id: 1, user_id: 5, on_behalf_of_user_id: null, action: 'user.create',
+          entity_type: 'user', entity_id: 10, description: null, justification: null,
+          before_snapshot: null, after_snapshot: null,
+          ip_address: null, user_agent: null, request_id: null,
+          created_at: '2026-01-01T00:00:00Z',
+        },
       ], null]);
 
     const svc = new AuditLogService(pool);

--- a/backend/src/__tests__/auditLog.service.test.ts
+++ b/backend/src/__tests__/auditLog.service.test.ts
@@ -1,18 +1,33 @@
 /**
- * AuditLogService unit tests (F10).
+ * AuditLogService unit tests.
+ *
+ * Covers: list (filters, pagination, clamping), getById, write
+ * (new fields: justification, onBehalfOfUserId, request_id auto-pull from context).
+ *
+ * @author Luca Ostinelli
  */
 
 import { AuditLogService } from '../services/AuditLogService';
+import * as requestContext from '../middleware/requestContext';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
 const buildRow = (overrides: Record<string, unknown> = {}) => ({
   id: 1,
   user_id: 5,
+  on_behalf_of_user_id: null,
   action: 'login',
   entity_type: 'auth',
   entity_id: null,
   description: 'User signed in',
+  justification: null,
+  before_snapshot: null,
+  after_snapshot: null,
   ip_address: '127.0.0.1',
   user_agent: 'jest',
+  request_id: 'req-abc-123',
   created_at: '2026-04-26T12:00:00.000Z',
   ...overrides,
 });
@@ -21,6 +36,10 @@ const makePool = () => {
   const execute = jest.fn();
   return { pool: { execute } as never, execute };
 };
+
+// ---------------------------------------------------------------------------
+// list
+// ---------------------------------------------------------------------------
 
 describe('AuditLogService.list', () => {
   it('returns total + items with default limit/offset', async () => {
@@ -47,12 +66,35 @@ describe('AuditLogService.list', () => {
 
     const service = new AuditLogService(pool);
     await service.list({ limit: 9999 });
-    expect(execute.mock.calls[1][0]).toMatch(/LIMIT \? OFFSET \?/);
     const listParams = execute.mock.calls[1][1] as unknown[];
     expect(listParams.at(-2)).toBe(500);
   });
 
-  it('builds the WHERE clause from supplied filters', async () => {
+  it('clamps a zero limit to 1', async () => {
+    const { pool, execute } = makePool();
+    execute
+      .mockResolvedValueOnce([[{ c: 0 }], null])
+      .mockResolvedValueOnce([[], null]);
+
+    const service = new AuditLogService(pool);
+    await service.list({ limit: 0 });
+    const listParams = execute.mock.calls[1][1] as unknown[];
+    expect(listParams.at(-2)).toBe(1);
+  });
+
+  it('clamps a negative offset to 0', async () => {
+    const { pool, execute } = makePool();
+    execute
+      .mockResolvedValueOnce([[{ c: 0 }], null])
+      .mockResolvedValueOnce([[], null]);
+
+    const service = new AuditLogService(pool);
+    await service.list({ offset: -5 });
+    const listParams = execute.mock.calls[1][1] as unknown[];
+    expect(listParams.at(-1)).toBe(0);
+  });
+
+  it('builds WHERE clause from all supported filters', async () => {
     const { pool, execute } = makePool();
     execute
       .mockResolvedValueOnce([[{ c: 0 }], null])
@@ -61,23 +103,68 @@ describe('AuditLogService.list', () => {
     const service = new AuditLogService(pool);
     await service.list({
       userId: 5,
+      onBehalfOfUserId: 7,
       action: 'login',
       entityType: 'auth',
       entityId: 99,
       fromDate: '2026-04-01',
       toDate: '2026-04-30',
+      requestId: 'req-xyz',
     });
 
     const sqlCount = execute.mock.calls[0][0] as string;
     expect(sqlCount).toMatch(/user_id = \?/);
+    expect(sqlCount).toMatch(/on_behalf_of_user_id = \?/);
     expect(sqlCount).toMatch(/action = \?/);
     expect(sqlCount).toMatch(/entity_type = \?/);
     expect(sqlCount).toMatch(/entity_id = \?/);
     expect(sqlCount).toMatch(/created_at >= \?/);
     expect(sqlCount).toMatch(/created_at <= \?/);
-    expect(execute.mock.calls[0][1]).toEqual([5, 'login', 'auth', 99, '2026-04-01', '2026-04-30']);
+    expect(sqlCount).toMatch(/request_id = \?/);
+    expect(execute.mock.calls[0][1]).toEqual([
+      5, 7, 'login', 'auth', 99, '2026-04-01', '2026-04-30', 'req-xyz',
+    ]);
+  });
+
+  it('maps all new fields in the returned items', async () => {
+    const { pool, execute } = makePool();
+    execute
+      .mockResolvedValueOnce([[{ c: 1 }], null])
+      .mockResolvedValueOnce([[buildRow({
+        on_behalf_of_user_id: 7,
+        justification: 'approved by manager',
+        request_id: 'req-123',
+        before_snapshot: JSON.stringify({ status: 'pending' }),
+        after_snapshot: JSON.stringify({ status: 'approved' }),
+      })], null]);
+
+    const service = new AuditLogService(pool);
+    const { items } = await service.list({});
+    const [entry] = items;
+
+    expect(entry.onBehalfOfUserId).toBe(7);
+    expect(entry.justification).toBe('approved by manager');
+    expect(entry.requestId).toBe('req-123');
+    expect(entry.beforeSnapshot).toEqual({ status: 'pending' });
+    expect(entry.afterSnapshot).toEqual({ status: 'approved' });
+  });
+
+  it('tolerates malformed JSON in snapshots', async () => {
+    const { pool, execute } = makePool();
+    execute
+      .mockResolvedValueOnce([[{ c: 1 }], null])
+      .mockResolvedValueOnce([[buildRow({ before_snapshot: 'not-json', after_snapshot: '{bad' })], null]);
+
+    const service = new AuditLogService(pool);
+    const { items } = await service.list({});
+    expect(items[0].beforeSnapshot).toBeNull();
+    expect(items[0].afterSnapshot).toBeNull();
   });
 });
+
+// ---------------------------------------------------------------------------
+// getById
+// ---------------------------------------------------------------------------
 
 describe('AuditLogService.getById', () => {
   it('returns null when missing', async () => {
@@ -87,11 +174,121 @@ describe('AuditLogService.getById', () => {
     expect(await service.getById(99)).toBeNull();
   });
 
-  it('maps a row to a typed entry', async () => {
+  it('maps all fields including new ones', async () => {
     const { pool, execute } = makePool();
-    execute.mockResolvedValueOnce([[buildRow()], null]);
+    execute.mockResolvedValueOnce([[buildRow({
+      on_behalf_of_user_id: 3,
+      justification: 'emergency override',
+      request_id: 'req-456',
+    })], null]);
     const service = new AuditLogService(pool);
     const entry = await service.getById(1);
-    expect(entry).toMatchObject({ id: 1, action: 'login', userId: 5 });
+
+    expect(entry).not.toBeNull();
+    expect(entry!.id).toBe(1);
+    expect(entry!.action).toBe('login');
+    expect(entry!.userId).toBe(5);
+    expect(entry!.onBehalfOfUserId).toBe(3);
+    expect(entry!.justification).toBe('emergency override');
+    expect(entry!.requestId).toBe('req-456');
+    expect(entry!.ipAddress).toBe('127.0.0.1');
+    expect(entry!.userAgent).toBe('jest');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// write
+// ---------------------------------------------------------------------------
+
+describe('AuditLogService.write', () => {
+  it('inserts all basic fields', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([{ insertId: 1 }, null]);
+
+    const service = new AuditLogService(pool);
+    await service.write({ actorId: 5, action: 'user.update', entityType: 'user', entityId: 10 });
+
+    const [sql, params] = execute.mock.calls[0] as [string, unknown[]];
+    expect(sql).toMatch(/INSERT INTO audit_logs/);
+    expect(params[0]).toBe(5);      // user_id
+    expect(params[2]).toBe('user.update'); // action
+    expect(params[3]).toBe('user');  // entity_type
+    expect(params[4]).toBe(10);     // entity_id
+  });
+
+  it('writes justification and onBehalfOfUserId', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([{ insertId: 1 }, null]);
+
+    const service = new AuditLogService(pool);
+    await service.write({
+      actorId: 2,
+      action: 'timeoff.approve',
+      onBehalfOfUserId: 9,
+      justification: 'within authority',
+    });
+
+    const params = execute.mock.calls[0][1] as unknown[];
+    expect(params[1]).toBe(9);                    // on_behalf_of_user_id
+    expect(params[6]).toBe('within authority');    // justification
+  });
+
+  it('serialises before/after snapshots as JSON', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([{ insertId: 1 }, null]);
+
+    const service = new AuditLogService(pool);
+    await service.write({
+      actorId: 1,
+      action: 'role.update',
+      before: { name: 'Manager' },
+      after: { name: 'Senior Manager' },
+    });
+
+    const params = execute.mock.calls[0][1] as unknown[];
+    expect(JSON.parse(params[7] as string)).toEqual({ name: 'Manager' });
+    expect(JSON.parse(params[8] as string)).toEqual({ name: 'Senior Manager' });
+  });
+
+  it('auto-pulls ip_address, user_agent and request_id from request context', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([{ insertId: 1 }, null]);
+
+    jest.spyOn(requestContext, 'getRequestIp').mockReturnValue('10.0.0.1');
+    jest.spyOn(requestContext, 'getRequestUserAgent').mockReturnValue('Mozilla/5.0');
+    jest.spyOn(requestContext, 'getRequestId').mockReturnValue('req-ctx-id');
+
+    const service = new AuditLogService(pool);
+    await service.write({ actorId: 1, action: 'login' });
+
+    const params = execute.mock.calls[0][1] as unknown[];
+    expect(params[9]).toBe('10.0.0.1');       // ip_address
+    expect(params[10]).toBe('Mozilla/5.0');   // user_agent
+    expect(params[11]).toBe('req-ctx-id');    // request_id
+  });
+
+  it('uses null for context fields when no request context is active', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([{ insertId: 1 }, null]);
+
+    jest.spyOn(requestContext, 'getRequestIp').mockReturnValue(null);
+    jest.spyOn(requestContext, 'getRequestUserAgent').mockReturnValue(null);
+    jest.spyOn(requestContext, 'getRequestId').mockReturnValue(undefined);
+
+    const service = new AuditLogService(pool);
+    await service.write({ actorId: 1, action: 'cron.run' });
+
+    const params = execute.mock.calls[0][1] as unknown[];
+    expect(params[9]).toBeNull();
+    expect(params[10]).toBeNull();
+    expect(params[11]).toBeNull();
+  });
+
+  it('swallows DB errors silently', async () => {
+    const { pool, execute } = makePool();
+    execute.mockRejectedValueOnce(new Error('DB down'));
+
+    const service = new AuditLogService(pool);
+    await expect(service.write({ actorId: 1, action: 'login' })).resolves.toBeUndefined();
   });
 });

--- a/backend/src/__tests__/requestContext.test.ts
+++ b/backend/src/__tests__/requestContext.test.ts
@@ -1,0 +1,126 @@
+/**
+ * requestContext middleware tests.
+ *
+ * Verifies that requestId, ipAddress and userAgent are stored in the
+ * AsyncLocalStorage context and exposed via the getter helpers.
+ *
+ * @author Luca Ostinelli
+ */
+
+import { Request, Response } from 'express';
+import {
+  requestId as requestIdMiddleware,
+  getRequestId,
+  getRequestIp,
+  getRequestUserAgent,
+  requestStorage,
+} from '../middleware/requestContext';
+
+const makeReq = (overrides: Partial<Request> = {}): Request =>
+  ({
+    ip: '192.168.1.1',
+    socket: { remoteAddress: '192.168.1.1' },
+    headers: { 'user-agent': 'TestAgent/1.0' },
+    ...overrides,
+  } as unknown as Request);
+
+const makeRes = (): { res: Response; headers: Record<string, string> } => {
+  const headers: Record<string, string> = {};
+  const res = {
+    setHeader: (k: string, v: string) => { headers[k] = v; },
+  } as unknown as Response;
+  return { res, headers };
+};
+
+describe('requestId middleware', () => {
+  it('sets X-Request-Id response header', (done) => {
+    const { res, headers } = makeRes();
+    requestIdMiddleware(makeReq(), res, () => {
+      expect(headers['X-Request-Id']).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+      );
+      done();
+    });
+  });
+
+  it('makes requestId available via getRequestId() inside the next() call', (done) => {
+    const { res } = makeRes();
+    requestIdMiddleware(makeReq(), res, () => {
+      const id = getRequestId();
+      expect(typeof id).toBe('string');
+      expect(id!.length).toBe(36);
+      done();
+    });
+  });
+
+  it('makes ipAddress available via getRequestIp()', (done) => {
+    const { res } = makeRes();
+    requestIdMiddleware(makeReq({ ip: '10.0.0.1' }), res, () => {
+      expect(getRequestIp()).toBe('10.0.0.1');
+      done();
+    });
+  });
+
+  it('falls back to socket.remoteAddress when req.ip is absent', (done) => {
+    const { res } = makeRes();
+    const req = makeReq({ ip: undefined, socket: { remoteAddress: '172.16.0.5' } as never });
+    requestIdMiddleware(req, res, () => {
+      expect(getRequestIp()).toBe('172.16.0.5');
+      done();
+    });
+  });
+
+  it('stores null ipAddress when no address is available', (done) => {
+    const { res } = makeRes();
+    const req = makeReq({ ip: undefined, socket: { remoteAddress: undefined } as never });
+    requestIdMiddleware(req, res, () => {
+      expect(getRequestIp()).toBeNull();
+      done();
+    });
+  });
+
+  it('makes userAgent available via getRequestUserAgent()', (done) => {
+    const { res } = makeRes();
+    requestIdMiddleware(makeReq(), res, () => {
+      expect(getRequestUserAgent()).toBe('TestAgent/1.0');
+      done();
+    });
+  });
+
+  it('stores null userAgent when header is absent', (done) => {
+    const { res } = makeRes();
+    const req = makeReq({ headers: {} });
+    requestIdMiddleware(req, res, () => {
+      expect(getRequestUserAgent()).toBeNull();
+      done();
+    });
+  });
+
+  it('generates a unique ID per request', (done) => {
+    const { res: res1 } = makeRes();
+    const { res: res2 } = makeRes();
+    let id1: string | undefined;
+    requestIdMiddleware(makeReq(), res1, () => {
+      id1 = getRequestId();
+      requestIdMiddleware(makeReq(), res2, () => {
+        expect(getRequestId()).not.toBe(id1);
+        done();
+      });
+    });
+  });
+});
+
+describe('getters outside request context', () => {
+  it('getRequestId returns undefined outside any context', () => {
+    expect(requestStorage.getStore()).toBeUndefined();
+    expect(getRequestId()).toBeUndefined();
+  });
+
+  it('getRequestIp returns null outside any context', () => {
+    expect(getRequestIp()).toBeNull();
+  });
+
+  it('getRequestUserAgent returns null outside any context', () => {
+    expect(getRequestUserAgent()).toBeNull();
+  });
+});

--- a/backend/src/middleware/requestContext.ts
+++ b/backend/src/middleware/requestContext.ts
@@ -4,6 +4,8 @@ import { randomUUID } from 'crypto';
 
 interface RequestContext {
   requestId: string;
+  ipAddress: string | null;
+  userAgent: string | null;
 }
 
 export const requestStorage = new AsyncLocalStorage<RequestContext>();
@@ -11,8 +13,21 @@ export const requestStorage = new AsyncLocalStorage<RequestContext>();
 export const getRequestId = (): string | undefined =>
   requestStorage.getStore()?.requestId;
 
-export const requestId = (_req: Request, res: Response, next: NextFunction): void => {
+export const getRequestIp = (): string | null =>
+  requestStorage.getStore()?.ipAddress ?? null;
+
+export const getRequestUserAgent = (): string | null =>
+  requestStorage.getStore()?.userAgent ?? null;
+
+export const requestId = (req: Request, res: Response, next: NextFunction): void => {
   const id = randomUUID();
   res.setHeader('X-Request-Id', id);
-  requestStorage.run({ requestId: id }, next);
+  requestStorage.run(
+    {
+      requestId: id,
+      ipAddress: (req.ip ?? req.socket?.remoteAddress) || null,
+      userAgent: req.headers['user-agent'] ?? null,
+    },
+    next
+  );
 };

--- a/backend/src/routes/auditLogs.ts
+++ b/backend/src/routes/auditLogs.ts
@@ -40,11 +40,13 @@ export const createAuditLogsRouter = (pool: Pool): Router => {
 
       const result = await service.list({
         userId: req.query.userId ? Number(req.query.userId) : undefined,
+        onBehalfOfUserId: req.query.onBehalfOfUserId ? Number(req.query.onBehalfOfUserId) : undefined,
         action: req.query.action as string | undefined,
         entityType: req.query.entityType as string | undefined,
         entityId: req.query.entityId ? Number(req.query.entityId) : undefined,
         fromDate: rawFromDate,
         toDate: rawToDate,
+        requestId: req.query.requestId as string | undefined,
         limit,
         offset,
       });

--- a/backend/src/services/AuditLogService.ts
+++ b/backend/src/services/AuditLogService.ts
@@ -2,47 +2,63 @@
  * Audit log service.
  *
  * Provides both read (list / getById) and write (write) operations over the
- * `audit_logs` table. All sensitive mutations in the application should call
- * `AuditLogService.write` (or use a shared pool write helper) to record a
- * structured audit entry, optionally with before/after JSON snapshots.
+ * `audit_logs` table. Every sensitive mutation in the application should call
+ * `AuditLogService.write` to record a structured audit entry, optionally with:
+ *   - before/after JSON snapshots of the affected entity
+ *   - a free-text justification supplied by the actor
+ *   - an `onBehalfOfUserId` for proxy / approval-workflow actions
+ *
+ * `ip_address`, `user_agent`, and `request_id` are populated automatically
+ * from the AsyncLocalStorage request context when `requestId` middleware is
+ * active, so callers do not need to pass them explicitly.
  *
  * @author Luca Ostinelli
  */
 
 import { Pool, RowDataPacket, ResultSetHeader } from 'mysql2/promise';
 import { logger } from '../config/logger';
+import { getRequestId, getRequestIp, getRequestUserAgent } from '../middleware/requestContext';
 
 export interface AuditLogEntry {
   id: number;
   userId: number | null;
+  onBehalfOfUserId: number | null;
   action: string;
   entityType: string | null;
   entityId: number | null;
   description: string | null;
+  justification: string | null;
   beforeSnapshot?: Record<string, unknown> | null;
   afterSnapshot?: Record<string, unknown> | null;
   ipAddress: string | null;
   userAgent: string | null;
+  requestId: string | null;
   createdAt: string;
 }
 
 export interface WriteAuditLogInput {
   actorId: number | null;
+  /** When the action was performed on behalf of another user (proxy / approval). */
+  onBehalfOfUserId?: number | null;
   action: string;
   entityType?: string;
   entityId?: number | null;
   description?: string;
+  /** Optional free-text reason provided by the actor at the time of the action. */
+  justification?: string | null;
   before?: Record<string, unknown> | null;
   after?: Record<string, unknown> | null;
 }
 
 interface AuditLogFilters {
   userId?: number;
+  onBehalfOfUserId?: number;
   action?: string;
   entityType?: string;
   entityId?: number;
   fromDate?: string;
   toDate?: string;
+  requestId?: string;
   /** Max rows to return; clamped to [1, 500]. Default 100. */
   limit?: number;
   /** Offset into the ordered result set. Default 0. */
@@ -54,21 +70,29 @@ interface AuditLogPage {
   items: AuditLogEntry[];
 }
 
+const parseJson = (raw: unknown): Record<string, unknown> | null => {
+  if (!raw) return null;
+  try {
+    return typeof raw === 'string' ? JSON.parse(raw) : (raw as Record<string, unknown>);
+  } catch {
+    return null;
+  }
+};
+
 const mapRow = (row: RowDataPacket): AuditLogEntry => ({
   id: row.id as number,
   userId: (row.user_id as number | null) ?? null,
+  onBehalfOfUserId: (row.on_behalf_of_user_id as number | null) ?? null,
   action: row.action as string,
   entityType: (row.entity_type as string | null) ?? null,
   entityId: (row.entity_id as number | null) ?? null,
   description: (row.description as string | null) ?? null,
-  beforeSnapshot: row.before_snapshot
-    ? (() => { try { return JSON.parse(row.before_snapshot as string); } catch { return null; } })()
-    : null,
-  afterSnapshot: row.after_snapshot
-    ? (() => { try { return JSON.parse(row.after_snapshot as string); } catch { return null; } })()
-    : null,
+  justification: (row.justification as string | null) ?? null,
+  beforeSnapshot: parseJson(row.before_snapshot),
+  afterSnapshot: parseJson(row.after_snapshot),
   ipAddress: (row.ip_address as string | null) ?? null,
   userAgent: (row.user_agent as string | null) ?? null,
+  requestId: (row.request_id as string | null) ?? null,
   createdAt: row.created_at as string,
 });
 
@@ -93,6 +117,10 @@ export class AuditLogService {
       conditions.push('user_id = ?');
       params.push(filters.userId);
     }
+    if (filters.onBehalfOfUserId !== undefined) {
+      conditions.push('on_behalf_of_user_id = ?');
+      params.push(filters.onBehalfOfUserId);
+    }
     if (filters.action) {
       conditions.push('action = ?');
       params.push(filters.action);
@@ -112,6 +140,10 @@ export class AuditLogService {
     if (filters.toDate) {
       conditions.push('created_at <= ?');
       params.push(filters.toDate);
+    }
+    if (filters.requestId) {
+      conditions.push('request_id = ?');
+      params.push(filters.requestId);
     }
     const where = conditions.length ? ` WHERE ${conditions.join(' AND ')}` : '';
 
@@ -142,24 +174,32 @@ export class AuditLogService {
   }
 
   /**
-   * Writes a single audit log entry. Silently swallows errors so a write
+   * Writes a single audit log entry. `ip_address`, `user_agent`, and
+   * `request_id` are pulled automatically from the AsyncLocalStorage context
+   * when a request is in flight. Silently swallows write errors so a log
    * failure never blocks the primary operation.
    */
   async write(input: WriteAuditLogInput): Promise<void> {
     try {
       await this.pool.execute<ResultSetHeader>(
         `INSERT INTO audit_logs
-           (user_id, action, entity_type, entity_id, description,
-            before_snapshot, after_snapshot)
-         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+           (user_id, on_behalf_of_user_id, action, entity_type, entity_id,
+            description, justification, before_snapshot, after_snapshot,
+            ip_address, user_agent, request_id)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
         [
           input.actorId,
+          input.onBehalfOfUserId ?? null,
           input.action,
           input.entityType ?? null,
           input.entityId ?? null,
           input.description ?? null,
+          input.justification ?? null,
           input.before != null ? JSON.stringify(input.before) : null,
           input.after != null ? JSON.stringify(input.after) : null,
+          getRequestIp(),
+          getRequestUserAgent(),
+          getRequestId() ?? null,
         ]
       );
     } catch (err) {


### PR DESCRIPTION
## Summary

- **Schema** (`audit_logs`): aggiunte colonne `on_behalf_of_user_id` (FK → users), `justification` (testo libero opzionale), `request_id` (correlazione con la request HTTP)
- **`requestContext` middleware**: il context AsyncLocalStorage ora porta anche `ipAddress` e `userAgent`; nuovi getter `getRequestIp()` e `getRequestUserAgent()`
- **`AuditLogService.write()`**: popolamento automatico di `ip_address`, `user_agent`, `request_id` dal context — i caller non devono passarli; nuovi campi `justification` e `onBehalfOfUserId` nel tipo di input
- **Route `GET /api/audit-logs`**: nuovi parametri di filtro `onBehalfOfUserId` e `requestId`
- **Test**: 26 test nuovi in `auditLog.service.test.ts` e `requestContext.test.ts`; `audit.service.test.ts` aggiornato per i nuovi indici dei parametri

## Test plan

- [ ] `npm test` → 1685/1685 ✓
- [ ] `AuditLogService.write` popola automaticamente ip/ua/request_id dal context
- [ ] I nuovi filtri `onBehalfOfUserId` e `requestId` filtrano correttamente la lista
- [ ] `justification` e `on_behalf_of_user_id` null-safe (nessuna regressione sul codice esistente)