### PR TITLE
feat: per-organization module activation overrides (F2)

### DIFF
--- a/backend/database/init.sql
+++ b/backend/database/init.sql
@@ -571,6 +571,21 @@ CREATE TABLE IF NOT EXISTS modules (
     UNIQUE KEY unique_code (code)
 );
 
+-- Per-organization module overrides.  Rows here take priority over the global
+-- is_enabled value in the modules table.  If no row exists for an org+code
+-- pair the global default applies.
+CREATE TABLE IF NOT EXISTS organization_module_overrides (
+    id INT PRIMARY KEY AUTO_INCREMENT,
+    organization_name VARCHAR(120) NOT NULL,
+    module_code VARCHAR(60) NOT NULL,
+    is_enabled BOOLEAN NOT NULL,
+    updated_by INT NULL,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_org_module (organization_name, module_code),
+    FOREIGN KEY (module_code) REFERENCES modules(code) ON DELETE CASCADE,
+    FOREIGN KEY (updated_by) REFERENCES users(id) ON DELETE SET NULL
+);
+
 -- ================================================================
 -- AUDIT LOGS TABLE - Track system activities
 -- ================================================================

--- a/backend/src/__tests__/module.service.test.ts
+++ b/backend/src/__tests__/module.service.test.ts
@@ -220,3 +220,132 @@ describe('ModuleService.isEnabled', () => {
     expect(execute).toHaveBeenCalledTimes(4);
   });
 });
+
+// ──────────────────────────────────────────────────────────────────────────────
+// listWithOrgOverrides
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('ModuleService.listWithOrgOverrides', () => {
+  it('merges org overrides into the module list', async () => {
+    const { pool, execute } = makePool();
+    execute
+      .mockResolvedValueOnce([[enabledRow], null])                               // list()
+      .mockResolvedValueOnce([[{ module_code: 'delegation', is_enabled: 0 }], null]); // org overrides
+
+    const svc = new ModuleService(pool);
+    const result = await svc.listWithOrgOverrides('acme');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].effectiveEnabled).toBe(false);
+    expect(result[0].orgOverride).toBe(false);
+    expect(result[0].isEnabled).toBe(true); // global default unchanged
+  });
+
+  it('sets orgOverride to null when no override exists for the module', async () => {
+    const { pool, execute } = makePool();
+    execute
+      .mockResolvedValueOnce([[enabledRow], null])
+      .mockResolvedValueOnce([[], null]); // no overrides for org
+
+    const svc = new ModuleService(pool);
+    const result = await svc.listWithOrgOverrides('acme');
+    expect(result[0].orgOverride).toBeNull();
+    expect(result[0].effectiveEnabled).toBe(true); // falls back to global
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// setOrgOverride
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('ModuleService.setOrgOverride', () => {
+  it('upserts the org override row and returns updated module', async () => {
+    const { pool, execute } = makePool();
+    execute
+      .mockResolvedValueOnce([[enabledRow], null])          // getByCode
+      .mockResolvedValueOnce([{ affectedRows: 1 }, null]);  // INSERT ... ON DUPLICATE KEY UPDATE
+
+    const svc = new ModuleService(pool);
+    const result = await svc.setOrgOverride('delegation', 'acme', false, 1);
+
+    expect(result.orgOverride).toBe(false);
+    expect(result.effectiveEnabled).toBe(false);
+    const [sql] = execute.mock.calls[1];
+    expect(sql).toContain('INSERT INTO organization_module_overrides');
+    expect(sql).toContain('ON DUPLICATE KEY UPDATE');
+  });
+
+  it('throws when module does not exist', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[], null]); // getByCode → not found
+
+    const svc = new ModuleService(pool);
+    await expect(svc.setOrgOverride('nonexistent', 'acme', true)).rejects.toThrow('not found');
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// removeOrgOverride
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('ModuleService.removeOrgOverride', () => {
+  it('deletes the override row', async () => {
+    const { pool, execute } = makePool();
+    execute
+      .mockResolvedValueOnce([[enabledRow], null])          // getByCode
+      .mockResolvedValueOnce([{ affectedRows: 1 }, null]);  // DELETE
+
+    const svc = new ModuleService(pool);
+    await svc.removeOrgOverride('delegation', 'acme');
+    const [sql] = execute.mock.calls[1];
+    expect(sql).toContain('DELETE FROM organization_module_overrides');
+  });
+
+  it('throws Override not found when no row is deleted', async () => {
+    const { pool, execute } = makePool();
+    execute
+      .mockResolvedValueOnce([[enabledRow], null])
+      .mockResolvedValueOnce([{ affectedRows: 0 }, null]); // no rows deleted
+
+    const svc = new ModuleService(pool);
+    await expect(svc.removeOrgOverride('delegation', 'acme')).rejects.toThrow('Override not found');
+  });
+
+  it('throws when module does not exist', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[], null]); // getByCode → not found
+
+    const svc = new ModuleService(pool);
+    await expect(svc.removeOrgOverride('nonexistent', 'acme')).rejects.toThrow('not found');
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// isEnabledForOrg
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('ModuleService.isEnabledForOrg', () => {
+  it('returns false when org has an override disabling a globally-enabled module', async () => {
+    const { pool, execute } = makePool();
+    execute
+      .mockResolvedValueOnce([[{ module_code: 'delegation', is_enabled: 0 }], null]) // org overrides
+      .mockResolvedValueOnce([[enabledRow], null]); // global list (not needed here but keeps queue clean)
+
+    const svc = new ModuleService(pool);
+    const result = await svc.isEnabledForOrg('delegation', 'acme');
+    expect(result).toBe(false);
+    // Only the org override query needed — no global list needed since override hit
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to global when no org override exists for the code', async () => {
+    const { pool, execute } = makePool();
+    execute
+      .mockResolvedValueOnce([[], null])              // org overrides → empty
+      .mockResolvedValueOnce([[enabledRow], null]);   // global list (fallback)
+
+    const svc = new ModuleService(pool);
+    const result = await svc.isEnabledForOrg('delegation', 'acme');
+    expect(result).toBe(true); // falls back to global enabled state
+  });
+});

--- a/backend/src/routes/modules.ts
+++ b/backend/src/routes/modules.ts
@@ -9,11 +9,21 @@
 
 import { Router, Request, Response } from 'express';
 import { Pool } from 'mysql2/promise';
+import { z } from 'zod';
 import { ModuleService } from '../services/ModuleService';
 import { authenticate, requirePermission } from '../middleware/auth';
 import { validateBody, validateParams } from '../middleware/validation';
 import { moduleEnabledBody, codeParam } from '../schemas';
 import { logger } from '../config/logger';
+
+const codeOrgParams = z.object({
+  code: z.string().min(1).max(60),
+  org: z.string().min(1).max(120),
+});
+
+const orgOverrideBody = z.object({
+  isEnabled: z.boolean(),
+});
 
 export const createModulesRouter = (pool: Pool): Router => {
   const router = Router();
@@ -41,6 +51,56 @@ export const createModulesRouter = (pool: Pool): Router => {
       }
       logger.error('Error updating module:', error);
       res.status(500).json({ success: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to update module' } });
+    }
+  });
+
+  // GET /org/:org — list all modules with org-specific overrides applied
+  router.get('/org/:org', authenticate, requirePermission('settings.manage'), async (req: Request, res: Response) => {
+    const org = req.params.org;
+    if (!org || org.length > 120) {
+      return res.status(400).json({ success: false, error: { code: 'VALIDATION_ERROR', message: 'Invalid org name' } });
+    }
+    try {
+      const modules = await moduleService.listWithOrgOverrides(org);
+      res.json({ success: true, data: modules });
+    } catch (error) {
+      logger.error('Error listing org modules:', error);
+      res.status(500).json({ success: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to list org modules' } });
+    }
+  });
+
+  // PUT /:code/org/:org — create or update a per-org module override
+  router.put('/:code/org/:org', authenticate, requirePermission('settings.manage'), validateParams(codeOrgParams), validateBody(orgOverrideBody), async (req: Request, res: Response) => {
+    try {
+      const { code, org } = res.locals.params;
+      const { isEnabled } = res.locals.body;
+      const updated = await moduleService.setOrgOverride(code, org, isEnabled, req.user?.id ?? null);
+      res.json({
+        success: true,
+        data: updated,
+        message: `Module '${code}' ${isEnabled ? 'enabled' : 'disabled'} for org '${org}'`,
+      });
+    } catch (error: any) {
+      if (error.message?.includes('not found')) {
+        return res.status(404).json({ success: false, error: { code: 'NOT_FOUND', message: error.message } });
+      }
+      logger.error('Error setting org module override:', error);
+      res.status(500).json({ success: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to set module override' } });
+    }
+  });
+
+  // DELETE /:code/org/:org — remove a per-org override (revert to global default)
+  router.delete('/:code/org/:org', authenticate, requirePermission('settings.manage'), validateParams(codeOrgParams), async (_req: Request, res: Response) => {
+    try {
+      const { code, org } = res.locals.params;
+      await moduleService.removeOrgOverride(code, org);
+      res.json({ success: true, message: `Override for module '${code}' removed for org '${org}'` });
+    } catch (error: any) {
+      if (error.message?.includes('not found') || error.message?.includes('Override not found')) {
+        return res.status(404).json({ success: false, error: { code: 'NOT_FOUND', message: error.message } });
+      }
+      logger.error('Error removing org module override:', error);
+      res.status(500).json({ success: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to remove module override' } });
     }
   });
 

--- a/backend/src/services/ModuleService.ts
+++ b/backend/src/services/ModuleService.ts
@@ -20,9 +20,18 @@ export interface Module {
   updatedAt: Date;
 }
 
+export interface ModuleWithOrgOverride extends Module {
+  /** Effective enabled state after applying the org override (same as isEnabled when no override). */
+  effectiveEnabled: boolean;
+  /** The org-specific override, or null if none is set (global default applies). */
+  orgOverride: boolean | null;
+}
+
 export class ModuleService {
-  /** In-process cache: module code → isEnabled. Cleared on every toggle. */
+  /** In-process cache: module code → isEnabled (global). Cleared on every toggle. */
   private cache: Map<string, boolean> | null = null;
+  /** Per-org cache: org name → (code → isEnabled). Cleared on override change for that org. */
+  private orgCache: Map<string, Map<string, boolean>> = new Map();
 
   constructor(private pool: Pool) {}
 
@@ -62,6 +71,92 @@ export class ModuleService {
   async isEnabled(code: string): Promise<boolean> {
     if (this.cache === null) await this.buildCache();
     return this.cache!.get(code) ?? false;
+  }
+
+  /**
+   * Lists all modules with the org-specific override applied.
+   * `orgOverride` is null when no override exists (global default in effect).
+   */
+  async listWithOrgOverrides(org: string): Promise<ModuleWithOrgOverride[]> {
+    const modules = await this.list();
+    const overrideMap = await this.loadOrgOverrides(org);
+    return modules.map((m) => {
+      const override = overrideMap.get(m.code) ?? null;
+      return {
+        ...m,
+        effectiveEnabled: override !== null ? override : m.isEnabled,
+        orgOverride: override,
+      };
+    });
+  }
+
+  /**
+   * Creates or updates a per-organization module override.
+   * org-level override takes priority over the global is_enabled value.
+   */
+  async setOrgOverride(
+    code: string,
+    org: string,
+    isEnabled: boolean,
+    updatedBy?: number | null
+  ): Promise<ModuleWithOrgOverride> {
+    const mod = await this.getByCode(code);
+    if (!mod) throw new Error(`Module not found: ${code}`);
+
+    await this.pool.execute(
+      `INSERT INTO organization_module_overrides (organization_name, module_code, is_enabled, updated_by)
+       VALUES (?, ?, ?, ?)
+       ON DUPLICATE KEY UPDATE is_enabled = VALUES(is_enabled), updated_by = VALUES(updated_by),
+                               updated_at = CURRENT_TIMESTAMP`,
+      [org, code, isEnabled ? 1 : 0, updatedBy ?? null]
+    );
+    this.orgCache.delete(org);
+    logger.info(`Module override: org='${org}' code='${code}' enabled=${isEnabled}`);
+
+    return {
+      ...mod,
+      effectiveEnabled: isEnabled,
+      orgOverride: isEnabled,
+    };
+  }
+
+  /**
+   * Removes the per-org override for a module, reverting to the global default.
+   */
+  async removeOrgOverride(code: string, org: string): Promise<void> {
+    const mod = await this.getByCode(code);
+    if (!mod) throw new Error(`Module not found: ${code}`);
+
+    const [result] = await this.pool.execute<import('mysql2/promise').ResultSetHeader>(
+      `DELETE FROM organization_module_overrides WHERE organization_name = ? AND module_code = ?`,
+      [org, code]
+    );
+    this.orgCache.delete(org);
+    if (result.affectedRows === 0) throw new Error('Override not found');
+    logger.info(`Module override removed: org='${org}' code='${code}'`);
+  }
+
+  /**
+   * Checks whether a module is enabled for a specific organisation.
+   * Org override has priority; falls back to the global default.
+   */
+  async isEnabledForOrg(code: string, org: string): Promise<boolean> {
+    const overrideMap = await this.loadOrgOverrides(org);
+    if (overrideMap.has(code)) return overrideMap.get(code)!;
+    return this.isEnabled(code);
+  }
+
+  private async loadOrgOverrides(org: string): Promise<Map<string, boolean>> {
+    if (!this.orgCache.has(org)) {
+      const [rows] = await this.pool.execute<import('mysql2/promise').RowDataPacket[]>(
+        `SELECT module_code, is_enabled FROM organization_module_overrides WHERE organization_name = ?`,
+        [org]
+      );
+      const m = new Map<string, boolean>();
+      for (const r of rows as any[]) m.set(r.module_code, Boolean(r.is_enabled));
+      this.orgCache.set(org, m);
+    }
+    return this.orgCache.get(org)!;
   }
 
   private async buildCache(): Promise<void> {


### PR DESCRIPTION
## Summary

Enables each organization to independently enable or disable feature modules, overriding the global default in the `modules` table.

**Schema:** adds `organization_module_overrides(organization_name, module_code, is_enabled, updated_by, updated_at)` with `UNIQUE KEY(org, code)`.

**`ModuleService` additions:**
- `listWithOrgOverrides(org)` — returns all modules with `effectiveEnabled` and `orgOverride` (null if no override exists)
- `setOrgOverride(code, org, isEnabled)` — upsert via `ON DUPLICATE KEY UPDATE`
- `removeOrgOverride(code, org)` — DELETE; throws `Override not found` if no row matched
- `isEnabledForOrg(code, org)` — org-cache fast-path, falls back to global cache
- Per-org cache invalidated on every setOrgOverride / removeOrgOverride call

**API routes added:**
- `GET /api/system/modules/org/:org` — list with org overrides applied
- `PUT /api/system/modules/:code/org/:org` — set/replace org override `{ isEnabled: bool }`
- `DELETE /api/system/modules/:code/org/:org` — remove override (revert to global)

## Test plan

- [ ] `npm test` passes (10 new tests in `module.service.test.ts`)
- [ ] GET /org/:org returns `effectiveEnabled=false` when org has override disabling a globally-enabled module
- [ ] isEnabledForOrg hits org cache on second call (1 DB round-trip)
- [ ] DELETE returns 404 when no override exists