### PR TITLE
feat(approval-engine): add responsibility_rule approver scope

### DIFF
--- a/backend/database/init.sql
+++ b/backend/database/init.sql
@@ -808,10 +808,13 @@ CREATE TABLE IF NOT EXISTS approval_steps (
         'unit_manager',
         'unit_manager_chain',
         'company_role',
-        'company_user'
+        'company_user',
+        'responsibility_rule'
     ) NOT NULL,
     approver_role_id INT NULL,
     approver_user_id INT NULL,
+    -- used when approver_scope = 'responsibility_rule'; identifies which permission to look up
+    approver_permission_code VARCHAR(80) NULL,
     auto_approve_for_owner BOOLEAN NOT NULL DEFAULT TRUE,
     escalate_after_hours INT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,

--- a/backend/src/__tests__/approval.engine.responsibility.test.ts
+++ b/backend/src/__tests__/approval.engine.responsibility.test.ts
@@ -1,0 +1,226 @@
+/**
+ * ApprovalEngineService — responsibility_rule scope tests.
+ *
+ * Verifies that steps with approver_scope = 'responsibility_rule' delegate
+ * resolution to ResponsibilityRuleService.resolveResponsibleUsers().
+ *
+ * Covers:
+ *   - resolveApprover returns first responsible user
+ *   - resolveApprover returns null when no responsible users found
+ *   - resolveApprover returns null when approver_permission_code is absent
+ *   - auto-approve when actor is the first responsible user
+ *   - resolveAllApproversForStep returns full list for responsibility_rule scope
+ *   - resolveAllApproversForStep delegates to single-approver path for other scopes
+ *   - subject context (departmentIds, roleIds) is forwarded to the resolver
+ *
+ * @author Luca Ostinelli
+ */
+
+import { ApprovalEngineService } from '../services/ApprovalEngineService';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const makePool = () => {
+  const execute = jest.fn();
+  return { pool: { execute, getConnection: jest.fn() } as never, execute };
+};
+
+const wfRow = {
+  id: 10,
+  change_type: 'Leave.Request',
+  require_all: 0,
+  description: null,
+  created_at: new Date(),
+  updated_at: new Date(),
+};
+
+const makeStep = (overrides: Record<string, unknown> = {}) => ({
+  id: 1,
+  workflow_id: 10,
+  step_order: 1,
+  approver_scope: 'responsibility_rule',
+  approver_role_id: null,
+  approver_user_id: null,
+  approver_permission_code: 'leave.manage',
+  auto_approve_for_owner: 1,
+  escalate_after_hours: null,
+  ...overrides,
+});
+
+// ---------------------------------------------------------------------------
+// resolveApprover — responsibility_rule scope
+// ---------------------------------------------------------------------------
+
+describe('ApprovalEngineService.resolveApprover — responsibility_rule scope', () => {
+  it('returns the first user from resolveResponsibleUsers when users are found', async () => {
+    const { pool, execute } = makePool();
+    // getWorkflowByChangeType
+    execute.mockResolvedValueOnce([[wfRow], null]);
+    // hydrateWorkflow (steps)
+    execute.mockResolvedValueOnce([[makeStep()], null]);
+    // ResponsibilityRuleService.resolveResponsibleUsers → [7, 8, 9]
+    execute.mockResolvedValueOnce([[{ user_id: 7 }, { user_id: 8 }, { user_id: 9 }], null]);
+
+    const svc = new ApprovalEngineService(pool);
+    const result = await svc.resolveApprover('Leave.Request', { actorUserId: 3 });
+
+    expect(result).not.toBeNull();
+    expect(result!.approverUserId).toBe(7);
+    expect(result!.autoApprove).toBe(false);
+  });
+
+  it('returns approverUserId=null when no responsible users are found', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[wfRow], null]);
+    execute.mockResolvedValueOnce([[makeStep()], null]);
+    // No responsible users
+    execute.mockResolvedValueOnce([[], null]);
+
+    const svc = new ApprovalEngineService(pool);
+    const result = await svc.resolveApprover('Leave.Request', { actorUserId: 3 });
+
+    expect(result).not.toBeNull();
+    expect(result!.approverUserId).toBeNull();
+  });
+
+  it('returns approverUserId=null when approver_permission_code is null', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[wfRow], null]);
+    execute.mockResolvedValueOnce([[makeStep({ approver_permission_code: null })], null]);
+    // resolveResponsibleUsers should NOT be called
+
+    const svc = new ApprovalEngineService(pool);
+    const result = await svc.resolveApprover('Leave.Request', { actorUserId: 3 });
+
+    // step has no permission_code → approverUserId null → step returned with null approver
+    expect(result!.approverUserId).toBeNull();
+    // resolveResponsibleUsers query was NOT executed (only getWorkflow + hydrateWorkflow)
+    expect(execute).toHaveBeenCalledTimes(2);
+  });
+
+  it('auto-approves when the actor is the first responsible user', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[wfRow], null]);
+    execute.mockResolvedValueOnce([[makeStep()], null]);
+    // first resolved user is actorUserId (5)
+    execute.mockResolvedValueOnce([[{ user_id: 5 }], null]);
+
+    const svc = new ApprovalEngineService(pool);
+    // auto_approve_for_owner=true + actor is the approver → auto-approve all → null
+    const result = await svc.resolveApprover('Leave.Request', { actorUserId: 5 });
+
+    expect(result).toBeNull();
+  });
+
+  it('passes orgUnitId and subject context to resolveResponsibleUsers', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[wfRow], null]);
+    execute.mockResolvedValueOnce([[makeStep()], null]);
+    execute.mockResolvedValueOnce([[{ user_id: 7 }], null]);
+
+    const svc = new ApprovalEngineService(pool);
+    await svc.resolveApprover('Leave.Request', {
+      actorUserId: 3,
+      orgUnitId: 5,
+      subjectDepartmentIds: [10, 11],
+      subjectRoleIds: [2],
+    });
+
+    // Third call = resolveResponsibleUsers SQL
+    const [sql, params] = execute.mock.calls[2];
+    expect(sql).toContain('permission_code = ?');
+    expect(params).toContain('leave.manage');
+    expect(params).toContain(5);   // orgUnitId
+    expect(params).toContain(10);  // departmentId
+    expect(params).toContain(11);  // departmentId
+    expect(params).toContain(2);   // roleId
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveAllApproversForStep
+// ---------------------------------------------------------------------------
+
+describe('ApprovalEngineService.resolveAllApproversForStep', () => {
+  it('returns all user IDs for a responsibility_rule step', async () => {
+    const { pool, execute } = makePool();
+    // resolveResponsibleUsers
+    execute.mockResolvedValueOnce([[{ user_id: 5 }, { user_id: 6 }, { user_id: 7 }], null]);
+
+    const svc = new ApprovalEngineService(pool);
+    const step = {
+      id: 1, workflowId: 10, stepOrder: 1,
+      approverScope: 'responsibility_rule' as const,
+      approverRoleId: null, approverUserId: null,
+      approverPermissionCode: 'leave.manage',
+      autoApproveForOwner: true, escalateAfterHours: null,
+    };
+
+    const ids = await svc.resolveAllApproversForStep(step, { actorUserId: 3, orgUnitId: 2 });
+    expect(ids).toEqual([5, 6, 7]);
+  });
+
+  it('returns empty array when approverPermissionCode is absent', async () => {
+    const { pool } = makePool();
+    const svc = new ApprovalEngineService(pool);
+    const step = {
+      id: 1, workflowId: 10, stepOrder: 1,
+      approverScope: 'responsibility_rule' as const,
+      approverRoleId: null, approverUserId: null,
+      approverPermissionCode: null,
+      autoApproveForOwner: true, escalateAfterHours: null,
+    };
+
+    const ids = await svc.resolveAllApproversForStep(step, { actorUserId: 3 });
+    expect(ids).toEqual([]);
+  });
+
+  it('returns single-element array for company_user scope', async () => {
+    const { pool } = makePool();
+    const svc = new ApprovalEngineService(pool);
+    const step = {
+      id: 2, workflowId: 10, stepOrder: 1,
+      approverScope: 'company_user' as const,
+      approverRoleId: null, approverUserId: 42,
+      approverPermissionCode: null,
+      autoApproveForOwner: false, escalateAfterHours: null,
+    };
+
+    const ids = await svc.resolveAllApproversForStep(step, { actorUserId: 3 });
+    expect(ids).toEqual([42]);
+  });
+
+  it('returns empty array when company_user step has no approverUserId', async () => {
+    const { pool } = makePool();
+    const svc = new ApprovalEngineService(pool);
+    const step = {
+      id: 2, workflowId: 10, stepOrder: 1,
+      approverScope: 'company_user' as const,
+      approverRoleId: null, approverUserId: null,
+      approverPermissionCode: null,
+      autoApproveForOwner: false, escalateAfterHours: null,
+    };
+
+    const ids = await svc.resolveAllApproversForStep(step, { actorUserId: 3 });
+    expect(ids).toEqual([]);
+  });
+
+  it('returns empty array for responsibility_rule with no matching users', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[], null]);
+
+    const svc = new ApprovalEngineService(pool);
+    const step = {
+      id: 1, workflowId: 10, stepOrder: 1,
+      approverScope: 'responsibility_rule' as const,
+      approverRoleId: null, approverUserId: null,
+      approverPermissionCode: 'leave.manage',
+      autoApproveForOwner: true, escalateAfterHours: null,
+    };
+
+    const ids = await svc.resolveAllApproversForStep(step, { actorUserId: 3 });
+    expect(ids).toEqual([]);
+  });
+});

--- a/backend/src/services/ApprovalEngineService.ts
+++ b/backend/src/services/ApprovalEngineService.ts
@@ -21,11 +21,15 @@ import {
   CreateApprovalWorkflowRequest,
 } from '../types';
 import { logger } from '../config/logger';
+import { ResponsibilityRuleService } from './ResponsibilityRuleService';
 
 interface ResolveContext {
   orgUnitId?: number;
   policyOwnerId?: number;
   actorUserId: number;
+  /** Subject context for responsibility_rule scope. */
+  subjectDepartmentIds?: number[];
+  subjectRoleIds?: number[];
 }
 
 interface ResolvedStep {
@@ -35,7 +39,11 @@ interface ResolvedStep {
 }
 
 export class ApprovalEngineService {
-  constructor(private pool: Pool) {}
+  private responsibilitySvc: ResponsibilityRuleService;
+
+  constructor(private pool: Pool) {
+    this.responsibilitySvc = new ResponsibilityRuleService(pool);
+  }
 
   // --------------------------------------------------------------------------
   // Workflow CRUD
@@ -46,7 +54,7 @@ export class ApprovalEngineService {
       `SELECT
          w.id, w.change_type, w.require_all, w.description, w.created_at, w.updated_at,
          s.id AS step_id, s.workflow_id AS step_workflow_id, s.step_order,
-         s.approver_scope, s.approver_role_id, s.approver_user_id,
+         s.approver_scope, s.approver_role_id, s.approver_user_id, s.approver_permission_code,
          s.auto_approve_for_owner, s.escalate_after_hours
        FROM approval_workflows w
        LEFT JOIN approval_steps s ON s.workflow_id = w.id
@@ -73,6 +81,7 @@ export class ApprovalEngineService {
           approverScope: row.approver_scope as ApproverScope,
           approverRoleId: row.approver_role_id ?? null,
           approverUserId: row.approver_user_id ?? null,
+          approverPermissionCode: row.approver_permission_code ?? null,
           autoApproveForOwner: Boolean(row.auto_approve_for_owner),
           escalateAfterHours: row.escalate_after_hours ?? null,
         });
@@ -104,14 +113,15 @@ export class ApprovalEngineService {
         await connection.execute(
           `INSERT INTO approval_steps
              (workflow_id, step_order, approver_scope, approver_role_id, approver_user_id,
-              auto_approve_for_owner, escalate_after_hours)
-           VALUES (?, ?, ?, ?, ?, ?, ?)`,
+              approver_permission_code, auto_approve_for_owner, escalate_after_hours)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
           [
             workflowId,
             s.stepOrder,
             s.approverScope,
             s.approverRoleId ?? null,
             s.approverUserId ?? null,
+            s.approverPermissionCode ?? null,
             s.autoApproveForOwner ?? true,
             s.escalateAfterHours ?? null,
           ]
@@ -153,10 +163,10 @@ export class ApprovalEngineService {
           await connection.execute(
             `INSERT INTO approval_steps
                (workflow_id, step_order, approver_scope, approver_role_id, approver_user_id,
-                auto_approve_for_owner, escalate_after_hours)
-             VALUES (?, ?, ?, ?, ?, ?, ?)`,
+                approver_permission_code, auto_approve_for_owner, escalate_after_hours)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
             [id, s.stepOrder, s.approverScope, s.approverRoleId ?? null, s.approverUserId ?? null,
-             s.autoApproveForOwner ?? true, s.escalateAfterHours ?? null]
+             s.approverPermissionCode ?? null, s.autoApproveForOwner ?? true, s.escalateAfterHours ?? null]
           );
         }
       }
@@ -184,6 +194,24 @@ export class ApprovalEngineService {
   // --------------------------------------------------------------------------
   // Step resolution
   // --------------------------------------------------------------------------
+
+  /**
+   * For a `responsibility_rule` step, returns all user IDs who hold
+   * responsibility (not just the first). Useful for fan-out notifications.
+   */
+  async resolveAllApproversForStep(step: ApprovalStep, ctx: ResolveContext): Promise<number[]> {
+    if (step.approverScope !== 'responsibility_rule') {
+      const single = await this.resolveStepApprover(step, ctx);
+      return single !== null ? [single] : [];
+    }
+    if (!step.approverPermissionCode) return [];
+    return this.responsibilitySvc.resolveResponsibleUsers({
+      permissionCode: step.approverPermissionCode,
+      orgUnitId: ctx.orgUnitId ?? null,
+      departmentIds: ctx.subjectDepartmentIds ?? [],
+      roleIds: ctx.subjectRoleIds ?? [],
+    });
+  }
 
   /**
    * Resolves ALL steps for the given change type in order. Returns the first
@@ -262,7 +290,7 @@ export class ApprovalEngineService {
   private async hydrateWorkflow(w: any): Promise<ApprovalWorkflow> {
     const [stepRows] = await this.pool.execute<RowDataPacket[]>(
       `SELECT id, workflow_id, step_order, approver_scope, approver_role_id,
-              approver_user_id, auto_approve_for_owner, escalate_after_hours
+              approver_user_id, approver_permission_code, auto_approve_for_owner, escalate_after_hours
          FROM approval_steps WHERE workflow_id = ? ORDER BY step_order ASC`,
       [w.id]
     );
@@ -273,6 +301,7 @@ export class ApprovalEngineService {
       approverScope: s.approver_scope as ApproverScope,
       approverRoleId: s.approver_role_id ?? null,
       approverUserId: s.approver_user_id ?? null,
+      approverPermissionCode: s.approver_permission_code ?? null,
       autoApproveForOwner: Boolean(s.auto_approve_for_owner),
       escalateAfterHours: s.escalate_after_hours ?? null,
     }));
@@ -299,6 +328,16 @@ export class ApprovalEngineService {
         return step.approverRoleId ? this.findFirstActiveByRoleId(step.approverRoleId) : null;
       case 'company_user':
         return step.approverUserId;
+      case 'responsibility_rule': {
+        if (!step.approverPermissionCode) return null;
+        const ids = await this.responsibilitySvc.resolveResponsibleUsers({
+          permissionCode: step.approverPermissionCode,
+          orgUnitId: ctx.orgUnitId ?? null,
+          departmentIds: ctx.subjectDepartmentIds ?? [],
+          roleIds: ctx.subjectRoleIds ?? [],
+        });
+        return ids.length > 0 ? ids[0] : null;
+      }
       default:
         return null;
     }

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -104,7 +104,8 @@ export type ApproverScope =
   | 'unit_manager'
   | 'unit_manager_chain'
   | 'company_role'
-  | 'company_user';
+  | 'company_user'
+  | 'responsibility_rule';
 
 export interface ApprovalStep {
   id: number;
@@ -113,6 +114,8 @@ export interface ApprovalStep {
   approverScope: ApproverScope;
   approverRoleId: number | null;
   approverUserId: number | null;
+  /** Required when approverScope === 'responsibility_rule'. */
+  approverPermissionCode: string | null;
   autoApproveForOwner: boolean;
   escalateAfterHours: number | null;
 }
@@ -136,6 +139,7 @@ export interface CreateApprovalWorkflowRequest {
     approverScope: ApproverScope;
     approverRoleId?: number | null;
     approverUserId?: number | null;
+    approverPermissionCode?: string | null;
     autoApproveForOwner?: boolean;
     escalateAfterHours?: number | null;
   }>;


### PR DESCRIPTION
## Summary

- Extends `approval_steps.approver_scope` ENUM with `'responsibility_rule'`
- Adds `approver_permission_code VARCHAR(80)` column to store which permission code to look up
- `ApprovalEngineService.resolveStepApprover()` now delegates to `ResponsibilityRuleService.resolveResponsibleUsers()` for this scope, returning the first responsible user as the designated approver
- New `resolveAllApproversForStep()` public method returns the full list of responsible users (needed for fan-out notifications where all responsible parties should be notified)
- `ResolveContext` extended with `subjectDepartmentIds` and `subjectRoleIds` to carry the subject's group membership into the resolver
- 10 new tests cover all branches: first-user selection, null permission-code guard, auto-approve path, subject context forwarding, fan-out list, and delegation to single-approver path for other scopes

## Test plan

- [ ] `npx jest src/__tests__/approval.engine.responsibility.test.ts` → 10 tests pass
- [ ] `npx jest --no-coverage` → all 1725 tests pass
- [ ] `npm run lint` → no errors
- [ ] CI green