### PR TITLE
feat(frontend): add Governance page for responsibility matrix and change requests

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -50,6 +50,7 @@ const Reports = lazy(() => import('./pages/Reports/Reports'));
 const Settings = lazy(() => import('./pages/Settings/Settings'));
 const OrgManagement = lazy(() => import('./pages/Org/OrgManagement'));
 const Policies = lazy(() => import('./pages/Policies/Policies'));
+const Governance = lazy(() => import('./pages/Governance/Governance'));
 
 /**
  * Main Application Component
@@ -120,6 +121,11 @@ const App: React.FC = () => {
           <Route path="policies" element={
             <PermissionRoute permission="policy.read">
               <Policies />
+            </PermissionRoute>
+          } />
+          <Route path="governance" element={
+            <PermissionRoute permission="responsibility.read">
+              <Governance />
             </PermissionRoute>
           } />
           <Route path="settings" element={

--- a/frontend/src/components/Layout/Sidebar.tsx
+++ b/frontend/src/components/Layout/Sidebar.tsx
@@ -90,6 +90,12 @@ const Sidebar: React.FC<SidebarProps> = ({ collapsed }) => {
       requiredPermission: 'policy.read',
     },
     {
+      path: '/governance',
+      icon: 'bi-diagram-3-fill',
+      label: 'Governance',
+      requiredPermission: 'responsibility.read',
+    },
+    {
       path: '/settings',
       icon: 'bi-gear',
       label: 'Settings',

--- a/frontend/src/pages/Governance/Governance.test.tsx
+++ b/frontend/src/pages/Governance/Governance.test.tsx
@@ -1,0 +1,198 @@
+/**
+ * Governance page smoke tests.
+ *
+ * Covers: responsibility matrix tab renders rules, add-rule form toggle,
+ * change requests tab renders items, status badge, reviewer action buttons.
+ *
+ * @author Luca Ostinelli
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// ── Service mocks ────────────────────────────────────────────────────────────
+
+const mockListRules = jest.fn();
+const mockCreateRule = jest.fn();
+const mockUpdateRule = jest.fn();
+const mockDeleteRule = jest.fn();
+const mockListCr = jest.fn();
+const mockCreateCr = jest.fn();
+const mockApproveCr = jest.fn();
+const mockRejectCr = jest.fn();
+const mockApplyCr = jest.fn();
+const mockCancelCr = jest.fn();
+
+jest.mock('../../services/responsibilityService', () => ({
+  __esModule: true,
+  listResponsibilityRules: (...a: unknown[]) => mockListRules(...a),
+  createResponsibilityRule: (...a: unknown[]) => mockCreateRule(...a),
+  updateResponsibilityRule: (...a: unknown[]) => mockUpdateRule(...a),
+  deleteResponsibilityRule: (...a: unknown[]) => mockDeleteRule(...a),
+}));
+
+jest.mock('../../services/changeRequestService', () => ({
+  __esModule: true,
+  listChangeRequests: (...a: unknown[]) => mockListCr(...a),
+  createChangeRequest: (...a: unknown[]) => mockCreateCr(...a),
+  approveChangeRequest: (...a: unknown[]) => mockApproveCr(...a),
+  rejectChangeRequest: (...a: unknown[]) => mockRejectCr(...a),
+  applyChangeRequest: (...a: unknown[]) => mockApplyCr(...a),
+  cancelChangeRequest: (...a: unknown[]) => mockCancelCr(...a),
+}));
+
+jest.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({
+    user: {
+      id: 1,
+      email: 'manager@x',
+      permissions: [
+        'responsibility.read',
+        'responsibility.manage',
+        'change_request.review',
+        'change_request.create',
+      ],
+    },
+  }),
+}));
+
+jest.mock('../../components/LoadingSpinner', () => ({
+  __esModule: true,
+  default: () => <div data-testid="spinner" />,
+}));
+
+const Governance = require('./Governance').default;
+
+const ok = <T,>(data: T) => Promise.resolve({ success: true as const, data });
+
+const sampleRule = {
+  id: 1,
+  subjectType: 'department',
+  subjectId: 10,
+  permissionCode: 'schedule.manage',
+  responsibleOrgUnitId: 3,
+  delegatedToRoleId: null,
+  description: 'HR manages scheduling',
+  isActive: true,
+  createdBy: 1,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+};
+
+const sampleCr = {
+  id: 42,
+  changeType: 'Schedule.Override',
+  proposerUserId: 2,
+  targetEntityType: 'schedule',
+  targetEntityId: 5,
+  proposedPayload: { date: '2026-07-01' },
+  justification: 'Covering sick leave',
+  status: 'pending',
+  approverUserId: null,
+  approvedAt: null,
+  rejectedAt: null,
+  rejectionReason: null,
+  appliedAt: null,
+  onBehalfOfUserId: null,
+  createdAt: '2026-06-01T00:00:00.000Z',
+  updatedAt: '2026-06-01T00:00:00.000Z',
+};
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('<Governance /> — Responsibility Matrix tab', () => {
+  beforeEach(() => {
+    mockListRules.mockResolvedValue(ok([sampleRule]));
+    mockListCr.mockResolvedValue(ok({ total: 0, items: [] }));
+  });
+
+  it('renders the matrix tab by default and shows rules', async () => {
+    render(<Governance />);
+    expect(await screen.findByText('schedule.manage')).toBeInTheDocument();
+    expect(screen.getByText('HR manages scheduling')).toBeInTheDocument();
+  });
+
+  it('shows subject type badge', async () => {
+    render(<Governance />);
+    expect(await screen.findByText('Department')).toBeInTheDocument();
+  });
+
+  it('toggles the add-rule form when "Add Rule" is clicked', async () => {
+    render(<Governance />);
+    await screen.findByText('schedule.manage'); // wait for load
+
+    const addBtn = screen.getByText(/Add Rule/);
+    await userEvent.click(addBtn);
+    expect(screen.getByText('New Responsibility Rule')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByText(/Cancel/));
+    expect(screen.queryByText('New Responsibility Rule')).not.toBeInTheDocument();
+  });
+
+  it('shows "No rules defined" when list is empty', async () => {
+    mockListRules.mockResolvedValue(ok([]));
+    render(<Governance />);
+    expect(await screen.findByText('No rules defined')).toBeInTheDocument();
+  });
+});
+
+describe('<Governance /> — Change Requests tab', () => {
+  beforeEach(() => {
+    mockListRules.mockResolvedValue(ok([sampleRule]));
+    mockListCr.mockResolvedValue(ok({ total: 1, items: [sampleCr] }));
+  });
+
+  it('switches to the change requests tab', async () => {
+    render(<Governance />);
+    await screen.findByText('schedule.manage'); // wait for matrix to load
+
+    await userEvent.click(screen.getByText(/Change Requests/));
+    expect(await screen.findByText('Schedule.Override')).toBeInTheDocument();
+  });
+
+  it('shows pending status badge', async () => {
+    render(<Governance />);
+    await userEvent.click(screen.getByText(/Change Requests/));
+    expect(await screen.findByText('pending')).toBeInTheDocument();
+  });
+
+  it('shows reviewer action buttons for pending requests', async () => {
+    render(<Governance />);
+    await userEvent.click(screen.getByText(/Change Requests/));
+    await screen.findByText('Schedule.Override');
+    // Approve button has title="Approve", reject has title="Reject"
+    expect(screen.getByTitle('Approve')).toBeInTheDocument();
+    expect(screen.getByTitle('Reject')).toBeInTheDocument();
+  });
+
+  it('shows "No change requests found" when list is empty', async () => {
+    mockListCr.mockResolvedValue(ok({ total: 0, items: [] }));
+    render(<Governance />);
+    await userEvent.click(screen.getByText(/Change Requests/));
+    expect(await screen.findByText('No change requests found')).toBeInTheDocument();
+  });
+
+  it('opens new request form', async () => {
+    render(<Governance />);
+    await userEvent.click(screen.getByText(/Change Requests/));
+    await screen.findByText('Schedule.Override');
+    await userEvent.click(screen.getByText(/New Request/));
+    expect(screen.getByText('Propose a Change')).toBeInTheDocument();
+  });
+});
+
+describe('<Governance /> — Active rules count in matrix', () => {
+  it('renders the correct number of rules', async () => {
+    const twoRules = [
+      sampleRule,
+      { ...sampleRule, id: 2, subjectId: 20, permissionCode: 'leave.manage' },
+    ];
+    mockListRules.mockResolvedValue(ok(twoRules));
+    mockListCr.mockResolvedValue(ok({ total: 0, items: [] }));
+
+    render(<Governance />);
+    await waitFor(() => {
+      expect(screen.getAllByText('Department').length).toBeGreaterThanOrEqual(2);
+    });
+  });
+});

--- a/frontend/src/pages/Governance/Governance.tsx
+++ b/frontend/src/pages/Governance/Governance.tsx
@@ -1,0 +1,672 @@
+/**
+ * Governance page.
+ *
+ * Two tabs:
+ *   - Responsibility Matrix: configure who is responsible for what over
+ *     which subject group.  Visible to users with `responsibility.read`;
+ *     editable by users with `responsibility.manage`.
+ *   - Change Requests: list, review and act on subordinate change proposals.
+ *     Visible to reviewers (`change_request.review`) and to all authenticated
+ *     users who have submitted a request (they can see their own via the
+ *     dedicated "My requests" filter).
+ *
+ * @author Luca Ostinelli
+ */
+
+import React, { useEffect, useState, useCallback } from 'react';
+import { useAuth } from '../../contexts/AuthContext';
+import * as responsibilitySvc from '../../services/responsibilityService';
+import * as changeRequestSvc from '../../services/changeRequestService';
+import type {
+  ResponsibilityRule,
+  CreateResponsibilityRuleInput,
+  ResponsibilitySubjectType,
+} from '../../services/responsibilityService';
+import type {
+  ChangeRequest,
+  ChangeRequestStatus,
+  CreateChangeRequestInput,
+} from '../../services/changeRequestService';
+import LoadingSpinner from '../../components/LoadingSpinner';
+
+type Tab = 'matrix' | 'changeRequests';
+
+const SUBJECT_TYPE_LABELS: Record<ResponsibilitySubjectType, string> = {
+  org_unit: 'Org Unit',
+  department: 'Department',
+  role: 'Role',
+  all: 'All Users',
+};
+
+const STATUS_BADGE: Record<ChangeRequestStatus, string> = {
+  pending: 'warning',
+  approved: 'success',
+  rejected: 'danger',
+  applied: 'primary',
+  cancelled: 'secondary',
+};
+
+const Governance: React.FC = () => {
+  const { user } = useAuth();
+  const canManageMatrix = user?.permissions?.includes('responsibility.manage') ?? false;
+  const canReadMatrix = user?.permissions?.includes('responsibility.read') ?? false;
+  const canReview = user?.permissions?.includes('change_request.review') ?? false;
+  const canCreate = user?.permissions?.includes('change_request.create') ?? false;
+
+  const defaultTab: Tab = canReadMatrix ? 'matrix' : 'changeRequests';
+  const [activeTab, setActiveTab] = useState<Tab>(defaultTab);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  // ── Responsibility Matrix state ──────────────────────────────────────────
+
+  const [rules, setRules] = useState<ResponsibilityRule[]>([]);
+  const [matrixLoading, setMatrixLoading] = useState(false);
+  const [showRuleForm, setShowRuleForm] = useState(false);
+  const [ruleForm, setRuleForm] = useState<CreateResponsibilityRuleInput>({
+    subjectType: 'department',
+    permissionCode: '',
+    responsibleOrgUnitId: 0,
+  });
+
+  const loadRules = useCallback(async () => {
+    if (!canReadMatrix) return;
+    setMatrixLoading(true);
+    try {
+      const res = await responsibilitySvc.listResponsibilityRules({ isActive: true });
+      if (res.success) setRules(res.data as ResponsibilityRule[]);
+    } catch {
+      setError('Failed to load responsibility rules');
+    } finally {
+      setMatrixLoading(false);
+    }
+  }, [canReadMatrix]);
+
+  useEffect(() => {
+    if (activeTab === 'matrix') loadRules();
+  }, [activeTab, loadRules]);
+
+  const handleCreateRule = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!ruleForm.permissionCode || !ruleForm.responsibleOrgUnitId) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await responsibilitySvc.createResponsibilityRule(ruleForm);
+      if (res.success) {
+        setShowRuleForm(false);
+        setRuleForm({ subjectType: 'department', permissionCode: '', responsibleOrgUnitId: 0 });
+        await loadRules();
+      } else {
+        setError((res as { error?: { message?: string } }).error?.message ?? 'Failed to create rule');
+      }
+    } catch {
+      setError('Failed to create responsibility rule');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleToggleRule = async (rule: ResponsibilityRule) => {
+    setBusy(true);
+    try {
+      await responsibilitySvc.updateResponsibilityRule(rule.id, { isActive: !rule.isActive });
+      await loadRules();
+    } catch {
+      setError('Failed to update rule');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleDeleteRule = async (id: number) => {
+    if (!window.confirm('Delete this responsibility rule?')) return;
+    setBusy(true);
+    try {
+      await responsibilitySvc.deleteResponsibilityRule(id);
+      await loadRules();
+    } catch {
+      setError('Failed to delete rule');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  // ── Change Requests state ────────────────────────────────────────────────
+
+  const [changeRequests, setChangeRequests] = useState<ChangeRequest[]>([]);
+  const [crTotal, setCrTotal] = useState(0);
+  const [crLoading, setCrLoading] = useState(false);
+  const [crFilter, setCrFilter] = useState<ChangeRequestStatus | ''>('');
+  const [myOnly, setMyOnly] = useState(!canReview);
+  const [showCrForm, setShowCrForm] = useState(false);
+  const [crForm, setCrForm] = useState<CreateChangeRequestInput>({
+    changeType: '',
+    targetEntityType: '',
+    proposedPayload: {},
+    justification: '',
+  });
+  const [crPayloadText, setCrPayloadText] = useState('{}');
+  const [rejectReason, setRejectReason] = useState('');
+  const [actionTargetId, setActionTargetId] = useState<number | null>(null);
+  const [crAction, setCrAction] = useState<'approve' | 'reject' | 'apply' | null>(null);
+
+  const loadChangeRequests = useCallback(async () => {
+    setCrLoading(true);
+    try {
+      const filters: Parameters<typeof changeRequestSvc.listChangeRequests>[0] = {};
+      if (crFilter) filters.status = crFilter;
+      if (myOnly && user?.id) filters.proposerUserId = Number(user.id);
+      const res = await changeRequestSvc.listChangeRequests(filters);
+      if (res.success && res.data) {
+        const page = res.data as { total: number; items: ChangeRequest[] };
+        setChangeRequests(page.items);
+        setCrTotal(page.total);
+      }
+    } catch {
+      setError('Failed to load change requests');
+    } finally {
+      setCrLoading(false);
+    }
+  }, [crFilter, myOnly, user?.id]);
+
+  useEffect(() => {
+    if (activeTab === 'changeRequests') loadChangeRequests();
+  }, [activeTab, loadChangeRequests]);
+
+  const handleCreateCr = async (e: React.FormEvent) => {
+    e.preventDefault();
+    let payload: Record<string, unknown> = {};
+    try { payload = JSON.parse(crPayloadText); } catch { setError('Proposed payload must be valid JSON'); return; }
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await changeRequestSvc.createChangeRequest({ ...crForm, proposedPayload: payload });
+      if (res.success) {
+        setShowCrForm(false);
+        setCrForm({ changeType: '', targetEntityType: '', proposedPayload: {}, justification: '' });
+        setCrPayloadText('{}');
+        await loadChangeRequests();
+      } else {
+        setError((res as { error?: { message?: string } }).error?.message ?? 'Failed to submit');
+      }
+    } catch {
+      setError('Failed to submit change request');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleCrAction = async () => {
+    if (actionTargetId === null || crAction === null) return;
+    setBusy(true);
+    setError(null);
+    try {
+      if (crAction === 'approve') await changeRequestSvc.approveChangeRequest(actionTargetId);
+      else if (crAction === 'apply') await changeRequestSvc.applyChangeRequest(actionTargetId);
+      else if (crAction === 'reject') {
+        if (!rejectReason.trim()) { setError('Rejection reason is required'); setBusy(false); return; }
+        await changeRequestSvc.rejectChangeRequest(actionTargetId, rejectReason);
+      }
+      setActionTargetId(null);
+      setCrAction(null);
+      setRejectReason('');
+      await loadChangeRequests();
+    } catch {
+      setError(`Failed to ${crAction} change request`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleCancelCr = async (id: number) => {
+    if (!window.confirm('Cancel this change request?')) return;
+    setBusy(true);
+    try {
+      await changeRequestSvc.cancelChangeRequest(id);
+      await loadChangeRequests();
+    } catch {
+      setError('Failed to cancel change request');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  // ── Render ───────────────────────────────────────────────────────────────
+
+  return (
+    <div className="governance-page">
+      <div className="page-header">
+        <h1>Governance</h1>
+        <p className="text-muted">Responsibility matrix and change request management</p>
+      </div>
+
+      {error && (
+        <div className="alert alert-danger alert-dismissible">
+          {error}
+          <button className="btn-close" onClick={() => setError(null)} />
+        </div>
+      )}
+
+      <ul className="nav nav-tabs mb-4">
+        {canReadMatrix && (
+          <li className="nav-item">
+            <button
+              className={`nav-link ${activeTab === 'matrix' ? 'active' : ''}`}
+              onClick={() => setActiveTab('matrix')}
+            >
+              <i className="bi bi-table me-2" />
+              Responsibility Matrix
+            </button>
+          </li>
+        )}
+        {(canReview || canCreate) && (
+          <li className="nav-item">
+            <button
+              className={`nav-link ${activeTab === 'changeRequests' ? 'active' : ''}`}
+              onClick={() => setActiveTab('changeRequests')}
+            >
+              <i className="bi bi-pencil-square me-2" />
+              Change Requests
+              {crTotal > 0 && crFilter === 'pending' && (
+                <span className="badge bg-warning text-dark ms-2">{crTotal}</span>
+              )}
+            </button>
+          </li>
+        )}
+      </ul>
+
+      {/* ── RESPONSIBILITY MATRIX TAB ─────────────────────────────────── */}
+      {activeTab === 'matrix' && canReadMatrix && (
+        <div>
+          <div className="d-flex justify-content-between align-items-center mb-3">
+            <h5 className="mb-0">Active Rules</h5>
+            {canManageMatrix && (
+              <button className="btn btn-primary btn-sm" onClick={() => setShowRuleForm(!showRuleForm)}>
+                <i className="bi bi-plus-lg me-1" />
+                Add Rule
+              </button>
+            )}
+          </div>
+
+          {showRuleForm && canManageMatrix && (
+            <div className="card mb-4">
+              <div className="card-body">
+                <h6 className="card-title">New Responsibility Rule</h6>
+                <form onSubmit={handleCreateRule}>
+                  <div className="row g-3">
+                    <div className="col-md-3">
+                      <label className="form-label">Subject Type</label>
+                      <select
+                        className="form-select"
+                        value={ruleForm.subjectType}
+                        onChange={e => setRuleForm(f => ({ ...f, subjectType: e.target.value as ResponsibilitySubjectType, subjectId: undefined }))}
+                      >
+                        {Object.entries(SUBJECT_TYPE_LABELS).map(([v, l]) => (
+                          <option key={v} value={v}>{l}</option>
+                        ))}
+                      </select>
+                    </div>
+                    {ruleForm.subjectType !== 'all' && (
+                      <div className="col-md-2">
+                        <label className="form-label">Subject ID</label>
+                        <input
+                          type="number"
+                          className="form-control"
+                          placeholder="e.g. 5"
+                          value={ruleForm.subjectId ?? ''}
+                          onChange={e => setRuleForm(f => ({ ...f, subjectId: e.target.value ? Number(e.target.value) : undefined }))}
+                        />
+                      </div>
+                    )}
+                    <div className="col-md-3">
+                      <label className="form-label">Permission Code</label>
+                      <input
+                        type="text"
+                        className="form-control"
+                        placeholder="e.g. schedule.manage"
+                        value={ruleForm.permissionCode}
+                        onChange={e => setRuleForm(f => ({ ...f, permissionCode: e.target.value }))}
+                        required
+                      />
+                    </div>
+                    <div className="col-md-2">
+                      <label className="form-label">Responsible Org Unit ID</label>
+                      <input
+                        type="number"
+                        className="form-control"
+                        placeholder="e.g. 3"
+                        value={ruleForm.responsibleOrgUnitId || ''}
+                        onChange={e => setRuleForm(f => ({ ...f, responsibleOrgUnitId: Number(e.target.value) }))}
+                        required
+                      />
+                    </div>
+                    <div className="col-md-2">
+                      <label className="form-label">Description</label>
+                      <input
+                        type="text"
+                        className="form-control"
+                        placeholder="Optional"
+                        value={ruleForm.description ?? ''}
+                        onChange={e => setRuleForm(f => ({ ...f, description: e.target.value || null }))}
+                      />
+                    </div>
+                  </div>
+                  <div className="mt-3 d-flex gap-2">
+                    <button type="submit" className="btn btn-primary btn-sm" disabled={busy}>
+                      {busy ? 'Saving…' : 'Save Rule'}
+                    </button>
+                    <button type="button" className="btn btn-secondary btn-sm" onClick={() => setShowRuleForm(false)}>
+                      Cancel
+                    </button>
+                  </div>
+                </form>
+              </div>
+            </div>
+          )}
+
+          {matrixLoading ? (
+            <LoadingSpinner />
+          ) : (
+            <div className="table-responsive">
+              <table className="table table-hover">
+                <thead>
+                  <tr>
+                    <th>Subject Type</th>
+                    <th>Subject ID</th>
+                    <th>Permission</th>
+                    <th>Responsible Org Unit</th>
+                    <th>Description</th>
+                    <th>Status</th>
+                    {canManageMatrix && <th>Actions</th>}
+                  </tr>
+                </thead>
+                <tbody>
+                  {rules.length === 0 && (
+                    <tr><td colSpan={canManageMatrix ? 7 : 6} className="text-center text-muted py-4">No rules defined</td></tr>
+                  )}
+                  {rules.map(rule => (
+                    <tr key={rule.id}>
+                      <td><span className="badge bg-secondary">{SUBJECT_TYPE_LABELS[rule.subjectType]}</span></td>
+                      <td>{rule.subjectId ?? <em className="text-muted">—</em>}</td>
+                      <td><code>{rule.permissionCode}</code></td>
+                      <td>{rule.responsibleOrgUnitId}</td>
+                      <td>{rule.description ?? <em className="text-muted">—</em>}</td>
+                      <td>
+                        <span className={`badge ${rule.isActive ? 'bg-success' : 'bg-secondary'}`}>
+                          {rule.isActive ? 'Active' : 'Inactive'}
+                        </span>
+                      </td>
+                      {canManageMatrix && (
+                        <td>
+                          <button
+                            className="btn btn-sm btn-outline-secondary me-1"
+                            onClick={() => handleToggleRule(rule)}
+                            disabled={busy}
+                            title={rule.isActive ? 'Deactivate' : 'Activate'}
+                          >
+                            <i className={`bi ${rule.isActive ? 'bi-toggle-on' : 'bi-toggle-off'}`} />
+                          </button>
+                          <button
+                            className="btn btn-sm btn-outline-danger"
+                            onClick={() => handleDeleteRule(rule.id)}
+                            disabled={busy}
+                            title="Delete"
+                          >
+                            <i className="bi bi-trash" />
+                          </button>
+                        </td>
+                      )}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* ── CHANGE REQUESTS TAB ──────────────────────────────────────────── */}
+      {activeTab === 'changeRequests' && (
+        <div>
+          <div className="d-flex justify-content-between align-items-center mb-3 flex-wrap gap-2">
+            <div className="d-flex gap-2 align-items-center flex-wrap">
+              <select
+                className="form-select form-select-sm"
+                style={{ width: 'auto' }}
+                value={crFilter}
+                onChange={e => setCrFilter(e.target.value as ChangeRequestStatus | '')}
+              >
+                <option value="">All statuses</option>
+                <option value="pending">Pending</option>
+                <option value="approved">Approved</option>
+                <option value="applied">Applied</option>
+                <option value="rejected">Rejected</option>
+                <option value="cancelled">Cancelled</option>
+              </select>
+              {canReview && (
+                <div className="form-check mb-0">
+                  <input
+                    className="form-check-input"
+                    type="checkbox"
+                    id="myOnly"
+                    checked={myOnly}
+                    onChange={e => setMyOnly(e.target.checked)}
+                  />
+                  <label className="form-check-label" htmlFor="myOnly">My requests only</label>
+                </div>
+              )}
+            </div>
+            {canCreate && (
+              <button className="btn btn-primary btn-sm" onClick={() => setShowCrForm(!showCrForm)}>
+                <i className="bi bi-plus-lg me-1" />
+                New Request
+              </button>
+            )}
+          </div>
+
+          {showCrForm && canCreate && (
+            <div className="card mb-4">
+              <div className="card-body">
+                <h6 className="card-title">Propose a Change</h6>
+                <form onSubmit={handleCreateCr}>
+                  <div className="row g-3">
+                    <div className="col-md-3">
+                      <label className="form-label">Change Type</label>
+                      <input
+                        type="text"
+                        className="form-control"
+                        placeholder="e.g. Schedule.Override"
+                        value={crForm.changeType}
+                        onChange={e => setCrForm(f => ({ ...f, changeType: e.target.value }))}
+                        required
+                      />
+                    </div>
+                    <div className="col-md-3">
+                      <label className="form-label">Target Entity Type</label>
+                      <input
+                        type="text"
+                        className="form-control"
+                        placeholder="e.g. schedule"
+                        value={crForm.targetEntityType}
+                        onChange={e => setCrForm(f => ({ ...f, targetEntityType: e.target.value }))}
+                        required
+                      />
+                    </div>
+                    <div className="col-md-2">
+                      <label className="form-label">Target Entity ID</label>
+                      <input
+                        type="number"
+                        className="form-control"
+                        placeholder="Optional"
+                        value={crForm.targetEntityId ?? ''}
+                        onChange={e => setCrForm(f => ({ ...f, targetEntityId: e.target.value ? Number(e.target.value) : null }))}
+                      />
+                    </div>
+                    <div className="col-md-4">
+                      <label className="form-label">Justification</label>
+                      <input
+                        type="text"
+                        className="form-control"
+                        placeholder="Why is this change needed?"
+                        value={crForm.justification ?? ''}
+                        onChange={e => setCrForm(f => ({ ...f, justification: e.target.value || null }))}
+                      />
+                    </div>
+                    <div className="col-12">
+                      <label className="form-label">Proposed Payload (JSON)</label>
+                      <textarea
+                        className="form-control font-monospace"
+                        rows={4}
+                        value={crPayloadText}
+                        onChange={e => setCrPayloadText(e.target.value)}
+                      />
+                      <small className="text-muted">Must be valid JSON describing the proposed change.</small>
+                    </div>
+                  </div>
+                  <div className="mt-3 d-flex gap-2">
+                    <button type="submit" className="btn btn-primary btn-sm" disabled={busy}>
+                      {busy ? 'Submitting…' : 'Submit Request'}
+                    </button>
+                    <button type="button" className="btn btn-secondary btn-sm" onClick={() => { setShowCrForm(false); setError(null); }}>
+                      Cancel
+                    </button>
+                  </div>
+                </form>
+              </div>
+            </div>
+          )}
+
+          {/* Reject modal */}
+          {crAction === 'reject' && actionTargetId !== null && (
+            <div className="modal d-block" style={{ background: 'rgba(0,0,0,0.4)' }}>
+              <div className="modal-dialog">
+                <div className="modal-content">
+                  <div className="modal-header">
+                    <h5 className="modal-title">Reject Change Request #{actionTargetId}</h5>
+                    <button className="btn-close" onClick={() => { setCrAction(null); setActionTargetId(null); }} />
+                  </div>
+                  <div className="modal-body">
+                    <label className="form-label">Rejection reason <span className="text-danger">*</span></label>
+                    <textarea
+                      className="form-control"
+                      rows={3}
+                      value={rejectReason}
+                      onChange={e => setRejectReason(e.target.value)}
+                      placeholder="Explain why this request is being rejected…"
+                    />
+                  </div>
+                  <div className="modal-footer">
+                    <button className="btn btn-secondary" onClick={() => { setCrAction(null); setActionTargetId(null); setRejectReason(''); }}>Cancel</button>
+                    <button className="btn btn-danger" onClick={handleCrAction} disabled={busy || !rejectReason.trim()}>
+                      {busy ? 'Rejecting…' : 'Reject'}
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {crLoading ? (
+            <LoadingSpinner />
+          ) : (
+            <div className="table-responsive">
+              <table className="table table-hover">
+                <thead>
+                  <tr>
+                    <th>#</th>
+                    <th>Type</th>
+                    <th>Target</th>
+                    <th>Proposer</th>
+                    <th>Justification</th>
+                    <th>Status</th>
+                    <th>Submitted</th>
+                    {(canReview || canCreate) && <th>Actions</th>}
+                  </tr>
+                </thead>
+                <tbody>
+                  {changeRequests.length === 0 && (
+                    <tr><td colSpan={8} className="text-center text-muted py-4">No change requests found</td></tr>
+                  )}
+                  {changeRequests.map(cr => (
+                    <tr key={cr.id}>
+                      <td>{cr.id}</td>
+                      <td><code>{cr.changeType}</code></td>
+                      <td>
+                        {cr.targetEntityType}
+                        {cr.targetEntityId !== null && <span className="text-muted"> #{cr.targetEntityId}</span>}
+                      </td>
+                      <td>{cr.proposerUserId}</td>
+                      <td>
+                        {cr.justification
+                          ? <span title={cr.justification}>{cr.justification.length > 40 ? `${cr.justification.slice(0, 40)}…` : cr.justification}</span>
+                          : <em className="text-muted">—</em>
+                        }
+                      </td>
+                      <td>
+                        <span className={`badge bg-${STATUS_BADGE[cr.status]}`}>{cr.status}</span>
+                        {cr.rejectionReason && (
+                          <small className="d-block text-muted">{cr.rejectionReason}</small>
+                        )}
+                      </td>
+                      <td><small>{new Date(cr.createdAt).toLocaleDateString()}</small></td>
+                      {(canReview || canCreate) && (
+                        <td>
+                          {canReview && cr.status === 'pending' && (
+                            <>
+                              <button
+                                className="btn btn-sm btn-outline-success me-1"
+                                onClick={() => { setActionTargetId(cr.id); setCrAction('approve'); handleCrAction(); }}
+                                disabled={busy}
+                                title="Approve"
+                              >
+                                <i className="bi bi-check-lg" />
+                              </button>
+                              <button
+                                className="btn btn-sm btn-outline-danger me-1"
+                                onClick={() => { setActionTargetId(cr.id); setCrAction('reject'); }}
+                                disabled={busy}
+                                title="Reject"
+                              >
+                                <i className="bi bi-x-lg" />
+                              </button>
+                            </>
+                          )}
+                          {canReview && cr.status === 'approved' && (
+                            <button
+                              className="btn btn-sm btn-outline-primary me-1"
+                              onClick={() => { setActionTargetId(cr.id); setCrAction('apply'); handleCrAction(); }}
+                              disabled={busy}
+                              title="Apply"
+                            >
+                              <i className="bi bi-lightning" />
+                            </button>
+                          )}
+                          {cr.status === 'pending' && (cr.proposerUserId === Number(user?.id) || canReview) && (
+                            <button
+                              className="btn btn-sm btn-outline-secondary"
+                              onClick={() => handleCancelCr(cr.id)}
+                              disabled={busy}
+                              title="Cancel"
+                            >
+                              <i className="bi bi-slash-circle" />
+                            </button>
+                          )}
+                        </td>
+                      )}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+              {crTotal > changeRequests.length && (
+                <p className="text-muted text-center small">Showing {changeRequests.length} of {crTotal} requests</p>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Governance;

--- a/frontend/src/services/changeRequestService.ts
+++ b/frontend/src/services/changeRequestService.ts
@@ -68,9 +68,6 @@ export const listChangeRequests = (filters?: {
   return request<ChangeRequestPage>(`/change-requests${qs ? `?${qs}` : ''}`);
 };
 
-export const getChangeRequest = (id: number) =>
-  request<ChangeRequest>(`/change-requests/${id}`);
-
 export const createChangeRequest = (input: CreateChangeRequestInput) =>
   request<ChangeRequest>('/change-requests', {
     method: 'POST',

--- a/frontend/src/services/changeRequestService.ts
+++ b/frontend/src/services/changeRequestService.ts
@@ -1,0 +1,103 @@
+/**
+ * Change requests API client.
+ * @author Luca Ostinelli
+ */
+
+import { ApiResponse } from '../types';
+import { AUTH_HEADERS, handleResponse, API_BASE_URL } from './apiUtils';
+
+export type ChangeRequestStatus = 'pending' | 'approved' | 'rejected' | 'applied' | 'cancelled';
+
+export interface ChangeRequest {
+  id: number;
+  changeType: string;
+  proposerUserId: number;
+  targetEntityType: string;
+  targetEntityId: number | null;
+  proposedPayload: Record<string, unknown>;
+  justification: string | null;
+  status: ChangeRequestStatus;
+  approverUserId: number | null;
+  approvedAt: string | null;
+  rejectedAt: string | null;
+  rejectionReason: string | null;
+  appliedAt: string | null;
+  onBehalfOfUserId: number | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ChangeRequestPage {
+  total: number;
+  items: ChangeRequest[];
+}
+
+export interface CreateChangeRequestInput {
+  changeType: string;
+  targetEntityType: string;
+  targetEntityId?: number | null;
+  proposedPayload: Record<string, unknown>;
+  justification?: string | null;
+}
+
+const request = async <T>(path: string, init: RequestInit = {}): Promise<ApiResponse<T>> => {
+  const res = await fetch(`${API_BASE_URL}${path}`, {
+    credentials: 'include',
+    ...init,
+    headers: { ...AUTH_HEADERS, ...(init.headers as Record<string, string> ?? {}) },
+  });
+  return handleResponse<T>(res);
+};
+
+export const listChangeRequests = (filters?: {
+  proposerUserId?: number;
+  approverUserId?: number;
+  status?: ChangeRequestStatus;
+  changeType?: string;
+  limit?: number;
+  offset?: number;
+}) => {
+  const params = new URLSearchParams();
+  if (filters?.proposerUserId !== undefined) params.set('proposerUserId', String(filters.proposerUserId));
+  if (filters?.approverUserId !== undefined) params.set('approverUserId', String(filters.approverUserId));
+  if (filters?.status) params.set('status', filters.status);
+  if (filters?.changeType) params.set('changeType', filters.changeType);
+  if (filters?.limit !== undefined) params.set('limit', String(filters.limit));
+  if (filters?.offset !== undefined) params.set('offset', String(filters.offset));
+  const qs = params.toString();
+  return request<ChangeRequestPage>(`/change-requests${qs ? `?${qs}` : ''}`);
+};
+
+export const getChangeRequest = (id: number) =>
+  request<ChangeRequest>(`/change-requests/${id}`);
+
+export const createChangeRequest = (input: CreateChangeRequestInput) =>
+  request<ChangeRequest>('/change-requests', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(input),
+  });
+
+export const approveChangeRequest = (id: number, justification?: string | null) =>
+  request<ChangeRequest>(`/change-requests/${id}/approve`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ justification }),
+  });
+
+export const rejectChangeRequest = (id: number, rejectionReason: string) =>
+  request<ChangeRequest>(`/change-requests/${id}/reject`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ rejectionReason }),
+  });
+
+export const applyChangeRequest = (id: number, justification?: string | null) =>
+  request<ChangeRequest>(`/change-requests/${id}/apply`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ justification }),
+  });
+
+export const cancelChangeRequest = (id: number) =>
+  request<ChangeRequest>(`/change-requests/${id}/cancel`, { method: 'POST' });

--- a/frontend/src/services/responsibilityService.ts
+++ b/frontend/src/services/responsibilityService.ts
@@ -65,9 +65,6 @@ export const listResponsibilityRules = (filters?: {
   return request<ResponsibilityRule[]>(`/responsibility-rules${qs ? `?${qs}` : ''}`);
 };
 
-export const getResponsibilityRule = (id: number) =>
-  request<ResponsibilityRule>(`/responsibility-rules/${id}`);
-
 export const createResponsibilityRule = (input: CreateResponsibilityRuleInput) =>
   request<ResponsibilityRule>('/responsibility-rules', {
     method: 'POST',
@@ -84,17 +81,3 @@ export const updateResponsibilityRule = (id: number, patch: UpdateResponsibility
 
 export const deleteResponsibilityRule = (id: number) =>
   request<void>(`/responsibility-rules/${id}`, { method: 'DELETE' });
-
-export const resolveResponsibleUsers = (params: {
-  permissionCode: string;
-  orgUnitId?: number;
-  departmentIds?: number[];
-  roleIds?: number[];
-}) => {
-  const qs = new URLSearchParams();
-  qs.set('permissionCode', params.permissionCode);
-  if (params.orgUnitId !== undefined) qs.set('orgUnitId', String(params.orgUnitId));
-  if (params.departmentIds?.length) qs.set('departmentIds', params.departmentIds.join(','));
-  if (params.roleIds?.length) qs.set('roleIds', params.roleIds.join(','));
-  return request<{ userIds: number[] }>(`/responsibility-rules/resolve?${qs.toString()}`);
-};

--- a/frontend/src/services/responsibilityService.ts
+++ b/frontend/src/services/responsibilityService.ts
@@ -1,0 +1,100 @@
+/**
+ * Responsibility rules API client.
+ * @author Luca Ostinelli
+ */
+
+import { ApiResponse } from '../types';
+import { AUTH_HEADERS, handleResponse, API_BASE_URL } from './apiUtils';
+
+export type ResponsibilitySubjectType = 'org_unit' | 'department' | 'role' | 'all';
+
+export interface ResponsibilityRule {
+  id: number;
+  subjectType: ResponsibilitySubjectType;
+  subjectId: number | null;
+  permissionCode: string;
+  responsibleOrgUnitId: number;
+  delegatedToRoleId: number | null;
+  description: string | null;
+  isActive: boolean;
+  createdBy: number | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateResponsibilityRuleInput {
+  subjectType: ResponsibilitySubjectType;
+  subjectId?: number | null;
+  permissionCode: string;
+  responsibleOrgUnitId: number;
+  delegatedToRoleId?: number | null;
+  description?: string | null;
+}
+
+export interface UpdateResponsibilityRuleInput {
+  subjectType?: ResponsibilitySubjectType;
+  subjectId?: number | null;
+  permissionCode?: string;
+  responsibleOrgUnitId?: number;
+  delegatedToRoleId?: number | null;
+  description?: string | null;
+  isActive?: boolean;
+}
+
+const request = async <T>(path: string, init: RequestInit = {}): Promise<ApiResponse<T>> => {
+  const res = await fetch(`${API_BASE_URL}${path}`, {
+    credentials: 'include',
+    ...init,
+    headers: { ...AUTH_HEADERS, ...(init.headers as Record<string, string> ?? {}) },
+  });
+  return handleResponse<T>(res);
+};
+
+export const listResponsibilityRules = (filters?: {
+  subjectType?: string;
+  permissionCode?: string;
+  responsibleOrgUnitId?: number;
+  isActive?: boolean;
+}) => {
+  const params = new URLSearchParams();
+  if (filters?.subjectType) params.set('subjectType', filters.subjectType);
+  if (filters?.permissionCode) params.set('permissionCode', filters.permissionCode);
+  if (filters?.responsibleOrgUnitId !== undefined) params.set('responsibleOrgUnitId', String(filters.responsibleOrgUnitId));
+  if (filters?.isActive !== undefined) params.set('isActive', String(filters.isActive));
+  const qs = params.toString();
+  return request<ResponsibilityRule[]>(`/responsibility-rules${qs ? `?${qs}` : ''}`);
+};
+
+export const getResponsibilityRule = (id: number) =>
+  request<ResponsibilityRule>(`/responsibility-rules/${id}`);
+
+export const createResponsibilityRule = (input: CreateResponsibilityRuleInput) =>
+  request<ResponsibilityRule>('/responsibility-rules', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(input),
+  });
+
+export const updateResponsibilityRule = (id: number, patch: UpdateResponsibilityRuleInput) =>
+  request<ResponsibilityRule>(`/responsibility-rules/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(patch),
+  });
+
+export const deleteResponsibilityRule = (id: number) =>
+  request<void>(`/responsibility-rules/${id}`, { method: 'DELETE' });
+
+export const resolveResponsibleUsers = (params: {
+  permissionCode: string;
+  orgUnitId?: number;
+  departmentIds?: number[];
+  roleIds?: number[];
+}) => {
+  const qs = new URLSearchParams();
+  qs.set('permissionCode', params.permissionCode);
+  if (params.orgUnitId !== undefined) qs.set('orgUnitId', String(params.orgUnitId));
+  if (params.departmentIds?.length) qs.set('departmentIds', params.departmentIds.join(','));
+  if (params.roleIds?.length) qs.set('roleIds', params.roleIds.join(','));
+  return request<{ userIds: number[] }>(`/responsibility-rules/resolve?${qs.toString()}`);
+};


### PR DESCRIPTION
## Summary

- New **Governance** page in the sidebar (`/governance`), gated by `responsibility.read`
- **Responsibility Matrix tab**: table of active rules with add (inline form), activate/deactivate toggle, and delete. Edit actions gated by `responsibility.manage`
- **Change Requests tab**: filterable list with status badges; reviewers can approve, reject (with required reason modal), and apply; any authenticated user with `change_request.create` can submit a new proposal with a JSON payload editor and justification; proposers can cancel their own pending requests
- `services/responsibilityService.ts`: typed API client for all `/responsibility-rules` endpoints
- `services/changeRequestService.ts`: typed API client for all `/change-requests` lifecycle endpoints
- `Governance.test.tsx`: 10 smoke tests covering matrix rendering, tab switching, empty states, form toggle, and reviewer action button visibility