### PR TITLE
fix: remaining project-review findings — JTI blacklist, RBAC validation, audit, CTE, chunking

### DIFF
--- a/backend/src/__tests__/approval.engine.extended.test.ts
+++ b/backend/src/__tests__/approval.engine.extended.test.ts
@@ -319,10 +319,8 @@ describe('ApprovalEngineService.resolveApprover — additional scopes', () => {
       approver_scope: 'unit_manager_chain', approver_role_id: null,
       approver_user_id: null, auto_approve_for_owner: 0, escalate_after_hours: null,
     }], null]);
-    // First org unit: no manager, has parent 2
-    execute.mockResolvedValueOnce([[{ manager_user_id: null, parent_id: 2 }], null]);
-    // Parent unit: manager is 30
-    execute.mockResolvedValueOnce([[{ manager_user_id: 30, parent_id: null }], null]);
+    // WITH RECURSIVE CTE returns the first non-null manager in the chain (parent's manager = 30)
+    execute.mockResolvedValueOnce([[{ manager_user_id: 30 }], null]);
 
     const svc = new ApprovalEngineService(pool);
     const result = await svc.resolveApprover('TimeOff.Request', {

--- a/backend/src/__tests__/routes.batch5.test.ts
+++ b/backend/src/__tests__/routes.batch5.test.ts
@@ -98,7 +98,8 @@ describe('rbac route — POST /roles/users/:userId with non-numeric userId retur
       .send({ roleId: 1 });
     expect(res.status).toBe(400);
     expect(res.body.error.code).toBe('VALIDATION_ERROR');
-    expect(res.body.error.message).toMatch(/userId must be a positive integer/);
+    // Zod-based validateParams returns the field-level message in details, not top-level message
+    expect(res.body.error.details[0].field).toBe('userId');
   });
 
   it('returns 400 VALIDATION_ERROR when userId is 0', async () => {

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -66,8 +66,6 @@ const _isBlacklisted = (jti: string): boolean => {
   return true;
 };
 
-export const getBlacklistSize = (): number => _jtiBlacklist.size;
-
 // Extend Express Request to include user and token JTI
 declare module 'express-serve-static-core' {
   interface Request {

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -29,11 +29,29 @@ const getModuleService = (): ModuleService => {
 };
 
 // In-memory JTI blacklist for server-side token revocation on logout.
-// Each entry stores the expiry timestamp (ms) so expired JTIs are pruned
-// automatically on access, preventing unbounded memory growth.
+// Each entry stores the expiry timestamp (ms). A background interval prunes
+// expired entries every hour so the map stays bounded even under sustained
+// logout traffic. MAX_JTI_BLACKLIST_SIZE caps absolute memory usage.
+const MAX_JTI_BLACKLIST_SIZE = 100_000;
 const _jtiBlacklist = new Map<string, number>();
 
+const _pruneBlacklist = (): void => {
+  const now = Date.now();
+  for (const [jti, exp] of _jtiBlacklist) {
+    if (now > exp) _jtiBlacklist.delete(jti);
+  }
+};
+
+// Prune every hour regardless of access patterns.
+const _pruneInterval = setInterval(_pruneBlacklist, 60 * 60 * 1000);
+_pruneInterval.unref(); // don't block process exit
+
 export const addToBlacklist = (jti: string, expiresAt?: number): void => {
+  // Drop oldest entry if at capacity (FIFO approximation).
+  if (_jtiBlacklist.size >= MAX_JTI_BLACKLIST_SIZE) {
+    const firstKey = _jtiBlacklist.keys().next().value;
+    if (firstKey !== undefined) _jtiBlacklist.delete(firstKey);
+  }
   const exp = expiresAt ?? Date.now() + 24 * 60 * 60 * 1000; // default: 24 h
   _jtiBlacklist.set(jti, exp);
 };
@@ -47,6 +65,8 @@ const _isBlacklisted = (jti: string): boolean => {
   }
   return true;
 };
+
+export const getBlacklistSize = (): number => _jtiBlacklist.size;
 
 // Extend Express Request to include user and token JTI
 declare module 'express-serve-static-core' {

--- a/backend/src/routes/rbac.ts
+++ b/backend/src/routes/rbac.ts
@@ -25,7 +25,7 @@ import { z } from 'zod';
 import { authenticate, requirePermission } from '../middleware/auth';
 import { validateParams, validateBody } from '../middleware/validation';
 import { RbacService } from '../services/RbacService';
-import { idParam, createRoleBody, updateRoleBody } from '../schemas';
+import { idParam, userIdParam, userIdAndRoleIdParam, createRoleBody, updateRoleBody } from '../schemas';
 import { logger } from '../config/logger';
 
 const assignRoleBody = z.object({
@@ -87,9 +87,9 @@ export const createRbacRouter = (pool: Pool): { roles: Router; permissions: Rout
     }
   });
 
-  roles.get('/:id', async (req: Request, res: Response) => {
+  roles.get('/:id', validateParams(idParam), async (_req: Request, res: Response) => {
     try {
-      const role = await rbac.getRoleById(Number(req.params.id));
+      const role = await rbac.getRoleById(res.locals.params.id);
       if (!role) return respondError(res, 404, 'NOT_FOUND', 'Role not found');
       res.json({ success: true, data: role });
     } catch (err) {
@@ -112,9 +112,9 @@ export const createRbacRouter = (pool: Pool): { roles: Router; permissions: Rout
     }
   });
 
-  roles.delete('/:id', async (req: Request, res: Response) => {
+  roles.delete('/:id', validateParams(idParam), async (_req: Request, res: Response) => {
     try {
-      await rbac.deleteRole(Number(req.params.id));
+      await rbac.deleteRole(res.locals.params.id);
       res.json({ success: true });
     } catch (err) {
       const msg = (err as Error).message;
@@ -122,19 +122,11 @@ export const createRbacRouter = (pool: Pool): { roles: Router; permissions: Rout
     }
   });
 
-  roles.post('/users/:userId', async (req: Request, res: Response) => {
+  roles.post('/users/:userId', validateParams(userIdParam), validateBody(assignRoleBody), async (req: Request, res: Response) => {
     try {
-      const userId = parseInt(req.params.userId, 10);
-      if (isNaN(userId) || userId <= 0) {
-        return respondError(res, 400, 'VALIDATION_ERROR', 'userId must be a positive integer');
-      }
-      const parseResult = assignRoleBody.safeParse(req.body);
-      if (!parseResult.success) {
-        return respondError(res, 400, 'VALIDATION_ERROR', 'roleId must be a positive integer');
-      }
-      const { roleId, scopeOrgUnitId, expiresAt } = parseResult.data;
+      const { roleId, scopeOrgUnitId, expiresAt } = res.locals.body;
       await rbac.assignRole(
-        userId,
+        res.locals.params.userId,
         roleId,
         scopeOrgUnitId ?? null,
         expiresAt ?? null,
@@ -146,10 +138,14 @@ export const createRbacRouter = (pool: Pool): { roles: Router; permissions: Rout
     }
   });
 
-  roles.delete('/users/:userId/:roleId', async (req: Request, res: Response) => {
+  roles.delete('/users/:userId/:roleId', validateParams(userIdAndRoleIdParam), async (req: Request, res: Response) => {
     try {
-      const scope = req.query.scopeOrgUnitId ? Number(req.query.scopeOrgUnitId) : null;
-      await rbac.removeRole(Number(req.params.userId), Number(req.params.roleId), scope, req.user?.id);
+      const rawScope = req.query.scopeOrgUnitId;
+      const scope = rawScope ? (() => {
+        const n = parseInt(String(rawScope), 10);
+        return isNaN(n) || n <= 0 ? null : n;
+      })() : null;
+      await rbac.removeRole(res.locals.params.userId, res.locals.params.roleId, scope, req.user?.id);
       res.json({ success: true });
     } catch (err) {
       respondError(res, 400, 'VALIDATION_ERROR', (err as Error).message);

--- a/backend/src/schemas/index.ts
+++ b/backend/src/schemas/index.ts
@@ -11,6 +11,7 @@ export const scheduleIdParam = z.object({ scheduleId: positiveInt });
 export const departmentIdParam = z.object({ departmentId: positiveInt });
 export const idAndSkillIdParam = z.object({ id: positiveInt, skillId: positiveInt });
 export const idAndUserIdParam = z.object({ id: positiveInt, userId: positiveInt });
+export const userIdAndRoleIdParam = z.object({ userId: positiveInt, roleId: positiveInt });
 
 const shortString = z.string().min(1).max(64);
 

--- a/backend/src/services/AuditLogService.ts
+++ b/backend/src/services/AuditLogService.ts
@@ -48,6 +48,12 @@ export interface WriteAuditLogInput {
   justification?: string | null;
   before?: Record<string, unknown> | null;
   after?: Record<string, unknown> | null;
+  /**
+   * When true, the write() method throws on DB failure instead of swallowing the
+   * error. Use for high-compliance actions where a missing audit record must stop
+   * the operation. Default: false (fire-and-forget, never blocks the caller).
+   */
+  throwOnFailure?: boolean;
 }
 
 interface AuditLogFilters {
@@ -176,8 +182,12 @@ export class AuditLogService {
   /**
    * Writes a single audit log entry. `ip_address`, `user_agent`, and
    * `request_id` are pulled automatically from the AsyncLocalStorage context
-   * when a request is in flight. Silently swallows write errors so a log
-   * failure never blocks the primary operation.
+   * when a request is in flight.
+   *
+   * By default the write is fire-and-forget: errors are logged but never
+   * propagated so audit failures never break the primary operation. Set
+   * `throwOnFailure: true` for actions where a missing audit record must
+   * abort the entire transaction.
    */
   async write(input: WriteAuditLogInput): Promise<void> {
     try {
@@ -203,7 +213,14 @@ export class AuditLogService {
         ]
       );
     } catch (err) {
-      logger.error('Failed to write audit log:', err);
+      logger.error('Failed to write audit log', {
+        action: input.action,
+        actorId: input.actorId,
+        entityType: input.entityType,
+        entityId: input.entityId,
+        error: err,
+      });
+      if (input.throwOnFailure) throw err;
     }
   }
 }

--- a/backend/src/services/RbacService.ts
+++ b/backend/src/services/RbacService.ts
@@ -68,17 +68,24 @@ export class RbacService {
     const delegatorIds = (delegRows as any[]).map((r) => r.delegator_id as number);
 
     if (delegatorIds.length > 0) {
-      // Batch-fetch all delegators' current permissions in a single query.
-      // No recursion: sub-delegation is not allowed by design.
-      const [batchRows] = await this.pool.execute<RowDataPacket[]>(
-        `SELECT DISTINCT ur.user_id, p.code
-           FROM user_roles ur
-           JOIN role_permissions rp ON rp.role_id = ur.role_id
-           JOIN permissions p       ON p.id = rp.permission_id
-          WHERE ur.user_id IN (${delegatorIds.map(() => '?').join(',')})
-            AND (ur.expires_at IS NULL OR ur.expires_at > NOW())`,
-        delegatorIds
-      );
+      // Batch-fetch all delegators' current permissions, chunked to avoid
+      // unbounded IN(...) placeholders on large delegation sets.
+      const CHUNK_SIZE = 500;
+      const allBatchRows: RowDataPacket[] = [];
+      for (let i = 0; i < delegatorIds.length; i += CHUNK_SIZE) {
+        const chunk = delegatorIds.slice(i, i + CHUNK_SIZE);
+        const [chunkRows] = await this.pool.execute<RowDataPacket[]>(
+          `SELECT DISTINCT ur.user_id, p.code
+             FROM user_roles ur
+             JOIN role_permissions rp ON rp.role_id = ur.role_id
+             JOIN permissions p       ON p.id = rp.permission_id
+            WHERE ur.user_id IN (${chunk.map(() => '?').join(',')})
+              AND (ur.expires_at IS NULL OR ur.expires_at > NOW())`,
+          chunk
+        );
+        allBatchRows.push(...(chunkRows as RowDataPacket[]));
+      }
+      const batchRows = allBatchRows;
 
       // Build a per-delegator permission set from the batch result.
       const delegatorPerms = new Map<number, Set<string>>();


### PR DESCRIPTION
## Summary

- **JTI blacklist** (`auth.ts` middleware): add `MAX_JTI_BLACKLIST_SIZE` cap, background prune interval every hour, bounds check in `addToBlacklist`; export `getBlacklistSize` for tests
- **RBAC route validation** (`routes/rbac.ts`): replace manual `Number(req.params.*)` parsing with `validateParams` Zod middleware; adopt `validateBody(assignRoleBody)` for the assign-role endpoint
- **AuditLogService** (`AuditLogService.ts`): structured error log on failure; add `throwOnFailure` option so high-compliance callers can abort on a missing audit record instead of silently continuing
- **ApprovalEngineService test**: update mock expectations to match the `WITH RECURSIVE` CTE introduced for `findUnitManagerChain` (one row returned instead of two sequential queries)
- **RbacService delegation batch** (`RbacService.ts`): chunk `delegatorIds` in batches of 500 to avoid unbounded `IN(...)` placeholders

## Test plan

- [ ] `npm test` passes with no regressions
- [ ] `getBlacklistSize()` can be imported and used in auth middleware tests
- [ ] RBAC route returns `VALIDATION_ERROR` with `details[0].field` for invalid `userId`