### PR TITLE
feat(responsibility-rules): add multidimensional responsibility matrix

### DIFF
--- a/backend/database/init.sql
+++ b/backend/database/init.sql
@@ -861,7 +861,9 @@ INSERT IGNORE INTO permissions (code, resource, action, description) VALUES
 ('user.read',         'user',      'read',    'View user accounts and the directory'),
 ('user.manage',       'user',      'manage',  'Create, update and delete user accounts and assign roles'),
 ('settings.manage',   'settings',  'manage',  'Edit system settings'),
-('role.manage',       'role',      'manage',  'Create roles and assign permissions to them');
+('role.manage',           'role',            'manage',  'Create roles and assign permissions to them'),
+('responsibility.read',  'responsibility',  'read',    'View responsibility rules'),
+('responsibility.manage','responsibility',  'manage',  'Create, update and delete responsibility rules');
 
 -- ----------------------------------------------------------------
 -- Default roles (editable data; not hardcoded in application code).
@@ -885,7 +887,8 @@ SELECT r.id, p.id FROM roles r JOIN permissions p ON p.code IN (
   'schedule.optimize','assignment.manage','shift.manage','department.read','department.manage',
   'org_unit.read','oncall.manage','policy.read','policy.manage','policy.approve',
   'loan.request','loan.approve','timeoff.approve','shiftswap.approve','preferences.manage',
-  'report.read','audit.read','user.read','user.manage'
+  'report.read','audit.read','user.read','user.manage',
+  'responsibility.read','responsibility.manage'
 ) WHERE r.name = 'Manager';
 
 -- Employee gets read-only visibility; self-service actions (creating own
@@ -994,6 +997,46 @@ CREATE TABLE IF NOT EXISTS delegations (
 
     FOREIGN KEY (delegator_id) REFERENCES users(id) ON DELETE CASCADE,
     FOREIGN KEY (delegatee_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+-- ================================================================
+-- RESPONSIBILITY RULES
+-- Multidimensional table that maps (subject group, permission) →
+-- (responsible org unit). Answers the question:
+--   "For users matching this condition, who is responsible for this
+--    permission/capability?"
+--
+-- subject_type / subject_id:
+--   'org_unit'   + id → all users whose primary org unit is that unit
+--   'department' + id → all users in that department
+--   'role'       + id → all users holding that role
+--   'all'        + NULL → every user in the system
+--
+-- responsible_org_unit_id: the org unit that holds authority.
+-- delegated_to_role_id: when set, only members of the org unit who also
+--   hold this role can exercise the authority (NULL = all members).
+-- ================================================================
+CREATE TABLE IF NOT EXISTS responsibility_rules (
+    id INT PRIMARY KEY AUTO_INCREMENT,
+    subject_type ENUM('org_unit', 'department', 'role', 'all') NOT NULL,
+    subject_id INT NULL,
+    permission_code VARCHAR(80) NOT NULL,
+    responsible_org_unit_id INT NOT NULL,
+    delegated_to_role_id INT NULL,
+    description TEXT NULL,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_by INT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+    INDEX idx_subject (subject_type, subject_id),
+    INDEX idx_permission (permission_code),
+    INDEX idx_responsible (responsible_org_unit_id),
+    INDEX idx_active (is_active),
+
+    FOREIGN KEY (responsible_org_unit_id) REFERENCES org_units(id) ON DELETE CASCADE,
+    FOREIGN KEY (delegated_to_role_id) REFERENCES roles(id) ON DELETE SET NULL,
+    FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE SET NULL
 );
 
 -- ================================================================

--- a/backend/src/__tests__/responsibilityRule.service.test.ts
+++ b/backend/src/__tests__/responsibilityRule.service.test.ts
@@ -1,0 +1,470 @@
+/**
+ * ResponsibilityRuleService unit tests.
+ *
+ * Covers: list (all filters), getById, create (validation + audit),
+ * update (merge + validation + audit), delete (not-found + audit),
+ * resolveResponsibleUsers (all subject-type branches).
+ *
+ * @author Luca Ostinelli
+ */
+
+import { ResponsibilityRuleService } from '../services/ResponsibilityRuleService';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const buildRow = (overrides: Record<string, unknown> = {}) => ({
+  id: 1,
+  subject_type: 'department',
+  subject_id: 10,
+  permission_code: 'schedule.manage',
+  responsible_org_unit_id: 3,
+  delegated_to_role_id: null,
+  description: 'HR manages scheduling for sales dept',
+  is_active: 1,
+  created_by: 42,
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-01T00:00:00.000Z',
+  ...overrides,
+});
+
+const makePool = () => {
+  const execute = jest.fn();
+  return { pool: { execute } as never, execute };
+};
+
+// ---------------------------------------------------------------------------
+// list
+// ---------------------------------------------------------------------------
+
+describe('ResponsibilityRuleService.list', () => {
+  it('returns all rules when no filters are given', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[buildRow(), buildRow({ id: 2, subject_id: 20 })], null]);
+
+    const svc = new ResponsibilityRuleService(pool);
+    const result = await svc.list();
+
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe(1);
+    expect(result[1].id).toBe(2);
+
+    const [sql, params] = execute.mock.calls[0];
+    expect(sql).not.toContain('WHERE');
+    expect(params).toEqual([]);
+  });
+
+  it('filters by subjectType', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[buildRow()], null]);
+
+    const svc = new ResponsibilityRuleService(pool);
+    await svc.list({ subjectType: 'department' });
+
+    const [sql, params] = execute.mock.calls[0];
+    expect(sql).toContain('subject_type = ?');
+    expect(params).toContain('department');
+  });
+
+  it('filters by permissionCode', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[buildRow()], null]);
+
+    const svc = new ResponsibilityRuleService(pool);
+    await svc.list({ permissionCode: 'schedule.manage' });
+
+    const [sql, params] = execute.mock.calls[0];
+    expect(sql).toContain('permission_code = ?');
+    expect(params).toContain('schedule.manage');
+  });
+
+  it('filters by responsibleOrgUnitId', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[buildRow()], null]);
+
+    const svc = new ResponsibilityRuleService(pool);
+    await svc.list({ responsibleOrgUnitId: 3 });
+
+    const [sql, params] = execute.mock.calls[0];
+    expect(sql).toContain('responsible_org_unit_id = ?');
+    expect(params).toContain(3);
+  });
+
+  it('filters by isActive=true', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[buildRow()], null]);
+
+    const svc = new ResponsibilityRuleService(pool);
+    await svc.list({ isActive: true });
+
+    const [, params] = execute.mock.calls[0];
+    expect(params).toContain(1);
+  });
+
+  it('filters by isActive=false', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[buildRow({ is_active: 0 })], null]);
+
+    const svc = new ResponsibilityRuleService(pool);
+    await svc.list({ isActive: false });
+
+    const [, params] = execute.mock.calls[0];
+    expect(params).toContain(0);
+  });
+
+  it('combines multiple filters with AND', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[buildRow()], null]);
+
+    const svc = new ResponsibilityRuleService(pool);
+    await svc.list({ permissionCode: 'schedule.manage', responsibleOrgUnitId: 3 });
+
+    const [sql] = execute.mock.calls[0];
+    expect(sql).toContain('WHERE');
+    expect(sql).toContain('AND');
+  });
+
+  it('maps is_active=1 to boolean true', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[buildRow({ is_active: 1 })], null]);
+
+    const svc = new ResponsibilityRuleService(pool);
+    const [rule] = await svc.list();
+    expect(rule.isActive).toBe(true);
+  });
+
+  it('maps is_active=0 to boolean false', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[buildRow({ is_active: 0 })], null]);
+
+    const svc = new ResponsibilityRuleService(pool);
+    const [rule] = await svc.list();
+    expect(rule.isActive).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getById
+// ---------------------------------------------------------------------------
+
+describe('ResponsibilityRuleService.getById', () => {
+  it('returns a mapped rule when found', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[buildRow()], null]);
+
+    const svc = new ResponsibilityRuleService(pool);
+    const rule = await svc.getById(1);
+
+    expect(rule).not.toBeNull();
+    expect(rule!.id).toBe(1);
+    expect(rule!.subjectType).toBe('department');
+    expect(rule!.permissionCode).toBe('schedule.manage');
+    expect(rule!.responsibleOrgUnitId).toBe(3);
+    expect(rule!.delegatedToRoleId).toBeNull();
+    expect(rule!.createdBy).toBe(42);
+  });
+
+  it('returns null when not found', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[], null]);
+
+    const svc = new ResponsibilityRuleService(pool);
+    const rule = await svc.getById(999);
+    expect(rule).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// create
+// ---------------------------------------------------------------------------
+
+describe('ResponsibilityRuleService.create', () => {
+  it('inserts and returns the new rule', async () => {
+    const { pool, execute } = makePool();
+    // INSERT → getById → audit write
+    execute
+      .mockResolvedValueOnce([{ insertId: 7, affectedRows: 1 }, null])
+      .mockResolvedValueOnce([[buildRow({ id: 7 })], null])
+      .mockResolvedValue([{ insertId: 99, affectedRows: 1 }, null]);
+
+    const svc = new ResponsibilityRuleService(pool);
+    const rule = await svc.create(
+      {
+        subjectType: 'department',
+        subjectId: 10,
+        permissionCode: 'schedule.manage',
+        responsibleOrgUnitId: 3,
+      },
+      42
+    );
+
+    expect(rule.id).toBe(7);
+    const [insertSql, insertParams] = execute.mock.calls[0];
+    expect(insertSql).toContain('INSERT INTO responsibility_rules');
+    expect(insertParams).toContain('department');
+    expect(insertParams).toContain('schedule.manage');
+    expect(insertParams).toContain(3);
+  });
+
+  it('throws when subjectId is missing for non-all subject_type', async () => {
+    const { pool } = makePool();
+    const svc = new ResponsibilityRuleService(pool);
+
+    await expect(
+      svc.create(
+        { subjectType: 'department', permissionCode: 'schedule.manage', responsibleOrgUnitId: 3 },
+        1
+      )
+    ).rejects.toThrow('subject_id is required');
+  });
+
+  it('throws when subjectId is supplied for subject_type "all"', async () => {
+    const { pool } = makePool();
+    const svc = new ResponsibilityRuleService(pool);
+
+    await expect(
+      svc.create(
+        { subjectType: 'all', subjectId: 5, permissionCode: 'schedule.manage', responsibleOrgUnitId: 3 },
+        1
+      )
+    ).rejects.toThrow('subject_id must be null');
+  });
+
+  it('accepts subject_type "all" with null subjectId', async () => {
+    const { pool, execute } = makePool();
+    execute
+      .mockResolvedValueOnce([{ insertId: 8, affectedRows: 1 }, null])
+      .mockResolvedValueOnce([[buildRow({ id: 8, subject_type: 'all', subject_id: null })], null])
+      .mockResolvedValue([{ insertId: 99, affectedRows: 1 }, null]);
+
+    const svc = new ResponsibilityRuleService(pool);
+    const rule = await svc.create(
+      { subjectType: 'all', permissionCode: 'schedule.manage', responsibleOrgUnitId: 3 },
+      1
+    );
+    expect(rule.subjectType).toBe('all');
+    expect(rule.subjectId).toBeNull();
+  });
+
+  it('writes an audit log entry after creation', async () => {
+    const { pool, execute } = makePool();
+    execute
+      .mockResolvedValueOnce([{ insertId: 7, affectedRows: 1 }, null])
+      .mockResolvedValueOnce([[buildRow({ id: 7 })], null])
+      .mockResolvedValueOnce([{ insertId: 99, affectedRows: 1 }, null]);
+
+    const svc = new ResponsibilityRuleService(pool);
+    await svc.create(
+      { subjectType: 'department', subjectId: 10, permissionCode: 'schedule.manage', responsibleOrgUnitId: 3 },
+      42
+    );
+
+    // 3rd execute call is the audit INSERT
+    expect(execute).toHaveBeenCalledTimes(3);
+    const [auditSql] = execute.mock.calls[2];
+    expect(auditSql).toContain('INSERT INTO audit_logs');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// update
+// ---------------------------------------------------------------------------
+
+describe('ResponsibilityRuleService.update', () => {
+  it('merges patch with existing rule and updates', async () => {
+    const { pool, execute } = makePool();
+    const existing = buildRow();
+    execute
+      .mockResolvedValueOnce([[existing], null])         // getById (existing)
+      .mockResolvedValueOnce([{ affectedRows: 1 }, null]) // UPDATE
+      .mockResolvedValueOnce([[buildRow({ description: 'updated' })], null]) // getById (updated)
+      .mockResolvedValue([{ insertId: 1, affectedRows: 1 }, null]); // audit
+
+    const svc = new ResponsibilityRuleService(pool);
+    const updated = await svc.update(1, { description: 'updated' }, 42);
+
+    expect(updated.description).toBe('updated');
+    const [updateSql] = execute.mock.calls[1];
+    expect(updateSql).toContain('UPDATE responsibility_rules');
+  });
+
+  it('throws NOT_FOUND when the rule does not exist', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[], null]);
+
+    const svc = new ResponsibilityRuleService(pool);
+    await expect(svc.update(999, { isActive: false }, 1)).rejects.toThrow('not found');
+  });
+
+  it('rejects update that would leave non-all subject without subjectId', async () => {
+    const { pool, execute } = makePool();
+    // existing rule has subject_type=department, subject_id=10
+    execute.mockResolvedValueOnce([[buildRow({ subject_type: 'department', subject_id: 10 })], null]);
+
+    const svc = new ResponsibilityRuleService(pool);
+    // patch sets subjectId to null while keeping subject_type=department
+    await expect(svc.update(1, { subjectId: null }, 1)).rejects.toThrow('subject_id is required');
+  });
+
+  it('writes an audit log entry with before and after snapshots', async () => {
+    const { pool, execute } = makePool();
+    execute
+      .mockResolvedValueOnce([[buildRow()], null])
+      .mockResolvedValueOnce([{ affectedRows: 1 }, null])
+      .mockResolvedValueOnce([[buildRow({ description: 'new desc' })], null])
+      .mockResolvedValue([{ insertId: 1, affectedRows: 1 }, null]);
+
+    const svc = new ResponsibilityRuleService(pool);
+    await svc.update(1, { description: 'new desc' }, 42);
+
+    const [auditSql, auditParams] = execute.mock.calls[3];
+    expect(auditSql).toContain('INSERT INTO audit_logs');
+    // before/after snapshots are JSON-serialised and appear in params
+    expect(auditParams.some((p: unknown) => typeof p === 'string' && p.includes('responsibility_rule.update'))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// delete
+// ---------------------------------------------------------------------------
+
+describe('ResponsibilityRuleService.delete', () => {
+  it('deletes the rule and writes an audit entry', async () => {
+    const { pool, execute } = makePool();
+    execute
+      .mockResolvedValueOnce([[buildRow()], null])         // getById
+      .mockResolvedValueOnce([{ affectedRows: 1 }, null])  // DELETE
+      .mockResolvedValue([{ insertId: 1, affectedRows: 1 }, null]); // audit
+
+    const svc = new ResponsibilityRuleService(pool);
+    await svc.delete(1, 42);
+
+    const [deleteSql, deleteParams] = execute.mock.calls[1];
+    expect(deleteSql).toContain('DELETE FROM responsibility_rules');
+    expect(deleteParams).toContain(1);
+
+    const [auditSql] = execute.mock.calls[2];
+    expect(auditSql).toContain('INSERT INTO audit_logs');
+  });
+
+  it('throws NOT_FOUND when the rule does not exist', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[], null]);
+
+    const svc = new ResponsibilityRuleService(pool);
+    await expect(svc.delete(999, 1)).rejects.toThrow('not found');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveResponsibleUsers
+// ---------------------------------------------------------------------------
+
+describe('ResponsibilityRuleService.resolveResponsibleUsers', () => {
+  it('always includes the "all" subject condition', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[{ user_id: 5 }, { user_id: 6 }], null]);
+
+    const svc = new ResponsibilityRuleService(pool);
+    const ids = await svc.resolveResponsibleUsers({ permissionCode: 'schedule.manage' });
+
+    expect(ids).toEqual([5, 6]);
+    const [sql] = execute.mock.calls[0];
+    expect(sql).toContain("subject_type = 'all'");
+    expect(sql).toContain('permission_code = ?');
+  });
+
+  it('adds org_unit condition when orgUnitId is provided', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[{ user_id: 7 }], null]);
+
+    const svc = new ResponsibilityRuleService(pool);
+    await svc.resolveResponsibleUsers({ permissionCode: 'leave.manage', orgUnitId: 3 });
+
+    const [sql, params] = execute.mock.calls[0];
+    expect(sql).toContain("subject_type = 'org_unit'");
+    expect(params).toContain(3);
+  });
+
+  it('adds department condition when departmentIds are provided', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[{ user_id: 8 }], null]);
+
+    const svc = new ResponsibilityRuleService(pool);
+    await svc.resolveResponsibleUsers({ permissionCode: 'schedule.manage', departmentIds: [10, 11] });
+
+    const [sql, params] = execute.mock.calls[0];
+    expect(sql).toContain("subject_type = 'department'");
+    expect(params).toContain(10);
+    expect(params).toContain(11);
+  });
+
+  it('adds role condition when roleIds are provided', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[{ user_id: 9 }], null]);
+
+    const svc = new ResponsibilityRuleService(pool);
+    await svc.resolveResponsibleUsers({ permissionCode: 'schedule.manage', roleIds: [2, 4] });
+
+    const [sql, params] = execute.mock.calls[0];
+    expect(sql).toContain("subject_type = 'role'");
+    expect(params).toContain(2);
+    expect(params).toContain(4);
+  });
+
+  it('combines all subject conditions with OR', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[{ user_id: 5 }], null]);
+
+    const svc = new ResponsibilityRuleService(pool);
+    await svc.resolveResponsibleUsers({
+      permissionCode: 'schedule.manage',
+      orgUnitId: 3,
+      departmentIds: [10],
+      roleIds: [2],
+    });
+
+    const [sql] = execute.mock.calls[0];
+    expect(sql).toContain("subject_type = 'all'");
+    expect(sql).toContain("subject_type = 'org_unit'");
+    expect(sql).toContain("subject_type = 'department'");
+    expect(sql).toContain("subject_type = 'role'");
+    // All joined by OR inside a sub-clause
+    expect(sql.match(/OR/g)!.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('returns empty array when no matching rules exist', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[], null]);
+
+    const svc = new ResponsibilityRuleService(pool);
+    const ids = await svc.resolveResponsibleUsers({ permissionCode: 'unknown.code' });
+    expect(ids).toEqual([]);
+  });
+
+  it('de-duplicates user IDs (DISTINCT in SQL)', async () => {
+    const { pool, execute } = makePool();
+    // The DISTINCT is in SQL; mock returns unique ids already
+    execute.mockResolvedValueOnce([[{ user_id: 5 }, { user_id: 5 }], null]);
+
+    const svc = new ResponsibilityRuleService(pool);
+    const ids = await svc.resolveResponsibleUsers({ permissionCode: 'schedule.manage' });
+
+    const [sql] = execute.mock.calls[0];
+    expect(sql).toContain('DISTINCT');
+    // Raw result from mock is [5,5]; DISTINCT is enforced by SQL — map returns what the mock gives
+    expect(ids).toHaveLength(2); // raw mock result; DISTINCT enforced by DB in production
+  });
+
+  it('filters by delegated_to_role_id when set (LEFT JOIN + null check in SQL)', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[{ user_id: 3 }], null]);
+
+    const svc = new ResponsibilityRuleService(pool);
+    await svc.resolveResponsibleUsers({ permissionCode: 'schedule.manage' });
+
+    const [sql] = execute.mock.calls[0];
+    expect(sql).toContain('delegated_to_role_id IS NULL OR ur.user_id IS NOT NULL');
+  });
+});

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -52,6 +52,7 @@ import { createRbacRouter } from './routes/rbac';
 import { createDelegationsRouter } from './routes/delegations';
 import { createApprovalWorkflowsRouter } from './routes/approvalWorkflows';
 import { createModulesRouter } from './routes/modules';
+import { createResponsibilityRulesRouter } from './routes/responsibilityRules';
 
 interface BuildAppOptions {
   /** When true, skip rate limiting + morgan logging (useful for tests). */
@@ -184,6 +185,7 @@ export function buildApp(pool: Pool, options: BuildAppOptions = {}): express.Exp
     app.use(`${prefix}/delegations`, createDelegationsRouter(pool));
     app.use(`${prefix}/approval-workflows`, createApprovalWorkflowsRouter(pool));
     app.use(`${prefix}/modules`, createModulesRouter(pool));
+    app.use(`${prefix}/responsibility-rules`, createResponsibilityRulesRouter(pool));
   };
   mountRoutes('/api/v1');
   mountRoutes('/api');

--- a/backend/src/routes/responsibilityRules.ts
+++ b/backend/src/routes/responsibilityRules.ts
@@ -1,0 +1,164 @@
+/**
+ * Responsibility rules routes.
+ *
+ * Manages the multidimensional responsibility matrix that maps
+ * (subject group × permission code) → responsible org unit.
+ *
+ * GET    /api/responsibility-rules           list (responsibility.read)
+ * POST   /api/responsibility-rules           create (responsibility.manage)
+ * GET    /api/responsibility-rules/resolve   resolve responsible users (responsibility.read)
+ * GET    /api/responsibility-rules/:id       get one (responsibility.read)
+ * PUT    /api/responsibility-rules/:id       update (responsibility.manage)
+ * DELETE /api/responsibility-rules/:id       delete (responsibility.manage)
+ *
+ * @author Luca Ostinelli
+ */
+
+import { Router, Request, Response } from 'express';
+import { Pool } from 'mysql2/promise';
+import { z } from 'zod';
+import { authenticate, requirePermission } from '../middleware/auth';
+import { validateBody, validateParams } from '../middleware/validation';
+import { idParam } from '../schemas';
+import { ResponsibilityRuleService } from '../services/ResponsibilityRuleService';
+import { User } from '../types';
+import { logger } from '../config/logger';
+
+const SUBJECT_TYPES = ['org_unit', 'department', 'role', 'all'] as const;
+
+const createRuleBody = z.object({
+  subjectType: z.enum(SUBJECT_TYPES),
+  subjectId: z.number().int().positive().nullable().optional(),
+  permissionCode: z.string().min(1).max(80),
+  responsibleOrgUnitId: z.number().int().positive(),
+  delegatedToRoleId: z.number().int().positive().nullable().optional(),
+  description: z.string().max(1000).nullable().optional(),
+});
+
+const updateRuleBody = z.object({
+  subjectType: z.enum(SUBJECT_TYPES).optional(),
+  subjectId: z.number().int().positive().nullable().optional(),
+  permissionCode: z.string().min(1).max(80).optional(),
+  responsibleOrgUnitId: z.number().int().positive().optional(),
+  delegatedToRoleId: z.number().int().positive().nullable().optional(),
+  description: z.string().max(1000).nullable().optional(),
+  isActive: z.boolean().optional(),
+});
+
+export const createResponsibilityRulesRouter = (pool: Pool): Router => {
+  const router = Router();
+  const svc = new ResponsibilityRuleService(pool);
+
+  router.use(authenticate);
+
+  // List rules
+  router.get('/', requirePermission('responsibility.read'), async (req: Request, res: Response) => {
+    try {
+      const { subjectType, permissionCode, responsibleOrgUnitId, isActive } = req.query;
+      const rules = await svc.list({
+        subjectType: subjectType as string | undefined,
+        permissionCode: permissionCode as string | undefined,
+        responsibleOrgUnitId: responsibleOrgUnitId ? Number(responsibleOrgUnitId) : undefined,
+        isActive: isActive === 'true' ? true : isActive === 'false' ? false : undefined,
+      });
+      res.json({ success: true, data: rules });
+    } catch (error) {
+      logger.error('List responsibility rules error:', error);
+      res.status(500).json({ success: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to list responsibility rules' } });
+    }
+  });
+
+  // Resolve responsible users for a given subject + permission
+  router.get('/resolve', requirePermission('responsibility.read'), async (req: Request, res: Response) => {
+    try {
+      const { orgUnitId, permissionCode } = req.query;
+
+      if (!permissionCode) {
+        return res.status(400).json({ success: false, error: { code: 'VALIDATION_ERROR', message: 'permissionCode is required' } });
+      }
+
+      const departmentIds = req.query.departmentIds
+        ? String(req.query.departmentIds).split(',').map(Number).filter(Boolean)
+        : [];
+      const roleIds = req.query.roleIds
+        ? String(req.query.roleIds).split(',').map(Number).filter(Boolean)
+        : [];
+
+      const userIds = await svc.resolveResponsibleUsers({
+        permissionCode: permissionCode as string,
+        orgUnitId: orgUnitId ? Number(orgUnitId) : null,
+        departmentIds,
+        roleIds,
+      });
+
+      res.json({ success: true, data: { userIds } });
+    } catch (error) {
+      logger.error('Resolve responsibility error:', error);
+      res.status(500).json({ success: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to resolve responsible users' } });
+    }
+  });
+
+  // Get by ID
+  router.get('/:id', requirePermission('responsibility.read'), validateParams(idParam), async (_req: Request, res: Response) => {
+    try {
+      const rule = await svc.getById(res.locals.params.id);
+      if (!rule) {
+        return res.status(404).json({ success: false, error: { code: 'NOT_FOUND', message: 'Responsibility rule not found' } });
+      }
+      res.json({ success: true, data: rule });
+    } catch (error) {
+      logger.error('Get responsibility rule error:', error);
+      res.status(500).json({ success: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to get responsibility rule' } });
+    }
+  });
+
+  // Create
+  router.post('/', requirePermission('responsibility.manage'), validateBody(createRuleBody), async (req: Request, res: Response) => {
+    try {
+      const actor = req.user as User;
+      const rule = await svc.create(res.locals.body, actor.id);
+      res.status(201).json({ success: true, data: rule, message: 'Responsibility rule created' });
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : 'Failed to create responsibility rule';
+      if (msg.toLowerCase().includes('not found')) {
+        return res.status(404).json({ success: false, error: { code: 'NOT_FOUND', message: msg } });
+      }
+      logger.error('Create responsibility rule error:', error);
+      res.status(500).json({ success: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to create responsibility rule' } });
+    }
+  });
+
+  // Update
+  router.put('/:id', requirePermission('responsibility.manage'), validateParams(idParam), validateBody(updateRuleBody), async (req: Request, res: Response) => {
+    try {
+      const actor = req.user as User;
+      const rule = await svc.update(res.locals.params.id, res.locals.body, actor.id);
+      res.json({ success: true, data: rule, message: 'Responsibility rule updated' });
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : 'Failed to update responsibility rule';
+      if (msg.toLowerCase().includes('not found')) {
+        return res.status(404).json({ success: false, error: { code: 'NOT_FOUND', message: msg } });
+      }
+      logger.error('Update responsibility rule error:', error);
+      res.status(500).json({ success: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to update responsibility rule' } });
+    }
+  });
+
+  // Delete
+  router.delete('/:id', requirePermission('responsibility.manage'), validateParams(idParam), async (req: Request, res: Response) => {
+    try {
+      const actor = req.user as User;
+      await svc.delete(res.locals.params.id, actor.id);
+      res.json({ success: true, message: 'Responsibility rule deleted' });
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : 'Failed to delete responsibility rule';
+      if (msg.toLowerCase().includes('not found')) {
+        return res.status(404).json({ success: false, error: { code: 'NOT_FOUND', message: msg } });
+      }
+      logger.error('Delete responsibility rule error:', error);
+      res.status(500).json({ success: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to delete responsibility rule' } });
+    }
+  });
+
+  return router;
+};

--- a/backend/src/services/ResponsibilityRuleService.ts
+++ b/backend/src/services/ResponsibilityRuleService.ts
@@ -1,0 +1,272 @@
+/**
+ * Responsibility Rule Service
+ *
+ * Manages the `responsibility_rules` table — the multidimensional matrix that
+ * maps (subject group × permission code) → responsible org unit.
+ *
+ * A rule answers: "For users matching condition X (e.g. members of
+ * department Y), who has responsibility for permission Z?"
+ *
+ * Subject types:
+ *   'org_unit'   — all users whose primary org unit is subject_id
+ *   'department' — all users in department subject_id
+ *   'role'       — all users holding role subject_id
+ *   'all'        — every active user in the system
+ *
+ * `responsible_org_unit_id` is the org unit that holds authority.
+ * `delegated_to_role_id`:  when set, only members of the responsible org
+ *   unit who also hold this role may exercise the authority; when null,
+ *   all active members of the responsible org unit have authority.
+ *
+ * @author Luca Ostinelli
+ */
+
+import { Pool, RowDataPacket, ResultSetHeader } from 'mysql2/promise';
+import {
+  ResponsibilityRule,
+  CreateResponsibilityRuleRequest,
+  UpdateResponsibilityRuleRequest,
+} from '../types';
+import { logger } from '../config/logger';
+import { AuditLogService } from './AuditLogService';
+
+interface ResolveContext {
+  /** Primary org unit of the subject user. */
+  orgUnitId?: number | null;
+  /** Department id(s) the subject user belongs to. */
+  departmentIds?: number[];
+  /** Role ids the subject user holds. */
+  roleIds?: number[];
+  /** Permission code to look up. */
+  permissionCode: string;
+}
+
+const mapRule = (row: RowDataPacket): ResponsibilityRule => ({
+  id: row.id as number,
+  subjectType: row.subject_type as ResponsibilityRule['subjectType'],
+  subjectId: (row.subject_id as number | null) ?? null,
+  permissionCode: row.permission_code as string,
+  responsibleOrgUnitId: row.responsible_org_unit_id as number,
+  delegatedToRoleId: (row.delegated_to_role_id as number | null) ?? null,
+  description: (row.description as string | null) ?? null,
+  isActive: Boolean(row.is_active),
+  createdBy: (row.created_by as number | null) ?? null,
+  createdAt: row.created_at as string,
+  updatedAt: row.updated_at as string,
+});
+
+export class ResponsibilityRuleService {
+  private audit: AuditLogService;
+
+  constructor(private pool: Pool) {
+    this.audit = new AuditLogService(pool);
+  }
+
+  // --------------------------------------------------------------------------
+  // CRUD
+  // --------------------------------------------------------------------------
+
+  async list(filters: {
+    subjectType?: string;
+    permissionCode?: string;
+    responsibleOrgUnitId?: number;
+    isActive?: boolean;
+  } = {}): Promise<ResponsibilityRule[]> {
+    const conditions: string[] = [];
+    const params: Array<string | number | boolean> = [];
+
+    if (filters.subjectType) {
+      conditions.push('subject_type = ?');
+      params.push(filters.subjectType);
+    }
+    if (filters.permissionCode) {
+      conditions.push('permission_code = ?');
+      params.push(filters.permissionCode);
+    }
+    if (filters.responsibleOrgUnitId !== undefined) {
+      conditions.push('responsible_org_unit_id = ?');
+      params.push(filters.responsibleOrgUnitId);
+    }
+    if (filters.isActive !== undefined) {
+      conditions.push('is_active = ?');
+      params.push(filters.isActive ? 1 : 0);
+    }
+
+    const where = conditions.length ? ` WHERE ${conditions.join(' AND ')}` : '';
+    const [rows] = await this.pool.execute<RowDataPacket[]>(
+      `SELECT * FROM responsibility_rules${where} ORDER BY permission_code ASC, subject_type ASC`,
+      params
+    );
+    return rows.map(mapRule);
+  }
+
+  async getById(id: number): Promise<ResponsibilityRule | null> {
+    const [rows] = await this.pool.execute<RowDataPacket[]>(
+      'SELECT * FROM responsibility_rules WHERE id = ? LIMIT 1',
+      [id]
+    );
+    return rows.length === 0 ? null : mapRule(rows[0]);
+  }
+
+  async create(input: CreateResponsibilityRuleRequest, actorId: number | null): Promise<ResponsibilityRule> {
+    if (input.subjectType !== 'all' && (input.subjectId === undefined || input.subjectId === null)) {
+      throw new Error('subject_id is required when subject_type is not "all"');
+    }
+    if (input.subjectType === 'all' && input.subjectId != null) {
+      throw new Error('subject_id must be null when subject_type is "all"');
+    }
+
+    const [res] = await this.pool.execute<ResultSetHeader>(
+      `INSERT INTO responsibility_rules
+         (subject_type, subject_id, permission_code, responsible_org_unit_id,
+          delegated_to_role_id, description, is_active, created_by)
+       VALUES (?, ?, ?, ?, ?, ?, TRUE, ?)`,
+      [
+        input.subjectType,
+        input.subjectId ?? null,
+        input.permissionCode,
+        input.responsibleOrgUnitId,
+        input.delegatedToRoleId ?? null,
+        input.description ?? null,
+        actorId,
+      ]
+    );
+
+    const created = await this.getById(res.insertId);
+    if (!created) throw new Error('Failed to retrieve created responsibility rule');
+
+    await this.audit.write({
+      actorId,
+      action: 'responsibility_rule.create',
+      entityType: 'responsibility_rule',
+      entityId: created.id,
+      description: `Rule created: ${created.permissionCode} for ${created.subjectType}`,
+      after: created as unknown as Record<string, unknown>,
+    });
+
+    logger.info(`Responsibility rule created: id=${created.id} permission=${created.permissionCode}`);
+    return created;
+  }
+
+  async update(id: number, patch: UpdateResponsibilityRuleRequest, actorId: number | null): Promise<ResponsibilityRule> {
+    const existing = await this.getById(id);
+    if (!existing) throw new Error('Responsibility rule not found');
+
+    const merged = { ...existing, ...patch };
+
+    if (merged.subjectType !== 'all' && merged.subjectId == null) {
+      throw new Error('subject_id is required when subject_type is not "all"');
+    }
+    if (merged.subjectType === 'all' && merged.subjectId != null) {
+      throw new Error('subject_id must be null when subject_type is "all"');
+    }
+
+    await this.pool.execute(
+      `UPDATE responsibility_rules
+          SET subject_type = ?, subject_id = ?, permission_code = ?,
+              responsible_org_unit_id = ?, delegated_to_role_id = ?,
+              description = ?, is_active = ?,
+              updated_at = CURRENT_TIMESTAMP
+        WHERE id = ?`,
+      [
+        merged.subjectType,
+        merged.subjectId ?? null,
+        merged.permissionCode,
+        merged.responsibleOrgUnitId,
+        merged.delegatedToRoleId ?? null,
+        merged.description ?? null,
+        merged.isActive ? 1 : 0,
+        id,
+      ]
+    );
+
+    const updated = await this.getById(id);
+    if (!updated) throw new Error('Failed to retrieve updated responsibility rule');
+
+    await this.audit.write({
+      actorId,
+      action: 'responsibility_rule.update',
+      entityType: 'responsibility_rule',
+      entityId: id,
+      before: existing as unknown as Record<string, unknown>,
+      after: updated as unknown as Record<string, unknown>,
+    });
+
+    return updated;
+  }
+
+  async delete(id: number, actorId: number | null): Promise<void> {
+    const existing = await this.getById(id);
+    if (!existing) throw new Error('Responsibility rule not found');
+
+    await this.pool.execute('DELETE FROM responsibility_rules WHERE id = ?', [id]);
+
+    await this.audit.write({
+      actorId,
+      action: 'responsibility_rule.delete',
+      entityType: 'responsibility_rule',
+      entityId: id,
+      description: `Rule deleted: ${existing.permissionCode} for ${existing.subjectType}`,
+      before: existing as unknown as Record<string, unknown>,
+    });
+
+    logger.info(`Responsibility rule deleted: id=${id}`);
+  }
+
+  // --------------------------------------------------------------------------
+  // Resolution
+  // --------------------------------------------------------------------------
+
+  /**
+   * Resolves the user IDs of everyone who holds responsibility for a given
+   * permission over a specific subject user. Takes the subject's org unit,
+   * department(s) and role(s) and returns all responsible users across all
+   * matching rules — de-duplicated.
+   *
+   * Used by the approval engine to find the approver(s) when a rule uses
+   * the `responsibility_rule` scope.
+   */
+  async resolveResponsibleUsers(ctx: ResolveContext): Promise<number[]> {
+    // Build a WHERE clause covering all subject conditions that apply.
+    const subjectConditions: string[] = ["rr.subject_type = 'all'"];
+    const params: Array<string | number> = [ctx.permissionCode];
+
+    if (ctx.orgUnitId != null) {
+      subjectConditions.push("(rr.subject_type = 'org_unit' AND rr.subject_id = ?)");
+      params.push(ctx.orgUnitId);
+    }
+    if (ctx.departmentIds && ctx.departmentIds.length > 0) {
+      subjectConditions.push(
+        `(rr.subject_type = 'department' AND rr.subject_id IN (${ctx.departmentIds.map(() => '?').join(',')}))`
+      );
+      params.push(...ctx.departmentIds);
+    }
+    if (ctx.roleIds && ctx.roleIds.length > 0) {
+      subjectConditions.push(
+        `(rr.subject_type = 'role' AND rr.subject_id IN (${ctx.roleIds.map(() => '?').join(',')}))`
+      );
+      params.push(...ctx.roleIds);
+    }
+
+    const subjectClause = subjectConditions.join(' OR ');
+
+    // Single query: join rules → responsible org unit members, filter by optional role.
+    const [rows] = await this.pool.execute<RowDataPacket[]>(
+      `SELECT DISTINCT uou.user_id
+         FROM responsibility_rules rr
+         JOIN user_org_units uou ON uou.org_unit_id = rr.responsible_org_unit_id
+         JOIN users u ON u.id = uou.user_id AND u.is_active = TRUE
+         LEFT JOIN user_roles ur
+           ON ur.user_id = uou.user_id
+          AND ur.role_id = rr.delegated_to_role_id
+          AND (ur.expires_at IS NULL OR ur.expires_at > NOW())
+        WHERE rr.is_active = TRUE
+          AND rr.permission_code = ?
+          AND (${subjectClause})
+          AND (rr.delegated_to_role_id IS NULL OR ur.user_id IS NOT NULL)`,
+      params
+    );
+
+    return rows.map((r: any) => r.user_id as number);
+  }
+}

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -401,6 +401,45 @@ export interface CreateAssignmentRequest {
   notes?: string;
 }
 
+// ============================================================================
+// RESPONSIBILITY RULES
+// ============================================================================
+
+export type ResponsibilitySubjectType = 'org_unit' | 'department' | 'role' | 'all';
+
+export interface ResponsibilityRule {
+  id: number;
+  subjectType: ResponsibilitySubjectType;
+  subjectId: number | null;
+  permissionCode: string;
+  responsibleOrgUnitId: number;
+  delegatedToRoleId: number | null;
+  description: string | null;
+  isActive: boolean;
+  createdBy: number | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateResponsibilityRuleRequest {
+  subjectType: ResponsibilitySubjectType;
+  subjectId?: number | null;
+  permissionCode: string;
+  responsibleOrgUnitId: number;
+  delegatedToRoleId?: number | null;
+  description?: string | null;
+}
+
+export interface UpdateResponsibilityRuleRequest {
+  subjectType?: ResponsibilitySubjectType;
+  subjectId?: number | null;
+  permissionCode?: string;
+  responsibleOrgUnitId?: number;
+  delegatedToRoleId?: number | null;
+  description?: string | null;
+  isActive?: boolean;
+}
+
 // System Settings Types
 export interface SystemSetting {
   id: number;


### PR DESCRIPTION
## Summary

- Adds `responsibility_rules` table mapping `(subject group × permission code) → responsible org unit`, supporting the case where two offices hold the same authority over different subordinate groups
- Introduces `responsibility.read` / `responsibility.manage` permission codes (both granted to Manager role)
- `ResponsibilityRuleService` provides full CRUD and a `resolveResponsibleUsers()` method that resolves the set of users responsible for a given permission over a specific subject (by org unit, department(s) or role(s)) in a single SQL join
- REST router mounted at `/api/v1/responsibility-rules` with appropriate permission guards
- 30 unit tests covering all CRUD paths, validation rules, audit-log writes, and all resolver subject-type branches

## Test plan

- [ ] `npx jest src/__tests__/responsibilityRule.service.test.ts` → 30 tests pass
- [ ] `npm run lint` → no errors
- [ ] `npx tsc --noEmit` → no errors
- [ ] CI green