### PR TITLE
feat: enforce delegation org-unit scope in RbacService

### DIFF
--- a/backend/src/__tests__/rbac.service.extended.test.ts
+++ b/backend/src/__tests__/rbac.service.extended.test.ts
@@ -832,3 +832,72 @@ describe('RbacService.getRoleIdByName', () => {
     await expect(svc.getRoleIdByName('Admin')).rejects.toThrow('timeout');
   });
 });
+
+// ---------------------------------------------------------------------------
+// getEffectiveDelegationScopes
+// ---------------------------------------------------------------------------
+
+describe('RbacService.getEffectiveDelegationScopes', () => {
+  it('returns empty array when user has no scoped delegations', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[], null]); // delegations query → none
+
+    const svc = new RbacService(pool);
+    const scopes = await svc.getEffectiveDelegationScopes(10);
+    expect(scopes).toEqual([]);
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves org-unit subtree for each scoped delegation', async () => {
+    const { pool, execute } = makePool();
+    execute
+      // Delegations query — one row with scope_org_unit_id = 5
+      .mockResolvedValueOnce([
+        [{ permission_codes: JSON.stringify(['schedule.manage', 'timeoff.approve']), scope_org_unit_id: 5 }],
+        null,
+      ])
+      // getDescendantOrgUnitIds(5) — CTE returns [5, 10, 11]
+      .mockResolvedValueOnce([[{ id: 5 }, { id: 10 }, { id: 11 }], null]);
+
+    const svc = new RbacService(pool);
+    const scopes = await svc.getEffectiveDelegationScopes(10);
+
+    expect(scopes).toHaveLength(2);
+    const scheduleScope = scopes.find((s) => s.permissionCode === 'schedule.manage')!;
+    expect(scheduleScope.allowedOrgUnitIds).toEqual(expect.arrayContaining([5, 10, 11]));
+    const timeoffScope = scopes.find((s) => s.permissionCode === 'timeoff.approve')!;
+    expect(timeoffScope.allowedOrgUnitIds).toEqual(expect.arrayContaining([5, 10, 11]));
+  });
+
+  it('merges allowedOrgUnitIds for the same permissionCode across multiple delegations', async () => {
+    const { pool, execute } = makePool();
+    execute
+      .mockResolvedValueOnce([
+        [
+          { permission_codes: JSON.stringify(['schedule.manage']), scope_org_unit_id: 5 },
+          { permission_codes: JSON.stringify(['schedule.manage']), scope_org_unit_id: 20 },
+        ],
+        null,
+      ])
+      .mockResolvedValueOnce([[{ id: 5 }], null])   // subtree for org 5
+      .mockResolvedValueOnce([[{ id: 20 }], null]);  // subtree for org 20
+
+    const svc = new RbacService(pool);
+    const scopes = await svc.getEffectiveDelegationScopes(7);
+
+    expect(scopes).toHaveLength(1); // merged into one entry
+    expect(scopes[0].permissionCode).toBe('schedule.manage');
+    expect(scopes[0].allowedOrgUnitIds).toEqual(expect.arrayContaining([5, 20]));
+  });
+
+  it('only queries delegations with scope_org_unit_id IS NOT NULL', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[], null]);
+
+    const svc = new RbacService(pool);
+    await svc.getEffectiveDelegationScopes(99);
+
+    const [sql] = execute.mock.calls[0];
+    expect(sql).toContain('scope_org_unit_id IS NOT NULL');
+  });
+});

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -161,6 +161,10 @@ export const authenticate = async (req: Request, res: Response, next: NextFuncti
     // roles this is a no-op (null = full access, zero extra queries).
     user.allowedOrgUnitIds = await rbac.computeAllowedOrgUnitIds(roles);
 
+    // Compute per-permission org-unit restrictions from scoped delegations.
+    // Empty array is the common case — no extra work when no scoped delegations exist.
+    user.delegationScopes = await rbac.getEffectiveDelegationScopes(userId);
+
     req.user = user;
 
     logger.debug('User authenticated', { userId: user.id });

--- a/backend/src/services/RbacService.ts
+++ b/backend/src/services/RbacService.ts
@@ -363,6 +363,46 @@ export class RbacService {
     return [...new Set(subtrees.flat())];
   }
 
+  /**
+   * Returns the per-permission org-unit restrictions that apply to this user
+   * through their active, scoped delegations. Entries are merged by permission
+   * code so callers receive one entry per code with the union of allowed org
+   * units across all matching delegations.
+   *
+   * Returns an empty array when the user has no scoped delegations.
+   */
+  async getEffectiveDelegationScopes(
+    userId: number
+  ): Promise<Array<{ permissionCode: string; allowedOrgUnitIds: number[] }>> {
+    const [rows] = await this.pool.execute<RowDataPacket[]>(
+      `SELECT d.permission_codes, d.scope_org_unit_id
+         FROM delegations d
+        WHERE d.delegatee_id = ? AND d.is_active = TRUE
+          AND d.starts_at <= NOW() AND d.expires_at > NOW()
+          AND d.scope_org_unit_id IS NOT NULL`,
+      [userId]
+    );
+    if ((rows as any[]).length === 0) return [];
+
+    // Build { permissionCode → Set<orgUnitId> } by expanding each delegation's
+    // scope_org_unit_id to include all descendants.
+    const merged = new Map<string, Set<number>>();
+    for (const row of rows as any[]) {
+      const codes: string[] = JSON.parse(row.permission_codes as string);
+      const scopeId: number = row.scope_org_unit_id as number;
+      const allowed = await this.getDescendantOrgUnitIds(scopeId);
+      for (const code of codes) {
+        if (!merged.has(code)) merged.set(code, new Set());
+        for (const id of allowed) merged.get(code)!.add(id);
+      }
+    }
+
+    return Array.from(merged.entries()).map(([permissionCode, ids]) => ({
+      permissionCode,
+      allowedOrgUnitIds: Array.from(ids),
+    }));
+  }
+
   /** Resolves a role id from its (unique) name. Useful for seeding/import. */
   async getRoleIdByName(name: string): Promise<number | null> {
     const [rows] = await this.pool.execute<RowDataPacket[]>(

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -29,6 +29,13 @@ export interface User {
    * valid org unit, so they can access nothing.
    */
   allowedOrgUnitIds?: number[] | null;
+  /**
+   * Per-permission org-unit restrictions introduced by scoped delegations.
+   * Only populated when the user holds at least one delegation with
+   * scope_org_unit_id set.  Route handlers that perform org-unit gating should
+   * check this before allowing a delegated permission to act outside its scope.
+   */
+  delegationScopes?: Array<{ permissionCode: string; allowedOrgUnitIds: number[] }>;
   departments?: UserDepartment[];
   /** Convenience field: name of the user's primary department (populated by list queries). */
   department?: string;


### PR DESCRIPTION
## Summary

- Add `getEffectiveDelegationScopes()` to `RbacService`: resolves per-permission org-unit restrictions from active scoped delegations (`scope_org_unit_id IS NOT NULL`), expanding each scope to include descendant org units via the existing recursive CTE helper.
- Wire the result into the `authenticate` middleware: `user.delegationScopes` is populated on every request so route handlers can gate delegated permissions to the correct org-unit subtree.
- Add `User.delegationScopes` field to `backend/src/types/index.ts`.
- Add 4 unit tests covering: empty result, subtree expansion, multi-delegation merge, and SQL filter correctness.

Closes #101