### PR TITLE
fix: remove email from JWT payload; dispatch LOGOUT on auth init failure

### DIFF
--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -62,7 +62,6 @@ declare module 'express-serve-static-core' {
  */
 interface JWTPayload {
   userId: string;
-  email: string;
   jti?: string;
   iat?: number;
   exp?: number;

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -160,7 +160,7 @@ router.post('/login', loginLimiter, validateBody(loginBody), async (_req: Reques
     // resolved from the database on every request by the auth middleware.
     const jti = crypto.randomUUID();
     const token = jwt.sign(
-      { userId: user.id, email: user.email, jti },
+      { userId: user.id, jti },
       config.jwt.secret,
       jwtSignOptions
     );
@@ -245,7 +245,7 @@ router.post('/refresh', authenticate, async (req: Request, res: Response) => {
 
     const jti = crypto.randomUUID();
     const token = jwt.sign(
-      { userId: user.id, email: user.email, jti },
+      { userId: user.id, jti },
       config.jwt.secret,
       jwtSignOptions
     );

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -93,7 +93,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
           dispatch({ type: 'SET_LOADING', payload: false });
         }
       } catch {
-        dispatch({ type: 'SET_LOADING', payload: false });
+        dispatch({ type: 'LOGOUT' });
       }
     };
 


### PR DESCRIPTION
## Summary

- **JWT payload** (`routes/auth.ts`, `middleware/auth.ts`): remove `email` from the token payload in both login and refresh. Only `userId` + `jti` are embedded; email is already returned in the response body and is re-fetched from DB on every request via `authenticate`. Tokens signed before this change remain valid — the extra field is ignored on decode.
- **AuthContext** (`frontend/src/contexts/AuthContext.tsx`): the `catch` block in `initializeAuth` now dispatches `LOGOUT` instead of the bare `SET_LOADING(false)` action, so `isAuthenticated` is explicitly set to `false` and the loading flag is cleared atomically.

## Test plan

- [ ] `npm test` passes
- [ ] Login flow still works end-to-end (token is set as httpOnly cookie, response body contains user)
- [ ] Refresh flow still works
- [ ] Expired / invalid session on page load shows login screen (not a stuck loading state)