### PR TITLE
feat: pending_approvals table and multi-step approval execution (F4)

### DIFF
--- a/backend/database/init.sql
+++ b/backend/database/init.sql
@@ -1081,6 +1081,29 @@ CREATE TABLE IF NOT EXISTS change_requests (
     FOREIGN KEY (on_behalf_of_user_id) REFERENCES users(id) ON DELETE SET NULL
 );
 
+CREATE TABLE IF NOT EXISTS pending_approvals (
+    id INT PRIMARY KEY AUTO_INCREMENT,
+    change_request_id INT NOT NULL,
+    workflow_id INT NOT NULL,
+    step_id INT NOT NULL,
+    step_order INT NOT NULL,
+    assigned_to_user_id INT NOT NULL,
+    status ENUM('pending','approved','rejected','escalated','skipped') NOT NULL DEFAULT 'pending',
+    decided_at TIMESTAMP NULL,
+    decision_note TEXT NULL,
+    escalated_at TIMESTAMP NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+    FOREIGN KEY (change_request_id) REFERENCES change_requests(id) ON DELETE CASCADE,
+    FOREIGN KEY (workflow_id) REFERENCES approval_workflows(id),
+    FOREIGN KEY (step_id) REFERENCES approval_steps(id),
+    FOREIGN KEY (assigned_to_user_id) REFERENCES users(id) ON DELETE CASCADE,
+
+    INDEX idx_pending_approvals_assigned (assigned_to_user_id, status),
+    INDEX idx_pending_approvals_cr (change_request_id, step_order)
+);
+
 -- ================================================================
 -- DEFERRED FOREIGN KEYS
 -- Added here because they reference tables defined later than the source table.

--- a/backend/src/__tests__/approval.engine.extended.test.ts
+++ b/backend/src/__tests__/approval.engine.extended.test.ts
@@ -319,10 +319,8 @@ describe('ApprovalEngineService.resolveApprover — additional scopes', () => {
       approver_scope: 'unit_manager_chain', approver_role_id: null,
       approver_user_id: null, auto_approve_for_owner: 0, escalate_after_hours: null,
     }], null]);
-    // First org unit: no manager, has parent 2
-    execute.mockResolvedValueOnce([[{ manager_user_id: null, parent_id: 2 }], null]);
-    // Parent unit: manager is 30
-    execute.mockResolvedValueOnce([[{ manager_user_id: 30, parent_id: null }], null]);
+    // WITH RECURSIVE CTE returns the first non-null manager in the chain (parent's manager = 30)
+    execute.mockResolvedValueOnce([[{ manager_user_id: 30 }], null]);
 
     const svc = new ApprovalEngineService(pool);
     const result = await svc.resolveApprover('TimeOff.Request', {

--- a/backend/src/__tests__/changeRequest.service.test.ts
+++ b/backend/src/__tests__/changeRequest.service.test.ts
@@ -153,9 +153,10 @@ describe('ChangeRequestService.create', () => {
   it('inserts a pending change request and returns it', async () => {
     const { pool, execute } = makePool();
     execute
-      .mockResolvedValueOnce([{ insertId: 7, affectedRows: 1 }, null])
-      .mockResolvedValueOnce([[buildRow({ id: 7 })], null])
-      .mockResolvedValue([{ insertId: 99, affectedRows: 1 }, null]); // audit
+      .mockResolvedValueOnce([{ insertId: 7, affectedRows: 1 }, null])  // INSERT change_request
+      .mockResolvedValueOnce([[buildRow({ id: 7 })], null])               // getById
+      .mockResolvedValueOnce([{ insertId: 99, affectedRows: 1 }, null])   // audit.write
+      .mockResolvedValueOnce([[], null]);                                  // getWorkflowByChangeType → no workflow
 
     const svc = new ChangeRequestService(pool);
     const cr = await svc.create(
@@ -176,7 +177,8 @@ describe('ChangeRequestService.create', () => {
     execute
       .mockResolvedValueOnce([{ insertId: 1, affectedRows: 1 }, null])
       .mockResolvedValueOnce([[buildRow()], null])
-      .mockResolvedValue([{ insertId: 1, affectedRows: 1 }, null]);
+      .mockResolvedValueOnce([{ insertId: 1, affectedRows: 1 }, null])   // audit
+      .mockResolvedValueOnce([[], null]);                                  // getWorkflowByChangeType → no workflow
 
     const svc = new ChangeRequestService(pool);
     await svc.create(
@@ -195,7 +197,8 @@ describe('ChangeRequestService.create', () => {
     execute
       .mockResolvedValueOnce([{ insertId: 1, affectedRows: 1 }, null])
       .mockResolvedValueOnce([[buildRow()], null])
-      .mockResolvedValueOnce([{ insertId: 99, affectedRows: 1 }, null]);
+      .mockResolvedValueOnce([{ insertId: 99, affectedRows: 1 }, null])
+      .mockResolvedValueOnce([[], null]); // getWorkflowByChangeType → no workflow
 
     const svc = new ChangeRequestService(pool);
     await svc.create(
@@ -203,9 +206,42 @@ describe('ChangeRequestService.create', () => {
       5
     );
 
-    expect(execute).toHaveBeenCalledTimes(3);
+    expect(execute).toHaveBeenCalledTimes(4);
     const [auditSql] = execute.mock.calls[2];
     expect(auditSql).toContain('INSERT INTO audit_logs');
+  });
+
+  it('creates a pending_approval when a workflow is configured for the change type', async () => {
+    const { pool, execute } = makePool();
+    const workflowRow = {
+      id: 1, change_type: 'Schedule.Override', require_all: 0, description: null,
+      created_at: 't', updated_at: 't',
+    };
+    const stepRow = {
+      id: 10, workflow_id: 1, step_order: 1, approver_scope: 'company_user',
+      approver_role_id: null, approver_user_id: 20, approver_permission_code: null,
+      auto_approve_for_owner: 0, escalate_after_hours: null,
+    };
+    execute
+      .mockResolvedValueOnce([{ insertId: 7 }, null])          // INSERT change_request
+      .mockResolvedValueOnce([[buildRow({ id: 7 })], null])     // getById
+      .mockResolvedValueOnce([{ insertId: 99 }, null])          // audit.write
+      .mockResolvedValueOnce([[workflowRow], null])              // getWorkflowByChangeType
+      .mockResolvedValueOnce([[stepRow], null])                  // hydrateWorkflow steps
+      .mockResolvedValueOnce([[stepRow], null])                  // resolveApproverForStep SELECT
+      .mockResolvedValueOnce([{ insertId: 5 }, null]);          // INSERT pending_approvals
+
+    const svc = new ChangeRequestService(pool);
+    await svc.create(
+      { changeType: 'Schedule.Override', targetEntityType: 'schedule', proposedPayload: {} },
+      10
+    );
+
+    const lastCall = execute.mock.calls[execute.mock.calls.length - 1];
+    expect(lastCall[0]).toContain('INSERT INTO pending_approvals');
+    expect(lastCall[1]).toContain(7);   // change_request_id
+    expect(lastCall[1]).toContain(1);   // workflow_id
+    expect(lastCall[1]).toContain(20);  // assigned_to_user_id (company_user approver)
   });
 });
 
@@ -386,5 +422,124 @@ describe('ChangeRequestService.cancel', () => {
 
     const [auditSql] = execute.mock.calls[3];
     expect(auditSql).toContain('INSERT INTO audit_logs');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// advancePendingApproval
+// ---------------------------------------------------------------------------
+
+const buildPaRow = (overrides: Record<string, unknown> = {}) => ({
+  id: 1,
+  change_request_id: 1,
+  workflow_id: 1,
+  step_id: 10,
+  step_order: 1,
+  assigned_to_user_id: 20,
+  status: 'pending',
+  decided_at: null,
+  decision_note: null,
+  escalated_at: null,
+  created_at: '2026-06-01T00:00:00.000Z',
+  updated_at: '2026-06-01T00:00:00.000Z',
+  ...overrides,
+});
+
+describe('ChangeRequestService.advancePendingApproval', () => {
+  it('throws not found when pending approval does not exist', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[], null]); // getPendingApprovalById → null
+
+    const svc = new ChangeRequestService(pool);
+    await expect(svc.advancePendingApproval(99, 20, 'approved')).rejects.toThrow('not found');
+  });
+
+  it('throws when pending approval is not in pending status', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[buildPaRow({ status: 'approved' })], null]);
+
+    const svc = new ChangeRequestService(pool);
+    await expect(svc.advancePendingApproval(1, 20, 'approved')).rejects.toThrow('already approved');
+  });
+
+  it('throws when user is not the assigned approver', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[buildPaRow({ assigned_to_user_id: 99 })], null]);
+
+    const svc = new ChangeRequestService(pool);
+    await expect(svc.advancePendingApproval(1, 20, 'approved')).rejects.toThrow('Not authorized');
+  });
+
+  it('rejects the change_request when decision is rejected', async () => {
+    const { pool, execute } = makePool();
+    execute
+      .mockResolvedValueOnce([[buildPaRow()], null])             // getPendingApprovalById
+      .mockResolvedValueOnce([{ affectedRows: 1 }, null])        // UPDATE pending_approval
+      .mockResolvedValueOnce([[buildRow()], null])                // getById change_request
+      .mockResolvedValueOnce([{ affectedRows: 1 }, null])        // UPDATE change_request → rejected
+      .mockResolvedValueOnce([{ insertId: 1 }, null])            // audit.write
+      .mockResolvedValueOnce([[buildPaRow({ status: 'rejected' })], null])           // getPendingApprovalById (refresh)
+      .mockResolvedValueOnce([[buildRow({ status: 'rejected' })], null]);            // getById (refresh)
+
+    const svc = new ChangeRequestService(pool);
+    const { changeRequest } = await svc.advancePendingApproval(1, 20, 'rejected', 'Not acceptable');
+    expect(changeRequest.status).toBe('rejected');
+
+    const [updateCrSql, updateCrParams] = execute.mock.calls[3];
+    expect(updateCrSql).toContain("'rejected'");
+    expect(updateCrParams).toContain('Not acceptable');
+  });
+
+  it('creates next pending_approval when an additional workflow step exists', async () => {
+    const { pool, execute } = makePool();
+    const nextStepRow = { id: 11, step_order: 2 };
+    const nextStepFullRow = {
+      id: 11, workflow_id: 1, step_order: 2, approver_scope: 'company_user',
+      approver_role_id: null, approver_user_id: 30, approver_permission_code: null,
+      auto_approve_for_owner: 0, escalate_after_hours: null,
+    };
+    execute
+      .mockResolvedValueOnce([[buildPaRow()], null])             // getPendingApprovalById
+      .mockResolvedValueOnce([{ affectedRows: 1 }, null])        // UPDATE pending_approval → approved
+      .mockResolvedValueOnce([[buildRow()], null])                // getById change_request
+      .mockResolvedValueOnce([[nextStepRow], null])               // SELECT next step from approval_steps
+      .mockResolvedValueOnce([[nextStepFullRow], null])           // resolveApproverForStep SELECT
+      .mockResolvedValueOnce([{ insertId: 6 }, null])            // INSERT next pending_approval
+      .mockResolvedValueOnce([[buildPaRow({ status: 'approved' })], null])  // getPendingApprovalById refresh
+      .mockResolvedValueOnce([[buildRow()], null]);               // getById change_request refresh
+
+    const svc = new ChangeRequestService(pool);
+    await svc.advancePendingApproval(1, 20, 'approved');
+
+    const insertCall = execute.mock.calls.find(
+      ([sql]: [string]) => typeof sql === 'string' && sql.includes('INSERT INTO pending_approvals')
+    );
+    expect(insertCall).toBeDefined();
+    expect(insertCall[1]).toContain(30); // assigned to next step's approver
+    expect(insertCall[1]).toContain(2);  // step_order = 2
+  });
+
+  it('approves the change_request when the final step is approved', async () => {
+    const { pool, execute } = makePool();
+    execute
+      .mockResolvedValueOnce([[buildPaRow()], null])             // getPendingApprovalById
+      .mockResolvedValueOnce([{ affectedRows: 1 }, null])        // UPDATE pending_approval → approved
+      .mockResolvedValueOnce([[buildRow()], null])                // getById change_request
+      .mockResolvedValueOnce([[], null])                         // SELECT next step → none (last step)
+      .mockResolvedValueOnce([{ affectedRows: 1 }, null])        // UPDATE change_request → approved
+      .mockResolvedValueOnce([{ insertId: 1 }, null])            // audit.write
+      .mockResolvedValueOnce([[buildPaRow({ status: 'approved' })], null])           // getPendingApprovalById refresh
+      .mockResolvedValueOnce([[buildRow({ status: 'approved', approver_user_id: 20 })], null]); // getById refresh
+
+    const svc = new ChangeRequestService(pool);
+    const { changeRequest } = await svc.advancePendingApproval(1, 20, 'approved');
+    expect(changeRequest.status).toBe('approved');
+    expect(changeRequest.approverUserId).toBe(20);
+
+    const updateCrCall = execute.mock.calls.find(
+      ([sql]: [string]) => typeof sql === 'string' && sql.includes("'approved'") && sql.includes('change_requests')
+    );
+    expect(updateCrCall).toBeDefined();
+    expect(updateCrCall[1]).toContain(20); // approver_user_id
   });
 });

--- a/backend/src/__tests__/pendingApprovals.route.test.ts
+++ b/backend/src/__tests__/pendingApprovals.route.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Pending Approvals route tests.
+ *
+ * Covers:
+ *   GET  /api/pending-approvals         — list + status filter
+ *   GET  /api/pending-approvals/count   — badge count
+ *   POST /api/pending-approvals/:id/approve — happy path + 404 + 400
+ *   POST /api/pending-approvals/:id/reject  — happy path + 403 (wrong user)
+ *
+ * @author Luca Ostinelli
+ */
+
+import express from 'express';
+import request from 'supertest';
+
+jest.mock('../middleware/auth', () => ({
+  authenticate: (req: any, _res: any, next: any) => {
+    req.user = { id: 20, email: 'approver@example.com' };
+    next();
+  },
+  requirePermission: () => (_req: any, _res: any, next: any) => next(),
+  requireModule: () => (_req: any, _res: any, next: any) => next(),
+  userHasPermission: () => true,
+}));
+
+jest.mock('../services/PendingApprovalService');
+jest.mock('../services/ChangeRequestService');
+
+import { PendingApprovalService } from '../services/PendingApprovalService';
+import { ChangeRequestService } from '../services/ChangeRequestService';
+import { createPendingApprovalsRouter } from '../routes/pendingApprovals';
+
+const fakePool = {} as never;
+
+const app = express();
+app.use(express.json());
+app.use('/api/pending-approvals', createPendingApprovalsRouter(fakePool));
+
+// ─── GET / ────────────────────────────────────────────────────────────────────
+
+describe('GET /api/pending-approvals', () => {
+  it('returns list with default status=pending', async () => {
+    const item = {
+      id: 1,
+      changeRequestId: 1,
+      workflowId: 1,
+      stepId: 10,
+      stepOrder: 1,
+      assignedToUserId: 20,
+      status: 'pending',
+      decidedAt: null,
+      decisionNote: null,
+      escalatedAt: null,
+      createdAt: 't',
+      updatedAt: 't',
+      changeType: 'Schedule.Override',
+      targetEntityType: 'schedule',
+      targetEntityId: null,
+      proposedPayload: {},
+      justification: null,
+      proposerUserId: 10,
+    };
+    (PendingApprovalService.prototype.listForUser as jest.Mock).mockResolvedValueOnce([item]);
+
+    const res = await request(app).get('/api/pending-approvals');
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.items).toHaveLength(1);
+    expect(res.body.data.total).toBe(1);
+    expect(PendingApprovalService.prototype.listForUser).toHaveBeenCalledWith(20, 'pending');
+  });
+
+  it('passes custom status query param to service', async () => {
+    (PendingApprovalService.prototype.listForUser as jest.Mock).mockResolvedValueOnce([]);
+
+    await request(app).get('/api/pending-approvals?status=approved');
+    expect(PendingApprovalService.prototype.listForUser).toHaveBeenCalledWith(20, 'approved');
+  });
+
+  it('returns 500 when service throws', async () => {
+    (PendingApprovalService.prototype.listForUser as jest.Mock).mockRejectedValueOnce(new Error('db error'));
+
+    const res = await request(app).get('/api/pending-approvals');
+    expect(res.status).toBe(500);
+    expect(res.body.error.code).toBe('INTERNAL_ERROR');
+  });
+});
+
+// ─── GET /count ───────────────────────────────────────────────────────────────
+
+describe('GET /api/pending-approvals/count', () => {
+  it('returns the pending count for the current user', async () => {
+    (PendingApprovalService.prototype.countForUser as jest.Mock).mockResolvedValueOnce(3);
+
+    const res = await request(app).get('/api/pending-approvals/count');
+    expect(res.status).toBe(200);
+    expect(res.body.data.count).toBe(3);
+    expect(PendingApprovalService.prototype.countForUser).toHaveBeenCalledWith(20);
+  });
+
+  it('returns 500 when service throws', async () => {
+    (PendingApprovalService.prototype.countForUser as jest.Mock).mockRejectedValueOnce(new Error('db error'));
+
+    const res = await request(app).get('/api/pending-approvals/count');
+    expect(res.status).toBe(500);
+    expect(res.body.error.code).toBe('INTERNAL_ERROR');
+  });
+});
+
+// ─── POST /:id/approve ────────────────────────────────────────────────────────
+
+describe('POST /api/pending-approvals/:id/approve', () => {
+  it('returns 200 with result when approval advances successfully', async () => {
+    const result = {
+      pendingApproval: { id: 1, status: 'approved' },
+      changeRequest: { id: 1, status: 'approved' },
+    };
+    (ChangeRequestService.prototype.advancePendingApproval as jest.Mock).mockResolvedValueOnce(result);
+
+    const res = await request(app).post('/api/pending-approvals/1/approve').send({ note: 'Looks good' });
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(ChangeRequestService.prototype.advancePendingApproval).toHaveBeenCalledWith(
+      1, 20, 'approved', 'Looks good'
+    );
+  });
+
+  it('returns 404 when pending approval is not found', async () => {
+    (ChangeRequestService.prototype.advancePendingApproval as jest.Mock).mockRejectedValueOnce(
+      new Error('Pending approval not found')
+    );
+
+    const res = await request(app).post('/api/pending-approvals/99/approve').send({});
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe('NOT_FOUND');
+  });
+
+  it('returns 400 when pending approval is already acted upon', async () => {
+    (ChangeRequestService.prototype.advancePendingApproval as jest.Mock).mockRejectedValueOnce(
+      new Error('Pending approval is already approved')
+    );
+
+    const res = await request(app).post('/api/pending-approvals/1/approve').send({});
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('INVALID_STATE');
+  });
+
+  it('returns 400 when :id is not a positive integer', async () => {
+    const res = await request(app).post('/api/pending-approvals/abc/approve').send({});
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+});
+
+// ─── POST /:id/reject ─────────────────────────────────────────────────────────
+
+describe('POST /api/pending-approvals/:id/reject', () => {
+  it('returns 200 with rejected result', async () => {
+    const result = {
+      pendingApproval: { id: 1, status: 'rejected' },
+      changeRequest: { id: 1, status: 'rejected' },
+    };
+    (ChangeRequestService.prototype.advancePendingApproval as jest.Mock).mockResolvedValueOnce(result);
+
+    const res = await request(app).post('/api/pending-approvals/1/reject').send({ note: 'Not justified' });
+    expect(res.status).toBe(200);
+    expect(ChangeRequestService.prototype.advancePendingApproval).toHaveBeenCalledWith(
+      1, 20, 'rejected', 'Not justified'
+    );
+  });
+
+  it('returns 400 when user is not authorized to act on this step', async () => {
+    (ChangeRequestService.prototype.advancePendingApproval as jest.Mock).mockRejectedValueOnce(
+      new Error('Not authorized to act on this pending approval')
+    );
+
+    const res = await request(app).post('/api/pending-approvals/1/reject').send({});
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('INVALID_STATE');
+  });
+
+  it('returns 500 when service throws unexpected error', async () => {
+    (ChangeRequestService.prototype.advancePendingApproval as jest.Mock).mockRejectedValueOnce(
+      new Error('disk full')
+    );
+
+    const res = await request(app).post('/api/pending-approvals/1/reject').send({});
+    expect(res.status).toBe(500);
+    expect(res.body.error.code).toBe('INTERNAL_ERROR');
+  });
+});

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -54,6 +54,7 @@ import { createApprovalWorkflowsRouter } from './routes/approvalWorkflows';
 import { createModulesRouter } from './routes/modules';
 import { createChangeRequestsRouter } from './routes/changeRequests';
 import { createResponsibilityRulesRouter } from './routes/responsibilityRules';
+import { createPendingApprovalsRouter } from './routes/pendingApprovals';
 
 interface BuildAppOptions {
   /** When true, skip rate limiting + morgan logging (useful for tests). */
@@ -188,6 +189,7 @@ export function buildApp(pool: Pool, options: BuildAppOptions = {}): express.Exp
     app.use(`${prefix}/modules`, createModulesRouter(pool));
     app.use(`${prefix}/responsibility-rules`, createResponsibilityRulesRouter(pool));
     app.use(`${prefix}/change-requests`, createChangeRequestsRouter(pool));
+    app.use(`${prefix}/pending-approvals`, createPendingApprovalsRouter(pool));
   };
   mountRoutes('/api/v1');
   mountRoutes('/api');

--- a/backend/src/routes/pendingApprovals.ts
+++ b/backend/src/routes/pendingApprovals.ts
@@ -1,0 +1,120 @@
+/**
+ * Pending Approvals Router
+ *
+ * Endpoints for approvers to view and act on workflow-routed change requests.
+ *
+ * GET  /api/pending-approvals          — list approvals assigned to caller
+ * GET  /api/pending-approvals/count    — badge count (status=pending)
+ * POST /api/pending-approvals/:id/approve
+ * POST /api/pending-approvals/:id/reject
+ *
+ * @author Luca Ostinelli
+ */
+
+import express from 'express';
+import { Pool } from 'mysql2/promise';
+import { z } from 'zod';
+import { authenticate, requirePermission } from '../middleware/auth';
+import { validateParams } from '../middleware/validation';
+import { PendingApprovalService } from '../services/PendingApprovalService';
+import { ChangeRequestService } from '../services/ChangeRequestService';
+import { logger } from '../config/logger';
+
+const idParams = z.object({ id: z.coerce.number().int().positive() });
+
+export function createPendingApprovalsRouter(pool: Pool): express.Router {
+  const router = express.Router();
+
+  // GET / — list pending approvals assigned to the current user
+  router.get('/', authenticate, async (req, res) => {
+    try {
+      const svc = new PendingApprovalService(pool);
+      const status = typeof req.query.status === 'string' ? req.query.status : 'pending';
+      const items = await svc.listForUser(req.user!.id, status);
+      res.json({ success: true, data: { items, total: items.length } });
+    } catch (error) {
+      logger.error('Failed to list pending approvals:', error);
+      res.status(500).json({
+        success: false,
+        error: { code: 'INTERNAL_ERROR', message: 'Failed to retrieve pending approvals' },
+      });
+    }
+  });
+
+  // GET /count — badge count for current user (always status=pending)
+  router.get('/count', authenticate, async (req, res) => {
+    try {
+      const svc = new PendingApprovalService(pool);
+      const count = await svc.countForUser(req.user!.id);
+      res.json({ success: true, data: { count } });
+    } catch (error) {
+      logger.error('Failed to count pending approvals:', error);
+      res.status(500).json({
+        success: false,
+        error: { code: 'INTERNAL_ERROR', message: 'Failed to count pending approvals' },
+      });
+    }
+  });
+
+  // POST /:id/approve — advance the step as approved
+  router.post(
+    '/:id/approve',
+    authenticate,
+    requirePermission('change_request.approve'),
+    validateParams(idParams),
+    async (req, res) => {
+      try {
+        const id = Number(req.params.id);
+        const note = typeof req.body?.note === 'string' ? req.body.note : null;
+        const svc = new ChangeRequestService(pool);
+        const result = await svc.advancePendingApproval(id, req.user!.id, 'approved', note);
+        res.json({ success: true, data: result });
+      } catch (error: any) {
+        const msg: string = error?.message ?? '';
+        if (msg.toLowerCase().includes('not found')) {
+          return res.status(404).json({ success: false, error: { code: 'NOT_FOUND', message: msg } });
+        }
+        if (msg.includes('Not authorized') || msg.includes('already')) {
+          return res.status(400).json({ success: false, error: { code: 'INVALID_STATE', message: msg } });
+        }
+        logger.error('Failed to approve pending approval:', error);
+        res.status(500).json({
+          success: false,
+          error: { code: 'INTERNAL_ERROR', message: 'Failed to approve pending approval' },
+        });
+      }
+    }
+  );
+
+  // POST /:id/reject — advance the step as rejected (closes the change_request)
+  router.post(
+    '/:id/reject',
+    authenticate,
+    requirePermission('change_request.approve'),
+    validateParams(idParams),
+    async (req, res) => {
+      try {
+        const id = Number(req.params.id);
+        const note = typeof req.body?.note === 'string' ? req.body.note : null;
+        const svc = new ChangeRequestService(pool);
+        const result = await svc.advancePendingApproval(id, req.user!.id, 'rejected', note);
+        res.json({ success: true, data: result });
+      } catch (error: any) {
+        const msg: string = error?.message ?? '';
+        if (msg.toLowerCase().includes('not found')) {
+          return res.status(404).json({ success: false, error: { code: 'NOT_FOUND', message: msg } });
+        }
+        if (msg.includes('Not authorized') || msg.includes('already')) {
+          return res.status(400).json({ success: false, error: { code: 'INVALID_STATE', message: msg } });
+        }
+        logger.error('Failed to reject pending approval:', error);
+        res.status(500).json({
+          success: false,
+          error: { code: 'INTERNAL_ERROR', message: 'Failed to reject pending approval' },
+        });
+      }
+    }
+  );
+
+  return router;
+}

--- a/backend/src/services/ApprovalEngineService.ts
+++ b/backend/src/services/ApprovalEngineService.ts
@@ -214,6 +214,36 @@ export class ApprovalEngineService {
   }
 
   /**
+   * Resolves the approver for a single step identified by its DB id.
+   * Used by ChangeRequestService to advance multi-step pending_approval chains.
+   */
+  async resolveApproverForStep(
+    stepId: number,
+    ctx: { actorUserId: number; orgUnitId?: number; policyOwnerId?: number }
+  ): Promise<number | null> {
+    const [rows] = await this.pool.execute<RowDataPacket[]>(
+      `SELECT id, workflow_id, step_order, approver_scope, approver_role_id,
+              approver_user_id, approver_permission_code, auto_approve_for_owner, escalate_after_hours
+         FROM approval_steps WHERE id = ? LIMIT 1`,
+      [stepId]
+    );
+    if (rows.length === 0) return null;
+    const r = rows[0] as any;
+    const step: ApprovalStep = {
+      id: r.id,
+      workflowId: r.workflow_id,
+      stepOrder: r.step_order,
+      approverScope: r.approver_scope as ApproverScope,
+      approverRoleId: r.approver_role_id ?? null,
+      approverUserId: r.approver_user_id ?? null,
+      approverPermissionCode: r.approver_permission_code ?? null,
+      autoApproveForOwner: Boolean(r.auto_approve_for_owner),
+      escalateAfterHours: r.escalate_after_hours ?? null,
+    };
+    return this.resolveStepApprover(step, ctx);
+  }
+
+  /**
    * Resolves ALL steps for the given change type in order. Returns the first
    * non-auto-approved step as the active approver, or null when every step
    * can auto-approve.
@@ -352,21 +382,27 @@ export class ApprovalEngineService {
   }
 
   private async findUnitManagerChain(orgUnitId: number): Promise<number | null> {
-    let current: number | null = orgUnitId;
-    const visited = new Set<number>();
-    while (current !== null && !visited.has(current)) {
-      const cur: number = current;
-      visited.add(cur);
-      const [chainRows] = await this.pool.execute<RowDataPacket[]>(
-        'SELECT manager_user_id, parent_id FROM org_units WHERE id = ? LIMIT 1',
-        [cur]
-      );
-      if (chainRows.length === 0) return null;
-      const managerId = chainRows[0].manager_user_id as number | null;
-      if (managerId !== null && managerId !== undefined) return managerId;
-      current = (chainRows[0].parent_id as number | null) ?? null;
-    }
-    return null;
+    // Walk the entire ancestor chain in one recursive CTE query and return the
+    // first manager found (closest ancestor with a non-null manager_user_id).
+    const [rows] = await this.pool.execute<RowDataPacket[]>(
+      `WITH RECURSIVE chain AS (
+         SELECT id, manager_user_id, parent_id, 0 AS depth
+           FROM org_units
+          WHERE id = ?
+         UNION ALL
+         SELECT o.id, o.manager_user_id, o.parent_id, c.depth + 1
+           FROM org_units o
+           JOIN chain c ON o.id = c.parent_id
+          WHERE c.depth < 20
+       )
+       SELECT manager_user_id
+         FROM chain
+        WHERE manager_user_id IS NOT NULL
+        ORDER BY depth ASC
+        LIMIT 1`,
+      [orgUnitId]
+    );
+    return rows.length === 0 ? null : (rows[0].manager_user_id as number);
   }
 
   private async findFirstActiveByRoleId(roleId: number): Promise<number | null> {

--- a/backend/src/services/ChangeRequestService.ts
+++ b/backend/src/services/ChangeRequestService.ts
@@ -19,9 +19,11 @@ import {
   ChangeRequestStatus,
   CreateChangeRequestInput,
   ChangeRequestFilters,
+  PendingApproval,
 } from '../types';
 import { logger } from '../config/logger';
 import { AuditLogService } from './AuditLogService';
+import { ApprovalEngineService } from './ApprovalEngineService';
 
 const mapRow = (row: RowDataPacket): ChangeRequest => ({
   id: row.id as number,
@@ -46,9 +48,11 @@ const mapRow = (row: RowDataPacket): ChangeRequest => ({
 
 export class ChangeRequestService {
   private audit: AuditLogService;
+  private engine: ApprovalEngineService;
 
   constructor(private pool: Pool) {
     this.audit = new AuditLogService(pool);
+    this.engine = new ApprovalEngineService(pool);
   }
 
   // --------------------------------------------------------------------------
@@ -139,6 +143,24 @@ export class ChangeRequestService {
       justification: input.justification ?? undefined,
       after: created as unknown as Record<string, unknown>,
     });
+
+    // Create first pending_approval if an approval workflow is configured for this change type.
+    const workflow = await this.engine.getWorkflowByChangeType(input.changeType);
+    if (workflow && workflow.steps.length > 0) {
+      const firstStep = workflow.steps[0];
+      const approverUserId = await this.engine.resolveApproverForStep(firstStep.id, {
+        actorUserId: proposerUserId,
+      });
+      if (approverUserId !== null) {
+        await this.pool.execute(
+          `INSERT INTO pending_approvals
+             (change_request_id, workflow_id, step_id, step_order, assigned_to_user_id, status)
+           VALUES (?, ?, ?, ?, ?, 'pending')`,
+          [created.id, workflow.id, firstStep.id, firstStep.stepOrder, approverUserId]
+        );
+        logger.info(`Pending approval created: cr=${created.id} step=${firstStep.stepOrder} assignee=${approverUserId}`);
+      }
+    }
 
     logger.info(`Change request created: id=${created.id} type=${created.changeType} proposer=${proposerUserId}`);
     return created;
@@ -282,5 +304,122 @@ export class ChangeRequestService {
     });
 
     return updated;
+  }
+
+  /**
+   * Advances a pending_approval step: mark it approved or rejected, then
+   * either open the next step or (when the final step is approved) transition
+   * the change_request to 'approved'.  When rejected the change_request is
+   * immediately set to 'rejected'.
+   *
+   * Only the user who is assigned to the step may act on it.
+   */
+  async advancePendingApproval(
+    pendingApprovalId: number,
+    userId: number,
+    decision: 'approved' | 'rejected',
+    note?: string | null
+  ): Promise<{ pendingApproval: PendingApproval; changeRequest: ChangeRequest }> {
+    const pa = await this.getPendingApprovalById(pendingApprovalId);
+    if (!pa) throw new Error('Pending approval not found');
+    if (pa.status !== 'pending') throw new Error(`Pending approval is already ${pa.status}`);
+    if (pa.assignedToUserId !== userId) throw new Error('Not authorized to act on this pending approval');
+
+    await this.pool.execute(
+      `UPDATE pending_approvals
+          SET status = ?, decided_at = CURRENT_TIMESTAMP, decision_note = ?, updated_at = CURRENT_TIMESTAMP
+        WHERE id = ?`,
+      [decision, note ?? null, pendingApprovalId]
+    );
+
+    const cr = await this.getById(pa.changeRequestId);
+    if (!cr) throw new Error('Change request not found');
+
+    if (decision === 'rejected') {
+      await this.pool.execute(
+        `UPDATE change_requests
+            SET status = 'rejected', approver_user_id = ?, rejected_at = CURRENT_TIMESTAMP,
+                rejection_reason = ?, updated_at = CURRENT_TIMESTAMP
+          WHERE id = ?`,
+        [userId, note ?? null, pa.changeRequestId]
+      );
+      await this.audit.write({
+        actorId: userId,
+        action: 'change_request.reject',
+        entityType: 'change_request',
+        entityId: pa.changeRequestId,
+        description: `Change request rejected via workflow step ${pa.stepOrder}: ${cr.changeType}`,
+        before: cr as unknown as Record<string, unknown>,
+      });
+    } else {
+      // Approved — look for next step in the same workflow.
+      const [nextRows] = await this.pool.execute<RowDataPacket[]>(
+        `SELECT id, step_order
+           FROM approval_steps
+          WHERE workflow_id = ? AND step_order > ?
+          ORDER BY step_order ASC LIMIT 1`,
+        [pa.workflowId, pa.stepOrder]
+      );
+
+      if (nextRows.length > 0) {
+        const nextStepId = (nextRows[0] as any).id as number;
+        const nextStepOrder = (nextRows[0] as any).step_order as number;
+        const nextApproverUserId = await this.engine.resolveApproverForStep(nextStepId, {
+          actorUserId: userId,
+        });
+        if (nextApproverUserId !== null) {
+          await this.pool.execute(
+            `INSERT INTO pending_approvals
+               (change_request_id, workflow_id, step_id, step_order, assigned_to_user_id, status)
+             VALUES (?, ?, ?, ?, ?, 'pending')`,
+            [pa.changeRequestId, pa.workflowId, nextStepId, nextStepOrder, nextApproverUserId]
+          );
+        }
+      } else {
+        // No more steps — all approved; transition change_request.
+        await this.pool.execute(
+          `UPDATE change_requests
+              SET status = 'approved', approver_user_id = ?, approved_at = CURRENT_TIMESTAMP,
+                  updated_at = CURRENT_TIMESTAMP
+            WHERE id = ?`,
+          [userId, pa.changeRequestId]
+        );
+        await this.audit.write({
+          actorId: userId,
+          action: 'change_request.approve',
+          entityType: 'change_request',
+          entityId: pa.changeRequestId,
+          description: `Change request approved after all workflow steps: ${cr.changeType}`,
+          before: cr as unknown as Record<string, unknown>,
+        });
+      }
+    }
+
+    const updatedPa = await this.getPendingApprovalById(pendingApprovalId);
+    const updatedCr = await this.getById(pa.changeRequestId);
+    return { pendingApproval: updatedPa!, changeRequest: updatedCr! };
+  }
+
+  private async getPendingApprovalById(id: number): Promise<PendingApproval | null> {
+    const [rows] = await this.pool.execute<RowDataPacket[]>(
+      'SELECT * FROM pending_approvals WHERE id = ? LIMIT 1',
+      [id]
+    );
+    if (rows.length === 0) return null;
+    const r = rows[0] as any;
+    return {
+      id: r.id,
+      changeRequestId: r.change_request_id,
+      workflowId: r.workflow_id,
+      stepId: r.step_id,
+      stepOrder: r.step_order,
+      assignedToUserId: r.assigned_to_user_id,
+      status: r.status,
+      decidedAt: r.decided_at ?? null,
+      decisionNote: r.decision_note ?? null,
+      escalatedAt: r.escalated_at ?? null,
+      createdAt: r.created_at,
+      updatedAt: r.updated_at,
+    };
   }
 }

--- a/backend/src/services/PendingApprovalService.ts
+++ b/backend/src/services/PendingApprovalService.ts
@@ -1,0 +1,75 @@
+/**
+ * Pending Approval Service
+ *
+ * Read-side queries for the pending_approvals table.  Write-side mutations
+ * (approve / reject / advance) live in ChangeRequestService so the full
+ * change_request lifecycle stays in one place.
+ *
+ * @author Luca Ostinelli
+ */
+
+import { Pool, RowDataPacket } from 'mysql2/promise';
+import { PendingApprovalWithContext } from '../types';
+
+const mapRow = (r: any): PendingApprovalWithContext => ({
+  id: r.id,
+  changeRequestId: r.change_request_id,
+  workflowId: r.workflow_id,
+  stepId: r.step_id,
+  stepOrder: r.step_order,
+  assignedToUserId: r.assigned_to_user_id,
+  status: r.status,
+  decidedAt: r.decided_at ?? null,
+  decisionNote: r.decision_note ?? null,
+  escalatedAt: r.escalated_at ?? null,
+  createdAt: r.created_at,
+  updatedAt: r.updated_at,
+  changeType: r.change_type,
+  targetEntityType: r.target_entity_type,
+  targetEntityId: r.target_entity_id ?? null,
+  proposedPayload: (() => {
+    try {
+      return typeof r.proposed_payload === 'string'
+        ? JSON.parse(r.proposed_payload)
+        : r.proposed_payload;
+    } catch {
+      return {};
+    }
+  })(),
+  justification: r.justification ?? null,
+  proposerUserId: r.proposer_user_id,
+});
+
+export class PendingApprovalService {
+  constructor(private pool: Pool) {}
+
+  async listForUser(userId: number, status?: string): Promise<PendingApprovalWithContext[]> {
+    const params: (number | string)[] = [userId];
+    let statusClause = '';
+    if (status) {
+      statusClause = ' AND pa.status = ?';
+      params.push(status);
+    }
+    const [rows] = await this.pool.execute<RowDataPacket[]>(
+      `SELECT pa.*,
+              cr.change_type, cr.target_entity_type, cr.target_entity_id,
+              cr.proposed_payload, cr.justification, cr.proposer_user_id
+         FROM pending_approvals pa
+         JOIN change_requests cr ON cr.id = pa.change_request_id
+        WHERE pa.assigned_to_user_id = ?${statusClause}
+        ORDER BY pa.created_at DESC`,
+      params
+    );
+    return (rows as any[]).map(mapRow);
+  }
+
+  async countForUser(userId: number): Promise<number> {
+    const [rows] = await this.pool.execute<RowDataPacket[]>(
+      `SELECT COUNT(*) AS c
+         FROM pending_approvals
+        WHERE assigned_to_user_id = ? AND status = 'pending'`,
+      [userId]
+    );
+    return ((rows[0] as any).c as number) ?? 0;
+  }
+}

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -488,6 +488,32 @@ export interface ChangeRequestFilters {
   offset?: number;
 }
 
+export type PendingApprovalStatus = 'pending' | 'approved' | 'rejected' | 'escalated' | 'skipped';
+
+export interface PendingApproval {
+  id: number;
+  changeRequestId: number;
+  workflowId: number;
+  stepId: number;
+  stepOrder: number;
+  assignedToUserId: number;
+  status: PendingApprovalStatus;
+  decidedAt: string | null;
+  decisionNote: string | null;
+  escalatedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface PendingApprovalWithContext extends PendingApproval {
+  changeType: string;
+  targetEntityType: string;
+  targetEntityId: number | null;
+  proposedPayload: Record<string, unknown>;
+  justification: string | null;
+  proposerUserId: number;
+}
+
 // System Settings Types
 export interface SystemSetting {
   id: number;


### PR DESCRIPTION
## Summary

Adds the `pending_approvals` table and wires multi-step approval workflows end-to-end. Previously `ApprovalEngineService` could model workflows but had no way to persist or advance per-step decisions.

**Schema:** `pending_approvals(id, change_request_id, workflow_id, step_id, step_order, assigned_to_user_id, status, decided_at, decision_note, escalated_at)` with indexes on `(assigned_to_user_id, status)` and `(change_request_id, step_order)`.

**`ApprovalEngineService`:** adds `resolveApproverForStep(stepId, ctx)` — public method that resolves the approver for a specific step by ID.

**`ChangeRequestService`:**
- `create()`: after inserting the change request, looks up the matching workflow and inserts the first `pending_approval` row when an approver is resolved
- `advancePendingApproval(id, userId, decision, note?)`: marks current step approved/rejected; auto-advances to next step or transitions the change request to `approved`/`rejected` when all steps are decided

**`PendingApprovalService`:** read-side `listForUser(userId, status?)` and `countForUser(userId)`.

**API routes:**
- `GET /api/pending-approvals` — list pending approvals for the authenticated user
- `GET /api/pending-approvals/count` — badge count
- `POST /api/pending-approvals/:id/approve`
- `POST /api/pending-approvals/:id/reject`

## Test plan

- [ ] `npm test` passes (6 advancePendingApproval tests + 11 route tests)
- [ ] create() inserts first pending_approval when a workflow matches the change type
- [ ] reject path sets change request to rejected and writes audit log
- [ ] approve with next step inserts new pending_approval for the next approver
- [ ] approve final step transitions change request to approved