### PR TITLE
feat(change-requests): subordinate change proposal mechanism

### DIFF
--- a/backend/database/init.sql
+++ b/backend/database/init.sql
@@ -863,7 +863,9 @@ INSERT IGNORE INTO permissions (code, resource, action, description) VALUES
 ('settings.manage',   'settings',  'manage',  'Edit system settings'),
 ('role.manage',           'role',            'manage',  'Create roles and assign permissions to them'),
 ('responsibility.read',  'responsibility',  'read',    'View responsibility rules'),
-('responsibility.manage','responsibility',  'manage',  'Create, update and delete responsibility rules');
+('responsibility.manage','responsibility',  'manage',  'Create, update and delete responsibility rules'),
+('change_request.create','change_request','create',   'Propose a change request'),
+('change_request.review','change_request','review',   'Approve, reject or apply change requests');
 
 -- ----------------------------------------------------------------
 -- Default roles (editable data; not hardcoded in application code).
@@ -888,7 +890,8 @@ SELECT r.id, p.id FROM roles r JOIN permissions p ON p.code IN (
   'org_unit.read','oncall.manage','policy.read','policy.manage','policy.approve',
   'loan.request','loan.approve','timeoff.approve','shiftswap.approve','preferences.manage',
   'report.read','audit.read','user.read','user.manage',
-  'responsibility.read','responsibility.manage'
+  'responsibility.read','responsibility.manage',
+  'change_request.create','change_request.review'
 ) WHERE r.name = 'Manager';
 
 -- Employee gets read-only visibility; self-service actions (creating own
@@ -1037,6 +1040,42 @@ CREATE TABLE IF NOT EXISTS responsibility_rules (
     FOREIGN KEY (responsible_org_unit_id) REFERENCES org_units(id) ON DELETE CASCADE,
     FOREIGN KEY (delegated_to_role_id) REFERENCES roles(id) ON DELETE SET NULL,
     FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE SET NULL
+);
+
+-- ================================================================
+-- CHANGE REQUESTS
+-- A subordinate proposes a change; when approved and applied the audit
+-- log attributes the action to the authority holder (on_behalf_of tracks
+-- the original proposer so the full chain is auditable).
+-- ================================================================
+CREATE TABLE IF NOT EXISTS change_requests (
+    id INT PRIMARY KEY AUTO_INCREMENT,
+    change_type VARCHAR(80) NOT NULL,
+    proposer_user_id INT NOT NULL,
+    target_entity_type VARCHAR(60) NOT NULL,
+    target_entity_id INT NULL,
+    proposed_payload JSON NOT NULL,
+    justification TEXT NULL,
+    status ENUM('pending','approved','rejected','applied','cancelled') NOT NULL DEFAULT 'pending',
+    approver_user_id INT NULL,
+    approved_at TIMESTAMP NULL,
+    rejected_at TIMESTAMP NULL,
+    rejection_reason TEXT NULL,
+    applied_at TIMESTAMP NULL,
+    -- when applied, the action is attributed to this user (the authority holder)
+    on_behalf_of_user_id INT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+    INDEX idx_cr_proposer (proposer_user_id),
+    INDEX idx_cr_status (status),
+    INDEX idx_cr_change_type (change_type),
+    INDEX idx_cr_target (target_entity_type, target_entity_id),
+    INDEX idx_cr_approver (approver_user_id),
+
+    FOREIGN KEY (proposer_user_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (approver_user_id) REFERENCES users(id) ON DELETE SET NULL,
+    FOREIGN KEY (on_behalf_of_user_id) REFERENCES users(id) ON DELETE SET NULL
 );
 
 -- ================================================================

--- a/backend/src/__tests__/changeRequest.service.test.ts
+++ b/backend/src/__tests__/changeRequest.service.test.ts
@@ -1,0 +1,390 @@
+/**
+ * ChangeRequestService unit tests.
+ *
+ * Covers: list (all filters, pagination), getById, create, approve,
+ * reject, apply (attribution audit), cancel, and status-transition guards.
+ *
+ * @author Luca Ostinelli
+ */
+
+import { ChangeRequestService } from '../services/ChangeRequestService';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const buildRow = (overrides: Record<string, unknown> = {}) => ({
+  id: 1,
+  change_type: 'Schedule.Override',
+  proposer_user_id: 10,
+  target_entity_type: 'schedule',
+  target_entity_id: 5,
+  proposed_payload: JSON.stringify({ date: '2026-07-01', shiftId: 3 }),
+  justification: 'Covering sick leave',
+  status: 'pending',
+  approver_user_id: null,
+  approved_at: null,
+  rejected_at: null,
+  rejection_reason: null,
+  applied_at: null,
+  on_behalf_of_user_id: null,
+  created_at: '2026-06-01T00:00:00.000Z',
+  updated_at: '2026-06-01T00:00:00.000Z',
+  ...overrides,
+});
+
+const makePool = () => {
+  const execute = jest.fn();
+  return { pool: { execute } as never, execute };
+};
+
+// ---------------------------------------------------------------------------
+// list
+// ---------------------------------------------------------------------------
+
+describe('ChangeRequestService.list', () => {
+  it('returns total and items without filters', async () => {
+    const { pool, execute } = makePool();
+    execute
+      .mockResolvedValueOnce([[{ c: 2 }], null])
+      .mockResolvedValueOnce([[buildRow(), buildRow({ id: 2 })], null]);
+
+    const svc = new ChangeRequestService(pool);
+    const { total, items } = await svc.list();
+    expect(total).toBe(2);
+    expect(items).toHaveLength(2);
+  });
+
+  it('filters by proposerUserId', async () => {
+    const { pool, execute } = makePool();
+    execute
+      .mockResolvedValueOnce([[{ c: 1 }], null])
+      .mockResolvedValueOnce([[buildRow()], null]);
+
+    const svc = new ChangeRequestService(pool);
+    await svc.list({ proposerUserId: 10 });
+
+    const [countSql, params] = execute.mock.calls[0];
+    expect(countSql).toContain('proposer_user_id = ?');
+    expect(params).toContain(10);
+  });
+
+  it('filters by status', async () => {
+    const { pool, execute } = makePool();
+    execute
+      .mockResolvedValueOnce([[{ c: 1 }], null])
+      .mockResolvedValueOnce([[buildRow({ status: 'approved' })], null]);
+
+    const svc = new ChangeRequestService(pool);
+    await svc.list({ status: 'approved' });
+
+    const [, params] = execute.mock.calls[0];
+    expect(params).toContain('approved');
+  });
+
+  it('filters by changeType', async () => {
+    const { pool, execute } = makePool();
+    execute
+      .mockResolvedValueOnce([[{ c: 1 }], null])
+      .mockResolvedValueOnce([[buildRow()], null]);
+
+    const svc = new ChangeRequestService(pool);
+    await svc.list({ changeType: 'Schedule.Override' });
+
+    const [, params] = execute.mock.calls[0];
+    expect(params).toContain('Schedule.Override');
+  });
+
+  it('maps proposed_payload JSON string to object', async () => {
+    const { pool, execute } = makePool();
+    execute
+      .mockResolvedValueOnce([[{ c: 1 }], null])
+      .mockResolvedValueOnce([[buildRow()], null]);
+
+    const svc = new ChangeRequestService(pool);
+    const { items } = await svc.list();
+    expect(items[0].proposedPayload).toEqual({ date: '2026-07-01', shiftId: 3 });
+  });
+
+  it('handles invalid JSON in proposed_payload gracefully', async () => {
+    const { pool, execute } = makePool();
+    execute
+      .mockResolvedValueOnce([[{ c: 1 }], null])
+      .mockResolvedValueOnce([[buildRow({ proposed_payload: 'not-json' })], null]);
+
+    const svc = new ChangeRequestService(pool);
+    const { items } = await svc.list();
+    expect(items[0].proposedPayload).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getById
+// ---------------------------------------------------------------------------
+
+describe('ChangeRequestService.getById', () => {
+  it('returns mapped change request when found', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[buildRow()], null]);
+
+    const svc = new ChangeRequestService(pool);
+    const cr = await svc.getById(1);
+    expect(cr).not.toBeNull();
+    expect(cr!.id).toBe(1);
+    expect(cr!.changeType).toBe('Schedule.Override');
+    expect(cr!.status).toBe('pending');
+    expect(cr!.proposerUserId).toBe(10);
+  });
+
+  it('returns null when not found', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[], null]);
+
+    const svc = new ChangeRequestService(pool);
+    expect(await svc.getById(999)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// create
+// ---------------------------------------------------------------------------
+
+describe('ChangeRequestService.create', () => {
+  it('inserts a pending change request and returns it', async () => {
+    const { pool, execute } = makePool();
+    execute
+      .mockResolvedValueOnce([{ insertId: 7, affectedRows: 1 }, null])
+      .mockResolvedValueOnce([[buildRow({ id: 7 })], null])
+      .mockResolvedValue([{ insertId: 99, affectedRows: 1 }, null]); // audit
+
+    const svc = new ChangeRequestService(pool);
+    const cr = await svc.create(
+      { changeType: 'Schedule.Override', targetEntityType: 'schedule', proposedPayload: { shift: 1 } },
+      10
+    );
+
+    expect(cr.id).toBe(7);
+    const [insertSql, insertParams] = execute.mock.calls[0];
+    expect(insertSql).toContain("INSERT INTO change_requests");
+    expect(insertSql).toContain("'pending'");
+    expect(insertParams).toContain('Schedule.Override');
+    expect(insertParams).toContain(10);
+  });
+
+  it('serialises proposedPayload as JSON', async () => {
+    const { pool, execute } = makePool();
+    execute
+      .mockResolvedValueOnce([{ insertId: 1, affectedRows: 1 }, null])
+      .mockResolvedValueOnce([[buildRow()], null])
+      .mockResolvedValue([{ insertId: 1, affectedRows: 1 }, null]);
+
+    const svc = new ChangeRequestService(pool);
+    await svc.create(
+      { changeType: 'X', targetEntityType: 'y', proposedPayload: { key: 'value' } },
+      5
+    );
+
+    const [, params] = execute.mock.calls[0];
+    const payload = params.find((p: unknown) => typeof p === 'string' && p.includes('"key"'));
+    expect(payload).toBeDefined();
+    expect(JSON.parse(payload as string)).toEqual({ key: 'value' });
+  });
+
+  it('writes an audit log entry after creation', async () => {
+    const { pool, execute } = makePool();
+    execute
+      .mockResolvedValueOnce([{ insertId: 1, affectedRows: 1 }, null])
+      .mockResolvedValueOnce([[buildRow()], null])
+      .mockResolvedValueOnce([{ insertId: 99, affectedRows: 1 }, null]);
+
+    const svc = new ChangeRequestService(pool);
+    await svc.create(
+      { changeType: 'X', targetEntityType: 'y', proposedPayload: {} },
+      5
+    );
+
+    expect(execute).toHaveBeenCalledTimes(3);
+    const [auditSql] = execute.mock.calls[2];
+    expect(auditSql).toContain('INSERT INTO audit_logs');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// approve
+// ---------------------------------------------------------------------------
+
+describe('ChangeRequestService.approve', () => {
+  it('transitions status to approved and sets approver_user_id', async () => {
+    const { pool, execute } = makePool();
+    execute
+      .mockResolvedValueOnce([[buildRow()], null])              // getById
+      .mockResolvedValueOnce([{ affectedRows: 1 }, null])       // UPDATE
+      .mockResolvedValueOnce([[buildRow({ status: 'approved', approver_user_id: 20 })], null]) // getById
+      .mockResolvedValue([{ insertId: 1, affectedRows: 1 }, null]); // audit
+
+    const svc = new ChangeRequestService(pool);
+    const cr = await svc.approve(1, 20, 'Looks good');
+    expect(cr.status).toBe('approved');
+    expect(cr.approverUserId).toBe(20);
+  });
+
+  it('throws when request is not in pending status', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[buildRow({ status: 'rejected' })], null]);
+
+    const svc = new ChangeRequestService(pool);
+    await expect(svc.approve(1, 20)).rejects.toThrow("Cannot approve");
+  });
+
+  it('throws not found when request does not exist', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[], null]);
+
+    const svc = new ChangeRequestService(pool);
+    await expect(svc.approve(999, 20)).rejects.toThrow('not found');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// reject
+// ---------------------------------------------------------------------------
+
+describe('ChangeRequestService.reject', () => {
+  it('transitions status to rejected with a reason', async () => {
+    const { pool, execute } = makePool();
+    execute
+      .mockResolvedValueOnce([[buildRow()], null])
+      .mockResolvedValueOnce([{ affectedRows: 1 }, null])
+      .mockResolvedValueOnce([[buildRow({ status: 'rejected', rejection_reason: 'Not justified' })], null])
+      .mockResolvedValue([{ insertId: 1, affectedRows: 1 }, null]);
+
+    const svc = new ChangeRequestService(pool);
+    const cr = await svc.reject(1, 20, 'Not justified');
+    expect(cr.status).toBe('rejected');
+    expect(cr.rejectionReason).toBe('Not justified');
+
+    const [updateSql, params] = execute.mock.calls[1];
+    expect(updateSql).toContain("'rejected'");
+    expect(params).toContain('Not justified');
+  });
+
+  it('throws when request is not in pending status', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[buildRow({ status: 'approved' })], null]);
+
+    const svc = new ChangeRequestService(pool);
+    await expect(svc.reject(1, 20, 'reason')).rejects.toThrow("Cannot reject");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// apply
+// ---------------------------------------------------------------------------
+
+describe('ChangeRequestService.apply', () => {
+  it('transitions status to applied and records on_behalf_of_user_id', async () => {
+    const { pool, execute } = makePool();
+    const approvedRow = buildRow({ status: 'approved', approver_user_id: 20 });
+    execute
+      .mockResolvedValueOnce([[approvedRow], null])
+      .mockResolvedValueOnce([{ affectedRows: 1 }, null])
+      .mockResolvedValueOnce([[buildRow({ status: 'applied', on_behalf_of_user_id: 10 })], null])
+      .mockResolvedValue([{ insertId: 1, affectedRows: 1 }, null]);
+
+    const svc = new ChangeRequestService(pool);
+    const cr = await svc.apply(1, 20);
+    expect(cr.status).toBe('applied');
+    expect(cr.onBehalfOfUserId).toBe(10); // proposer
+
+    const [updateSql, updateParams] = execute.mock.calls[1];
+    expect(updateSql).toContain("'applied'");
+    // on_behalf_of_user_id should be set to proposer (10)
+    expect(updateParams).toContain(10);
+  });
+
+  it('writes audit log with authority holder as actor and proposer as on_behalf_of', async () => {
+    const { pool, execute } = makePool();
+    const approvedRow = buildRow({ status: 'approved', approver_user_id: 20, proposer_user_id: 10 });
+    execute
+      .mockResolvedValueOnce([[approvedRow], null])
+      .mockResolvedValueOnce([{ affectedRows: 1 }, null])
+      .mockResolvedValueOnce([[buildRow({ status: 'applied' })], null])
+      .mockResolvedValueOnce([{ insertId: 1, affectedRows: 1 }, null]);
+
+    const svc = new ChangeRequestService(pool);
+    await svc.apply(1, 20);
+
+    const [auditSql, auditParams] = execute.mock.calls[3];
+    expect(auditSql).toContain('INSERT INTO audit_logs');
+    // user_id (index 0) = authority holder (20)
+    expect(auditParams[0]).toBe(20);
+    // on_behalf_of_user_id (index 1) = proposer (10)
+    expect(auditParams[1]).toBe(10);
+  });
+
+  it('throws when request is not in approved status', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[buildRow({ status: 'pending' })], null]);
+
+    const svc = new ChangeRequestService(pool);
+    await expect(svc.apply(1, 20)).rejects.toThrow('Cannot apply');
+  });
+
+  it('throws not found when request does not exist', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[], null]);
+
+    const svc = new ChangeRequestService(pool);
+    await expect(svc.apply(999, 20)).rejects.toThrow('not found');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cancel
+// ---------------------------------------------------------------------------
+
+describe('ChangeRequestService.cancel', () => {
+  it('transitions status to cancelled', async () => {
+    const { pool, execute } = makePool();
+    execute
+      .mockResolvedValueOnce([[buildRow()], null])
+      .mockResolvedValueOnce([{ affectedRows: 1 }, null])
+      .mockResolvedValueOnce([[buildRow({ status: 'cancelled' })], null])
+      .mockResolvedValue([{ insertId: 1, affectedRows: 1 }, null]);
+
+    const svc = new ChangeRequestService(pool);
+    const cr = await svc.cancel(1, 10);
+    expect(cr.status).toBe('cancelled');
+  });
+
+  it('throws when request is not in pending status', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[buildRow({ status: 'applied' })], null]);
+
+    const svc = new ChangeRequestService(pool);
+    await expect(svc.cancel(1, 10)).rejects.toThrow('Cannot cancel');
+  });
+
+  it('throws not found when request does not exist', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[], null]);
+
+    const svc = new ChangeRequestService(pool);
+    await expect(svc.cancel(999, 10)).rejects.toThrow('not found');
+  });
+
+  it('writes an audit entry after cancellation', async () => {
+    const { pool, execute } = makePool();
+    execute
+      .mockResolvedValueOnce([[buildRow()], null])
+      .mockResolvedValueOnce([{ affectedRows: 1 }, null])
+      .mockResolvedValueOnce([[buildRow({ status: 'cancelled' })], null])
+      .mockResolvedValueOnce([{ insertId: 1, affectedRows: 1 }, null]);
+
+    const svc = new ChangeRequestService(pool);
+    await svc.cancel(1, 10);
+
+    const [auditSql] = execute.mock.calls[3];
+    expect(auditSql).toContain('INSERT INTO audit_logs');
+  });
+});

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -52,6 +52,7 @@ import { createRbacRouter } from './routes/rbac';
 import { createDelegationsRouter } from './routes/delegations';
 import { createApprovalWorkflowsRouter } from './routes/approvalWorkflows';
 import { createModulesRouter } from './routes/modules';
+import { createChangeRequestsRouter } from './routes/changeRequests';
 import { createResponsibilityRulesRouter } from './routes/responsibilityRules';
 
 interface BuildAppOptions {
@@ -186,6 +187,7 @@ export function buildApp(pool: Pool, options: BuildAppOptions = {}): express.Exp
     app.use(`${prefix}/approval-workflows`, createApprovalWorkflowsRouter(pool));
     app.use(`${prefix}/modules`, createModulesRouter(pool));
     app.use(`${prefix}/responsibility-rules`, createResponsibilityRulesRouter(pool));
+    app.use(`${prefix}/change-requests`, createChangeRequestsRouter(pool));
   };
   mountRoutes('/api/v1');
   mountRoutes('/api');

--- a/backend/src/routes/changeRequests.ts
+++ b/backend/src/routes/changeRequests.ts
@@ -1,0 +1,192 @@
+/**
+ * Change requests routes.
+ *
+ * Provides the subordinate change-proposal mechanism: any authenticated user
+ * may propose a change; users with `change_request.review` may approve,
+ * reject or apply it.  When applied, the audit log attributes the action to
+ * the authority holder (approver) and records the proposer via
+ * on_behalf_of_user_id.
+ *
+ * GET    /api/change-requests            list    (change_request.review)
+ * POST   /api/change-requests            create  (change_request.create)
+ * GET    /api/change-requests/:id        get one (change_request.review or own)
+ * POST   /api/change-requests/:id/approve approve (change_request.review)
+ * POST   /api/change-requests/:id/reject  reject  (change_request.review)
+ * POST   /api/change-requests/:id/apply   apply   (change_request.review)
+ * POST   /api/change-requests/:id/cancel  cancel  (own, pending only)
+ *
+ * @author Luca Ostinelli
+ */
+
+import { Router, Request, Response } from 'express';
+import { Pool } from 'mysql2/promise';
+import { z } from 'zod';
+import { authenticate, requirePermission, userHasPermission } from '../middleware/auth';
+import { validateBody, validateParams } from '../middleware/validation';
+import { idParam } from '../schemas';
+import { ChangeRequestService } from '../services/ChangeRequestService';
+import { User } from '../types';
+import { logger } from '../config/logger';
+
+const createBody = z.object({
+  changeType: z.string().min(1).max(80),
+  targetEntityType: z.string().min(1).max(60),
+  targetEntityId: z.number().int().positive().nullable().optional(),
+  proposedPayload: z.record(z.string(), z.unknown()),
+  justification: z.string().max(2000).nullable().optional(),
+});
+
+const approveBody = z.object({
+  justification: z.string().max(2000).nullable().optional(),
+});
+
+const rejectBody = z.object({
+  rejectionReason: z.string().min(1).max(2000),
+});
+
+const applyBody = z.object({
+  justification: z.string().max(2000).nullable().optional(),
+});
+
+export const createChangeRequestsRouter = (pool: Pool): Router => {
+  const router = Router();
+  const svc = new ChangeRequestService(pool);
+
+  router.use(authenticate);
+
+  // List (reviewers only)
+  router.get('/', requirePermission('change_request.review'), async (req: Request, res: Response) => {
+    try {
+      const { proposerUserId, approverUserId, status, changeType, targetEntityType, limit, offset } = req.query;
+      const page = await svc.list({
+        proposerUserId: proposerUserId ? Number(proposerUserId) : undefined,
+        approverUserId: approverUserId ? Number(approverUserId) : undefined,
+        status: status as string | undefined as never,
+        changeType: changeType as string | undefined,
+        targetEntityType: targetEntityType as string | undefined,
+        limit: limit ? Number(limit) : undefined,
+        offset: offset ? Number(offset) : undefined,
+      });
+      res.json({ success: true, data: page });
+    } catch (error) {
+      logger.error('List change requests error:', error);
+      res.status(500).json({ success: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to list change requests' } });
+    }
+  });
+
+  // Create (any authenticated user with permission)
+  router.post('/', requirePermission('change_request.create'), validateBody(createBody), async (req: Request, res: Response) => {
+    try {
+      const actor = req.user as User;
+      const cr = await svc.create(res.locals.body, actor.id);
+      res.status(201).json({ success: true, data: cr, message: 'Change request submitted' });
+    } catch (error) {
+      logger.error('Create change request error:', error);
+      res.status(500).json({ success: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to create change request' } });
+    }
+  });
+
+  // Get by ID (reviewers OR the proposer themselves)
+  router.get('/:id', validateParams(idParam), async (req: Request, res: Response) => {
+    try {
+      const actor = req.user as User;
+      const cr = await svc.getById(res.locals.params.id);
+      if (!cr) {
+        return res.status(404).json({ success: false, error: { code: 'NOT_FOUND', message: 'Change request not found' } });
+      }
+      // Allow access to the proposer or anyone with review permission
+      if (cr.proposerUserId !== actor.id && !userHasPermission(actor, 'change_request.review')) {
+        return res.status(403).json({ success: false, error: { code: 'FORBIDDEN', message: 'Access denied' } });
+      }
+      res.json({ success: true, data: cr });
+    } catch (error) {
+      logger.error('Get change request error:', error);
+      res.status(500).json({ success: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to get change request' } });
+    }
+  });
+
+  // Approve
+  router.post('/:id/approve', requirePermission('change_request.review'), validateParams(idParam), validateBody(approveBody), async (req: Request, res: Response) => {
+    try {
+      const actor = req.user as User;
+      const cr = await svc.approve(res.locals.params.id, actor.id, res.locals.body.justification);
+      res.json({ success: true, data: cr, message: 'Change request approved' });
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : '';
+      if (msg.toLowerCase().includes('not found')) {
+        return res.status(404).json({ success: false, error: { code: 'NOT_FOUND', message: msg } });
+      }
+      if (msg.includes('Cannot approve')) {
+        return res.status(409).json({ success: false, error: { code: 'INVALID_STATUS', message: msg } });
+      }
+      logger.error('Approve change request error:', error);
+      res.status(500).json({ success: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to approve change request' } });
+    }
+  });
+
+  // Reject
+  router.post('/:id/reject', requirePermission('change_request.review'), validateParams(idParam), validateBody(rejectBody), async (req: Request, res: Response) => {
+    try {
+      const actor = req.user as User;
+      const cr = await svc.reject(res.locals.params.id, actor.id, res.locals.body.rejectionReason);
+      res.json({ success: true, data: cr, message: 'Change request rejected' });
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : '';
+      if (msg.toLowerCase().includes('not found')) {
+        return res.status(404).json({ success: false, error: { code: 'NOT_FOUND', message: msg } });
+      }
+      if (msg.includes('Cannot reject')) {
+        return res.status(409).json({ success: false, error: { code: 'INVALID_STATUS', message: msg } });
+      }
+      logger.error('Reject change request error:', error);
+      res.status(500).json({ success: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to reject change request' } });
+    }
+  });
+
+  // Apply (marks applied; caller is responsible for executing the actual business logic)
+  router.post('/:id/apply', requirePermission('change_request.review'), validateParams(idParam), validateBody(applyBody), async (req: Request, res: Response) => {
+    try {
+      const actor = req.user as User;
+      const cr = await svc.apply(res.locals.params.id, actor.id, res.locals.body.justification);
+      res.json({ success: true, data: cr, message: 'Change request applied' });
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : '';
+      if (msg.toLowerCase().includes('not found')) {
+        return res.status(404).json({ success: false, error: { code: 'NOT_FOUND', message: msg } });
+      }
+      if (msg.includes('Cannot apply')) {
+        return res.status(409).json({ success: false, error: { code: 'INVALID_STATUS', message: msg } });
+      }
+      logger.error('Apply change request error:', error);
+      res.status(500).json({ success: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to apply change request' } });
+    }
+  });
+
+  // Cancel (proposer only, while pending)
+  router.post('/:id/cancel', validateParams(idParam), async (req: Request, res: Response) => {
+    try {
+      const actor = req.user as User;
+      const cr = await svc.getById(res.locals.params.id);
+      if (!cr) {
+        return res.status(404).json({ success: false, error: { code: 'NOT_FOUND', message: 'Change request not found' } });
+      }
+      if (cr.proposerUserId !== actor.id && !userHasPermission(actor, 'change_request.review')) {
+        return res.status(403).json({ success: false, error: { code: 'FORBIDDEN', message: 'Only the proposer or a reviewer may cancel this request' } });
+      }
+      const updated = await svc.cancel(cr.id, actor.id);
+      res.json({ success: true, data: updated, message: 'Change request cancelled' });
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : '';
+      if (msg.toLowerCase().includes('not found')) {
+        return res.status(404).json({ success: false, error: { code: 'NOT_FOUND', message: msg } });
+      }
+      if (msg.includes('Cannot cancel')) {
+        return res.status(409).json({ success: false, error: { code: 'INVALID_STATUS', message: msg } });
+      }
+      logger.error('Cancel change request error:', error);
+      res.status(500).json({ success: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to cancel change request' } });
+    }
+  });
+
+  return router;
+};

--- a/backend/src/services/ChangeRequestService.ts
+++ b/backend/src/services/ChangeRequestService.ts
@@ -1,0 +1,286 @@
+/**
+ * Change Request Service
+ *
+ * Enables subordinates to propose changes that, once approved and applied,
+ * are attributed to the authority holder (approver) in the audit log.
+ * The proposer's identity is recorded in on_behalf_of_user_id so the full
+ * chain of custody is always auditable.
+ *
+ * Lifecycle:  pending → approved → applied
+ *                      → rejected
+ *             pending → cancelled
+ *
+ * @author Luca Ostinelli
+ */
+
+import { Pool, RowDataPacket, ResultSetHeader } from 'mysql2/promise';
+import {
+  ChangeRequest,
+  ChangeRequestStatus,
+  CreateChangeRequestInput,
+  ChangeRequestFilters,
+} from '../types';
+import { logger } from '../config/logger';
+import { AuditLogService } from './AuditLogService';
+
+const mapRow = (row: RowDataPacket): ChangeRequest => ({
+  id: row.id as number,
+  changeType: row.change_type as string,
+  proposerUserId: row.proposer_user_id as number,
+  targetEntityType: row.target_entity_type as string,
+  targetEntityId: (row.target_entity_id as number | null) ?? null,
+  proposedPayload: (() => {
+    try { return typeof row.proposed_payload === 'string' ? JSON.parse(row.proposed_payload) : row.proposed_payload; } catch { return {}; }
+  })(),
+  justification: (row.justification as string | null) ?? null,
+  status: row.status as ChangeRequestStatus,
+  approverUserId: (row.approver_user_id as number | null) ?? null,
+  approvedAt: (row.approved_at as string | null) ?? null,
+  rejectedAt: (row.rejected_at as string | null) ?? null,
+  rejectionReason: (row.rejection_reason as string | null) ?? null,
+  appliedAt: (row.applied_at as string | null) ?? null,
+  onBehalfOfUserId: (row.on_behalf_of_user_id as number | null) ?? null,
+  createdAt: row.created_at as string,
+  updatedAt: row.updated_at as string,
+});
+
+export class ChangeRequestService {
+  private audit: AuditLogService;
+
+  constructor(private pool: Pool) {
+    this.audit = new AuditLogService(pool);
+  }
+
+  // --------------------------------------------------------------------------
+  // Read
+  // --------------------------------------------------------------------------
+
+  async list(filters: ChangeRequestFilters = {}): Promise<{ total: number; items: ChangeRequest[] }> {
+    const conditions: string[] = [];
+    const params: Array<string | number> = [];
+
+    if (filters.proposerUserId !== undefined) {
+      conditions.push('proposer_user_id = ?');
+      params.push(filters.proposerUserId);
+    }
+    if (filters.approverUserId !== undefined) {
+      conditions.push('approver_user_id = ?');
+      params.push(filters.approverUserId);
+    }
+    if (filters.status) {
+      conditions.push('status = ?');
+      params.push(filters.status);
+    }
+    if (filters.changeType) {
+      conditions.push('change_type = ?');
+      params.push(filters.changeType);
+    }
+    if (filters.targetEntityType) {
+      conditions.push('target_entity_type = ?');
+      params.push(filters.targetEntityType);
+    }
+
+    const where = conditions.length ? ` WHERE ${conditions.join(' AND ')}` : '';
+
+    const [countRows] = await this.pool.execute<RowDataPacket[]>(
+      `SELECT COUNT(*) AS c FROM change_requests${where}`,
+      params
+    );
+    const total = (countRows[0] as { c: number }).c;
+
+    const limit = Math.max(1, Math.min(500, filters.limit ?? 100));
+    const offset = Math.max(0, filters.offset ?? 0);
+
+    const [rows] = await this.pool.execute<RowDataPacket[]>(
+      `SELECT * FROM change_requests${where} ORDER BY created_at DESC LIMIT ? OFFSET ?`,
+      [...params, limit, offset]
+    );
+
+    return { total, items: rows.map(mapRow) };
+  }
+
+  async getById(id: number): Promise<ChangeRequest | null> {
+    const [rows] = await this.pool.execute<RowDataPacket[]>(
+      'SELECT * FROM change_requests WHERE id = ? LIMIT 1',
+      [id]
+    );
+    return rows.length === 0 ? null : mapRow(rows[0]);
+  }
+
+  // --------------------------------------------------------------------------
+  // Lifecycle mutations
+  // --------------------------------------------------------------------------
+
+  async create(input: CreateChangeRequestInput, proposerUserId: number): Promise<ChangeRequest> {
+    const [res] = await this.pool.execute<ResultSetHeader>(
+      `INSERT INTO change_requests
+         (change_type, proposer_user_id, target_entity_type, target_entity_id,
+          proposed_payload, justification, status)
+       VALUES (?, ?, ?, ?, ?, ?, 'pending')`,
+      [
+        input.changeType,
+        proposerUserId,
+        input.targetEntityType,
+        input.targetEntityId ?? null,
+        JSON.stringify(input.proposedPayload),
+        input.justification ?? null,
+      ]
+    );
+
+    const created = await this.getById(res.insertId);
+    if (!created) throw new Error('Failed to retrieve created change request');
+
+    await this.audit.write({
+      actorId: proposerUserId,
+      action: 'change_request.create',
+      entityType: 'change_request',
+      entityId: created.id,
+      description: `Change request proposed: ${created.changeType} on ${created.targetEntityType}`,
+      justification: input.justification ?? undefined,
+      after: created as unknown as Record<string, unknown>,
+    });
+
+    logger.info(`Change request created: id=${created.id} type=${created.changeType} proposer=${proposerUserId}`);
+    return created;
+  }
+
+  async approve(id: number, approverUserId: number, justification?: string | null): Promise<ChangeRequest> {
+    const existing = await this.getById(id);
+    if (!existing) throw new Error('Change request not found');
+    if (existing.status !== 'pending') {
+      throw new Error(`Cannot approve a change request in '${existing.status}' status`);
+    }
+
+    await this.pool.execute(
+      `UPDATE change_requests
+          SET status = 'approved', approver_user_id = ?, approved_at = CURRENT_TIMESTAMP,
+              updated_at = CURRENT_TIMESTAMP
+        WHERE id = ?`,
+      [approverUserId, id]
+    );
+
+    const updated = await this.getById(id);
+    if (!updated) throw new Error('Failed to retrieve updated change request');
+
+    await this.audit.write({
+      actorId: approverUserId,
+      action: 'change_request.approve',
+      entityType: 'change_request',
+      entityId: id,
+      description: `Change request approved: ${existing.changeType} on ${existing.targetEntityType}`,
+      justification: justification ?? undefined,
+      before: existing as unknown as Record<string, unknown>,
+      after: updated as unknown as Record<string, unknown>,
+    });
+
+    return updated;
+  }
+
+  async reject(id: number, approverUserId: number, rejectionReason: string): Promise<ChangeRequest> {
+    const existing = await this.getById(id);
+    if (!existing) throw new Error('Change request not found');
+    if (existing.status !== 'pending') {
+      throw new Error(`Cannot reject a change request in '${existing.status}' status`);
+    }
+
+    await this.pool.execute(
+      `UPDATE change_requests
+          SET status = 'rejected', approver_user_id = ?, rejected_at = CURRENT_TIMESTAMP,
+              rejection_reason = ?, updated_at = CURRENT_TIMESTAMP
+        WHERE id = ?`,
+      [approverUserId, rejectionReason, id]
+    );
+
+    const updated = await this.getById(id);
+    if (!updated) throw new Error('Failed to retrieve updated change request');
+
+    await this.audit.write({
+      actorId: approverUserId,
+      action: 'change_request.reject',
+      entityType: 'change_request',
+      entityId: id,
+      description: `Change request rejected: ${existing.changeType} — ${rejectionReason}`,
+      before: existing as unknown as Record<string, unknown>,
+      after: updated as unknown as Record<string, unknown>,
+    });
+
+    return updated;
+  }
+
+  /**
+   * Marks the request as applied and writes a proxy audit log entry.
+   *
+   * The audit log records:
+   *   user_id           = approverUserId (the authority holder who takes responsibility)
+   *   on_behalf_of_user_id = proposer (who originally requested the change)
+   *
+   * This means externally the action appears as if directly decided by the
+   * approver; the proposer's identity is preserved for full traceability.
+   */
+  async apply(id: number, actorUserId: number, justification?: string | null): Promise<ChangeRequest> {
+    const existing = await this.getById(id);
+    if (!existing) throw new Error('Change request not found');
+    if (existing.status !== 'approved') {
+      throw new Error(`Cannot apply a change request in '${existing.status}' status — must be approved first`);
+    }
+
+    const authorityHolder = existing.approverUserId ?? actorUserId;
+
+    await this.pool.execute(
+      `UPDATE change_requests
+          SET status = 'applied', applied_at = CURRENT_TIMESTAMP,
+              on_behalf_of_user_id = ?, updated_at = CURRENT_TIMESTAMP
+        WHERE id = ?`,
+      [existing.proposerUserId, id]
+    );
+
+    const updated = await this.getById(id);
+    if (!updated) throw new Error('Failed to retrieve updated change request');
+
+    // Attribution: the authority holder (approver) is the actor; the proposer appears as on_behalf_of.
+    await this.audit.write({
+      actorId: authorityHolder,
+      onBehalfOfUserId: existing.proposerUserId,
+      action: 'change_request.apply',
+      entityType: existing.targetEntityType,
+      entityId: existing.targetEntityId ?? undefined,
+      description: `Change applied via request #${id}: ${existing.changeType}`,
+      justification: justification ?? undefined,
+      before: existing as unknown as Record<string, unknown>,
+      after: updated as unknown as Record<string, unknown>,
+    });
+
+    logger.info(`Change request applied: id=${id} authority=${authorityHolder} proposer=${existing.proposerUserId}`);
+    return updated;
+  }
+
+  async cancel(id: number, requestorUserId: number): Promise<ChangeRequest> {
+    const existing = await this.getById(id);
+    if (!existing) throw new Error('Change request not found');
+    if (existing.status !== 'pending') {
+      throw new Error(`Cannot cancel a change request in '${existing.status}' status`);
+    }
+
+    await this.pool.execute(
+      `UPDATE change_requests
+          SET status = 'cancelled', updated_at = CURRENT_TIMESTAMP
+        WHERE id = ?`,
+      [id]
+    );
+
+    const updated = await this.getById(id);
+    if (!updated) throw new Error('Failed to retrieve updated change request');
+
+    await this.audit.write({
+      actorId: requestorUserId,
+      action: 'change_request.cancel',
+      entityType: 'change_request',
+      entityId: id,
+      description: `Change request cancelled: ${existing.changeType} on ${existing.targetEntityType}`,
+      before: existing as unknown as Record<string, unknown>,
+      after: updated as unknown as Record<string, unknown>,
+    });
+
+    return updated;
+  }
+}

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -440,6 +440,50 @@ export interface UpdateResponsibilityRuleRequest {
   isActive?: boolean;
 }
 
+// ============================================================================
+// CHANGE REQUEST TYPES
+// ============================================================================
+
+export type ChangeRequestStatus = 'pending' | 'approved' | 'rejected' | 'applied' | 'cancelled';
+
+export interface ChangeRequest {
+  id: number;
+  changeType: string;
+  proposerUserId: number;
+  targetEntityType: string;
+  targetEntityId: number | null;
+  proposedPayload: Record<string, unknown>;
+  justification: string | null;
+  status: ChangeRequestStatus;
+  approverUserId: number | null;
+  approvedAt: string | null;
+  rejectedAt: string | null;
+  rejectionReason: string | null;
+  appliedAt: string | null;
+  /** When applied, the action is attributed to this user (the authority holder). */
+  onBehalfOfUserId: number | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateChangeRequestInput {
+  changeType: string;
+  targetEntityType: string;
+  targetEntityId?: number | null;
+  proposedPayload: Record<string, unknown>;
+  justification?: string | null;
+}
+
+export interface ChangeRequestFilters {
+  proposerUserId?: number;
+  approverUserId?: number;
+  status?: ChangeRequestStatus;
+  changeType?: string;
+  targetEntityType?: string;
+  limit?: number;
+  offset?: number;
+}
+
 // System Settings Types
 export interface SystemSetting {
   id: number;


### PR DESCRIPTION
## Summary

- Adds `change_requests` table with full lifecycle: `pending → approved → applied` (or `rejected` / `cancelled`)
- Subordinates propose changes with an optional justification; authority holders (reviewers) approve, reject or apply them
- On `apply`, the audit log entry is attributed to the **approver** (authority holder) as `user_id`, while the **proposer** is preserved as `on_behalf_of_user_id` — making the change appear as if directly decided by the authority holder while maintaining full chain-of-custody traceability
- `change_request.create` and `change_request.review` permissions added and granted to Manager role
- `GET /:id` allows either the proposer or a reviewer to view; `POST /:id/cancel` enforces proposer-or-reviewer ownership
- 24 unit tests covering all lifecycle transitions, status-guard errors, JSON payload handling, and correct audit attribution

## Test plan

- [ ] `npx jest src/__tests__/changeRequest.service.test.ts` → 24 tests pass
- [ ] `npx jest --no-coverage` → all 1739 tests pass
- [ ] `npm run lint` → no errors
- [ ] CI green