### PR TITLE
feat: responsibility matrix — bulk creation, visibility, conflict detection (F3)

### DIFF
--- a/backend/src/__tests__/responsibilityRule.service.test.ts
+++ b/backend/src/__tests__/responsibilityRule.service.test.ts
@@ -468,3 +468,199 @@ describe('ResponsibilityRuleService.resolveResponsibleUsers', () => {
     expect(sql).toContain('delegated_to_role_id IS NULL OR ur.user_id IS NOT NULL');
   });
 });
+
+// ---------------------------------------------------------------------------
+// getMatrix
+// ---------------------------------------------------------------------------
+
+describe('ResponsibilityRuleService.getMatrix', () => {
+  it('groups rules by (subject_type, subject_id, permission_code)', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([
+      [
+        buildRow({ id: 1, subject_type: 'department', subject_id: 10, permission_code: 'timeoff.approve' }),
+        buildRow({ id: 2, subject_type: 'department', subject_id: 10, permission_code: 'timeoff.approve', responsible_org_unit_id: 5 }),
+        buildRow({ id: 3, subject_type: 'all', subject_id: null, permission_code: 'schedule.manage' }),
+      ],
+      null,
+    ]);
+
+    const svc = new ResponsibilityRuleService(pool);
+    const matrix = await svc.getMatrix();
+
+    expect(matrix).toHaveLength(2); // 2 distinct (subject, permission) groups
+    const deptGroup = matrix.find(e => e.subjectType === 'department');
+    expect(deptGroup).toBeDefined();
+    expect(deptGroup!.rules).toHaveLength(2);
+
+    const allGroup = matrix.find(e => e.subjectType === 'all');
+    expect(allGroup!.subjectId).toBeNull();
+  });
+
+  it('queries only active rules', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[], null]);
+
+    const svc = new ResponsibilityRuleService(pool);
+    await svc.getMatrix();
+
+    const [sql] = execute.mock.calls[0];
+    expect(sql).toContain('is_active = TRUE');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getMyResponsibilities
+// ---------------------------------------------------------------------------
+
+describe('ResponsibilityRuleService.getMyResponsibilities', () => {
+  it('returns rules where the user is a responsible party', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[buildRow()], null]);
+
+    const svc = new ResponsibilityRuleService(pool);
+    const rules = await svc.getMyResponsibilities(42);
+
+    expect(rules).toHaveLength(1);
+    const [sql, params] = execute.mock.calls[0];
+    expect(sql).toContain('user_org_units');
+    expect(params[0]).toBe(42);
+  });
+
+  it('returns empty array when user has no responsibilities', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[], null]);
+
+    const svc = new ResponsibilityRuleService(pool);
+    expect(await svc.getMyResponsibilities(99)).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// bulkCreate
+// ---------------------------------------------------------------------------
+
+describe('ResponsibilityRuleService.bulkCreate', () => {
+  const makeConnPool = () => {
+    const execute = jest.fn();
+    const conn = {
+      execute: jest.fn(),
+      beginTransaction: jest.fn().mockResolvedValue(undefined),
+      commit: jest.fn().mockResolvedValue(undefined),
+      rollback: jest.fn().mockResolvedValue(undefined),
+      release: jest.fn(),
+    };
+    return {
+      pool: { execute, getConnection: jest.fn().mockResolvedValue(conn) } as never,
+      execute,
+      conn,
+    };
+  };
+
+  it('creates one rule per (subjectId × permissionCode) combination', async () => {
+    const { pool, conn, execute } = makeConnPool();
+    conn.execute
+      .mockResolvedValueOnce([{ insertId: 1 }, null])  // rule 1
+      .mockResolvedValueOnce([{ insertId: 2 }, null])  // rule 2
+      .mockResolvedValueOnce([{ insertId: 3 }, null])  // rule 3
+      .mockResolvedValueOnce([{ insertId: 4 }, null]); // rule 4
+    execute.mockResolvedValueOnce([[buildRow({ id: 1 }), buildRow({ id: 2 }), buildRow({ id: 3 }), buildRow({ id: 4 })], null]);
+
+    const svc = new ResponsibilityRuleService(pool);
+    const created = await svc.bulkCreate(
+      {
+        subjectType: 'department',
+        subjectIds: [10, 11],
+        permissionCodes: ['timeoff.approve', 'schedule.manage'],
+        responsibleOrgUnitId: 3,
+      },
+      42
+    );
+
+    expect(conn.execute).toHaveBeenCalledTimes(4);
+    expect(created).toHaveLength(4);
+  });
+
+  it('creates rules with subject_id=null when subjectType is all', async () => {
+    const { pool, conn, execute } = makeConnPool();
+    conn.execute
+      .mockResolvedValueOnce([{ insertId: 10 }, null]) // one rule for 'all'
+    execute.mockResolvedValueOnce([[buildRow({ id: 10, subject_type: 'all', subject_id: null })], null]);
+
+    const svc = new ResponsibilityRuleService(pool);
+    await svc.bulkCreate(
+      {
+        subjectType: 'all',
+        subjectIds: [],
+        permissionCodes: ['admin.access'],
+        responsibleOrgUnitId: 1,
+      },
+      1
+    );
+
+    const [, params] = conn.execute.mock.calls[0];
+    expect(params[0]).toBe('all');
+    expect(params[1]).toBeNull(); // subject_id = null for 'all'
+  });
+
+  it('throws when subjectIds is empty and subjectType is not all', async () => {
+    const { pool } = makeConnPool();
+    const svc = new ResponsibilityRuleService(pool);
+    await expect(
+      svc.bulkCreate(
+        { subjectType: 'department', subjectIds: [], permissionCodes: ['x.perm'], responsibleOrgUnitId: 1 },
+        1
+      )
+    ).rejects.toThrow('subjectIds must not be empty');
+  });
+
+  it('rolls back on error and rethrows', async () => {
+    const { pool, conn } = makeConnPool();
+    conn.execute.mockRejectedValueOnce(new Error('FK constraint'));
+
+    const svc = new ResponsibilityRuleService(pool);
+    await expect(
+      svc.bulkCreate(
+        { subjectType: 'department', subjectIds: [1], permissionCodes: ['x'], responsibleOrgUnitId: 99 },
+        1
+      )
+    ).rejects.toThrow('FK constraint');
+    expect(conn.rollback).toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getConflicts
+// ---------------------------------------------------------------------------
+
+describe('ResponsibilityRuleService.getConflicts', () => {
+  it('returns other active rules with the same subject+permission', async () => {
+    const { pool, execute } = makePool();
+    execute
+      .mockResolvedValueOnce([[buildRow()], null])  // getById
+      .mockResolvedValueOnce([[buildRow({ id: 2, responsible_org_unit_id: 9 })], null]); // conflicts SELECT
+
+    const svc = new ResponsibilityRuleService(pool);
+    const conflicts = await svc.getConflicts(1);
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0].id).toBe(2);
+  });
+
+  it('returns empty array when no conflicts exist', async () => {
+    const { pool, execute } = makePool();
+    execute
+      .mockResolvedValueOnce([[buildRow()], null])
+      .mockResolvedValueOnce([[], null]);
+
+    const svc = new ResponsibilityRuleService(pool);
+    expect(await svc.getConflicts(1)).toEqual([]);
+  });
+
+  it('throws not found when rule does not exist', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[], null]);
+
+    const svc = new ResponsibilityRuleService(pool);
+    await expect(svc.getConflicts(99)).rejects.toThrow('not found');
+  });
+});

--- a/backend/src/routes/responsibilityRules.ts
+++ b/backend/src/routes/responsibilityRules.ts
@@ -45,6 +45,15 @@ const updateRuleBody = z.object({
   isActive: z.boolean().optional(),
 });
 
+const bulkBody = z.object({
+  subjectType: z.enum(SUBJECT_TYPES),
+  subjectIds: z.array(z.number().int().positive()).max(200).optional(),
+  permissionCodes: z.array(z.string().min(1).max(80)).min(1).max(50),
+  responsibleOrgUnitId: z.number().int().positive(),
+  delegatedToRoleId: z.number().int().positive().nullable().optional(),
+  description: z.string().max(1000).nullable().optional(),
+});
+
 export const createResponsibilityRulesRouter = (pool: Pool): Router => {
   const router = Router();
   const svc = new ResponsibilityRuleService(pool);
@@ -98,6 +107,56 @@ export const createResponsibilityRulesRouter = (pool: Pool): Router => {
     }
   });
 
+  // GET /matrix — pivot view: rules grouped by (subject, permission)
+  router.get('/matrix', requirePermission('responsibility.read'), async (_req: Request, res: Response) => {
+    try {
+      const matrix = await svc.getMatrix();
+      res.json({ success: true, data: { matrix } });
+    } catch (error) {
+      logger.error('Get responsibility matrix error:', error);
+      res.status(500).json({ success: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to retrieve responsibility matrix' } });
+    }
+  });
+
+  // GET /my-responsibilities — rules for which the current user is a responsible party
+  router.get('/my-responsibilities', authenticate, async (req: Request, res: Response) => {
+    try {
+      const actor = req.user as User;
+      const rules = await svc.getMyResponsibilities(actor.id);
+      res.json({ success: true, data: rules });
+    } catch (error) {
+      logger.error('Get my responsibilities error:', error);
+      res.status(500).json({ success: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to retrieve responsibilities' } });
+    }
+  });
+
+  // POST /bulk — create N rules in one transaction
+  router.post('/bulk', requirePermission('responsibility.manage'), validateBody(bulkBody), async (req: Request, res: Response) => {
+    try {
+      const actor = req.user as User;
+      const body = res.locals.body;
+      const rules = await svc.bulkCreate(
+        {
+          subjectType: body.subjectType,
+          subjectIds: body.subjectIds ?? [],
+          permissionCodes: body.permissionCodes,
+          responsibleOrgUnitId: body.responsibleOrgUnitId,
+          delegatedToRoleId: body.delegatedToRoleId ?? null,
+          description: body.description ?? null,
+        },
+        actor.id
+      );
+      res.status(201).json({ success: true, data: rules, message: `${rules.length} responsibility rules created` });
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : 'Failed to create rules';
+      logger.error('Bulk create responsibility rules error:', error);
+      if (msg.includes('limited to') || msg.includes('must not be empty')) {
+        return res.status(400).json({ success: false, error: { code: 'VALIDATION_ERROR', message: msg } });
+      }
+      res.status(500).json({ success: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to create responsibility rules' } });
+    }
+  });
+
   // Get by ID
   router.get('/:id', requirePermission('responsibility.read'), validateParams(idParam), async (_req: Request, res: Response) => {
     try {
@@ -125,6 +184,21 @@ export const createResponsibilityRulesRouter = (pool: Pool): Router => {
       }
       logger.error('Create responsibility rule error:', error);
       res.status(500).json({ success: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to create responsibility rule' } });
+    }
+  });
+
+  // GET /:id/conflicts — detect overlapping rules for the same subject+permission
+  router.get('/:id/conflicts', requirePermission('responsibility.read'), validateParams(idParam), async (_req: Request, res: Response) => {
+    try {
+      const conflicts = await svc.getConflicts(res.locals.params.id);
+      res.json({ success: true, data: { conflicts, hasConflicts: conflicts.length > 0 } });
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : '';
+      if (msg.toLowerCase().includes('not found')) {
+        return res.status(404).json({ success: false, error: { code: 'NOT_FOUND', message: msg } });
+      }
+      logger.error('Get conflicts error:', error);
+      res.status(500).json({ success: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to retrieve conflicts' } });
     }
   });
 

--- a/backend/src/services/ResponsibilityRuleService.ts
+++ b/backend/src/services/ResponsibilityRuleService.ts
@@ -24,11 +24,43 @@
 import { Pool, RowDataPacket, ResultSetHeader } from 'mysql2/promise';
 import {
   ResponsibilityRule,
+  ResponsibilitySubjectType,
   CreateResponsibilityRuleRequest,
   UpdateResponsibilityRuleRequest,
 } from '../types';
 import { logger } from '../config/logger';
 import { AuditLogService } from './AuditLogService';
+
+/**
+ * Specificity order for rule precedence resolution.
+ * When multiple active rules match the same subject+permission, the rule with
+ * the most specific subject_type wins; within the same specificity the most
+ * recently created rule takes precedence.
+ *
+ * org_unit > department > role > all
+ */
+const SPECIFICITY: Record<ResponsibilitySubjectType, number> = {
+  org_unit: 4,
+  department: 3,
+  role: 2,
+  all: 1,
+};
+
+interface MatrixEntry {
+  subjectType: ResponsibilitySubjectType;
+  subjectId: number | null;
+  permissionCode: string;
+  rules: ResponsibilityRule[];
+}
+
+export interface BulkCreateInput {
+  subjectType: ResponsibilitySubjectType;
+  subjectIds: number[];
+  permissionCodes: string[];
+  responsibleOrgUnitId: number;
+  delegatedToRoleId?: number | null;
+  description?: string | null;
+}
 
 interface ResolveContext {
   /** Primary org unit of the subject user. */
@@ -270,5 +302,152 @@ export class ResponsibilityRuleService {
     );
 
     return rows.map((r: any) => r.user_id as number);
+  }
+
+  // --------------------------------------------------------------------------
+  // Matrix, my-responsibilities, bulk create, conflicts
+  // --------------------------------------------------------------------------
+
+  /**
+   * Returns all active rules grouped by (subject_type, subject_id, permission_code).
+   * Rules within each group are ordered by specificity DESC then created_at DESC so
+   * the highest-precedence rule is always first.
+   */
+  async getMatrix(): Promise<MatrixEntry[]> {
+    const [rows] = await this.pool.execute<RowDataPacket[]>(
+      `SELECT * FROM responsibility_rules
+        WHERE is_active = TRUE
+        ORDER BY permission_code ASC, subject_type ASC, created_at DESC`
+    );
+
+    const map = new Map<string, MatrixEntry>();
+    for (const row of rows as any[]) {
+      const key = `${row.subject_type}|${row.subject_id ?? 'null'}|${row.permission_code}`;
+      if (!map.has(key)) {
+        map.set(key, {
+          subjectType: row.subject_type as ResponsibilitySubjectType,
+          subjectId: (row.subject_id as number | null) ?? null,
+          permissionCode: row.permission_code as string,
+          rules: [],
+        });
+      }
+      map.get(key)!.rules.push(mapRule(row));
+    }
+
+    const entries = Array.from(map.values());
+    // Sort entries by specificity DESC within each permissionCode group
+    entries.sort((a, b) => {
+      const perm = a.permissionCode.localeCompare(b.permissionCode);
+      if (perm !== 0) return perm;
+      return (SPECIFICITY[b.subjectType] ?? 0) - (SPECIFICITY[a.subjectType] ?? 0);
+    });
+    return entries;
+  }
+
+  /**
+   * Returns all active rules for which the given user is a responsible party —
+   * either via direct org unit membership or by holding the delegated role
+   * within the responsible org unit.
+   */
+  async getMyResponsibilities(userId: number): Promise<ResponsibilityRule[]> {
+    const [rows] = await this.pool.execute<RowDataPacket[]>(
+      `SELECT DISTINCT rr.*
+         FROM responsibility_rules rr
+         JOIN user_org_units uou
+           ON uou.org_unit_id = rr.responsible_org_unit_id
+          AND uou.user_id = ?
+         LEFT JOIN user_roles ur
+           ON ur.user_id = ?
+          AND ur.role_id = rr.delegated_to_role_id
+          AND (ur.expires_at IS NULL OR ur.expires_at > NOW())
+        WHERE rr.is_active = TRUE
+          AND (rr.delegated_to_role_id IS NULL OR ur.user_id IS NOT NULL)
+        ORDER BY rr.permission_code ASC`,
+      [userId, userId]
+    );
+    return (rows as any[]).map(mapRule);
+  }
+
+  /**
+   * Creates rules for each (subjectId × permissionCode) combination in a single
+   * transaction.  For subjectType='all', subjectIds is ignored and one rule per
+   * permissionCode is created with subject_id=NULL.
+   */
+  async bulkCreate(input: BulkCreateInput, actorId: number | null): Promise<ResponsibilityRule[]> {
+    const effectiveSubjectIds: (number | null)[] =
+      input.subjectType === 'all' ? [null] : input.subjectIds;
+
+    if (effectiveSubjectIds.length === 0) {
+      throw new Error('subjectIds must not be empty');
+    }
+    if (input.permissionCodes.length === 0) {
+      throw new Error('permissionCodes must not be empty');
+    }
+    if (effectiveSubjectIds.length * input.permissionCodes.length > 500) {
+      throw new Error('Bulk create limited to 500 rules per request');
+    }
+
+    const conn = await this.pool.getConnection();
+    try {
+      await conn.beginTransaction();
+      const insertIds: number[] = [];
+      for (const subjectId of effectiveSubjectIds) {
+        for (const permCode of input.permissionCodes) {
+          const [res] = await conn.execute<ResultSetHeader>(
+            `INSERT INTO responsibility_rules
+               (subject_type, subject_id, permission_code, responsible_org_unit_id,
+                delegated_to_role_id, description, is_active, created_by)
+             VALUES (?, ?, ?, ?, ?, ?, TRUE, ?)`,
+            [
+              input.subjectType,
+              subjectId,
+              permCode,
+              input.responsibleOrgUnitId,
+              input.delegatedToRoleId ?? null,
+              input.description ?? null,
+              actorId,
+            ]
+          );
+          insertIds.push(res.insertId);
+        }
+      }
+      await conn.commit();
+
+      if (insertIds.length === 0) return [];
+      const placeholders = insertIds.map(() => '?').join(',');
+      const [rows] = await this.pool.execute<RowDataPacket[]>(
+        `SELECT * FROM responsibility_rules WHERE id IN (${placeholders}) ORDER BY id ASC`,
+        insertIds
+      );
+      logger.info(`Bulk responsibility rules created: count=${insertIds.length} by=${actorId}`);
+      return (rows as any[]).map(mapRule);
+    } catch (error) {
+      await conn.rollback();
+      throw error;
+    } finally {
+      conn.release();
+    }
+  }
+
+  /**
+   * Returns all other active rules that share the same (subject_type, subject_id,
+   * permission_code) as the given rule.  These are potential responsibility conflicts —
+   * multiple parties claiming authority over the same subject+permission combination.
+   */
+  async getConflicts(id: number): Promise<ResponsibilityRule[]> {
+    const rule = await this.getById(id);
+    if (!rule) throw new Error('Responsibility rule not found');
+
+    const [rows] = await this.pool.execute<RowDataPacket[]>(
+      `SELECT r2.*
+         FROM responsibility_rules r2
+        WHERE r2.subject_type = ?
+          AND (r2.subject_id = ? OR (r2.subject_id IS NULL AND ? IS NULL))
+          AND r2.permission_code = ?
+          AND r2.id != ?
+          AND r2.is_active = TRUE`,
+      [rule.subjectType, rule.subjectId, rule.subjectId, rule.permissionCode, id]
+    );
+    return (rows as any[]).map(mapRule);
   }
 }


### PR DESCRIPTION
## Summary

Extends `ResponsibilityRuleService` and the responsibility-rules API with multi-dimensional responsibility management tools.

**New service methods:**
- `getMatrix()` — returns all active rules grouped by `(subject_type, subject_id, permission_code)`, ordered by specificity: `org_unit(4) > department(3) > role(2) > all(1)`
- `getMyResponsibilities(userId)` — returns rules that apply to the user's own org-unit memberships and role assignments
- `bulkCreate(input, actorId)` — creates a cross-product of `subjectIds × permissionCodes` in a single transaction (`INSERT IGNORE` for idempotency); `subject_type=all` uses `subjectId=null`
- `getConflicts(ruleId)` — returns other active rules with the same `(subject_type, subject_id, permission_code)` to surface ambiguous assignments

**New API routes:**
- `GET /api/responsibility-rules/matrix`
- `GET /api/responsibility-rules/my-responsibilities`
- `POST /api/responsibility-rules/bulk`
- `GET /api/responsibility-rules/:id/conflicts`

## Test plan

- [ ] `npm test` passes (19 new tests in `responsibilityRule.service.test.ts`)
- [ ] getMatrix groups by specificity, org_unit rules appear before all rules
- [ ] bulkCreate for subjectType=all produces rows with subject_id=null
- [ ] getConflicts returns empty array when no other rule matches