### PR TITLE
feat: audit log immutability enforcement and CSV/JSON export endpoint

### DIFF
--- a/backend/database/init.sql
+++ b/backend/database/init.sql
@@ -627,6 +627,22 @@ CREATE TABLE IF NOT EXISTS audit_logs (
     FOREIGN KEY (on_behalf_of_user_id) REFERENCES users(id) ON DELETE SET NULL
 );
 
+-- Immutability triggers: audit_logs rows are append-only. Any attempt to
+-- UPDATE or DELETE a row raises SQLSTATE '45000' with a descriptive message.
+DROP TRIGGER IF EXISTS trg_audit_logs_no_update;
+CREATE TRIGGER trg_audit_logs_no_update
+BEFORE UPDATE ON audit_logs
+FOR EACH ROW
+  SIGNAL SQLSTATE '45000'
+    SET MESSAGE_TEXT = 'audit_logs rows are immutable and cannot be updated';
+
+DROP TRIGGER IF EXISTS trg_audit_logs_no_delete;
+CREATE TRIGGER trg_audit_logs_no_delete
+BEFORE DELETE ON audit_logs
+FOR EACH ROW
+  SIGNAL SQLSTATE '45000'
+    SET MESSAGE_TEXT = 'audit_logs rows are immutable and cannot be deleted';
+
 -- ================================================================
 -- ORG UNITS TABLE - Hierarchical organizational tree
 -- Each unit has an optional parent (self-FK) and an optional manager.

--- a/backend/src/__tests__/approval.engine.extended.test.ts
+++ b/backend/src/__tests__/approval.engine.extended.test.ts
@@ -395,34 +395,36 @@ describe('ApprovalEngineService.resolveApprover — additional scopes', () => {
 // ──────────────────────────────────────────────────────────────────────────────
 
 describe('ApprovalEngineService.processEscalations — default now', () => {
-  it('uses the current ISO timestamp when no arg is supplied', async () => {
+  it('returns empty result when no overdue items exist', async () => {
     const { pool, execute } = makePool();
     execute.mockResolvedValueOnce([[], null]);
 
     const svc = new ApprovalEngineService(pool);
-    const before = new Date();
-    await svc.processEscalations();
-    const after = new Date();
+    const result = await svc.processEscalations();
 
-    const passedTimestamp = execute.mock.calls[0][1]![0] as string;
-    const ts = new Date(passedTimestamp);
-    expect(ts.getTime()).toBeGreaterThanOrEqual(before.getTime() - 1000);
-    expect(ts.getTime()).toBeLessThanOrEqual(after.getTime() + 1000);
+    expect(result.escalated).toBe(0);
+    expect(result.items).toHaveLength(0);
+    // Uses NOW() in SQL so no timestamp param is needed
+    expect(execute.mock.calls[0][1]).toEqual([]);
   });
 
   it('returns multiple overdue items', async () => {
     const { pool, execute } = makePool();
-    execute.mockResolvedValueOnce([[
-      { workflow_id: 1, step_id: 1, change_type: 'TimeOff.Request' },
-      { workflow_id: 2, step_id: 3, change_type: 'Loan.Request' },
-    ], null]);
+    execute
+      .mockResolvedValueOnce([[
+        { id: 1, change_request_id: 5, workflow_id: 1, step_id: 1, step_order: 1, assigned_to_user_id: 10, escalate_after_hours: 24, manager_id: 11 },
+        { id: 2, change_request_id: 6, workflow_id: 2, step_id: 3, step_order: 1, assigned_to_user_id: 20, escalate_after_hours: 48, manager_id: null },
+      ], null])
+      .mockResolvedValueOnce([{ affectedRows: 1 }, null])  // UPDATE row 1
+      .mockResolvedValueOnce([{ insertId: 10 }, null])     // INSERT escalated for row 1
+      .mockResolvedValueOnce([{ affectedRows: 1 }, null])  // UPDATE row 2 (no manager → no INSERT)
 
     const svc = new ApprovalEngineService(pool);
-    const result = await svc.processEscalations('2030-01-01T00:00:00Z');
+    const result = await svc.processEscalations();
 
-    expect(result).toHaveLength(2);
-    expect(result[1].changeType).toBe('Loan.Request');
-    expect(result[1].workflowId).toBe(2);
-    expect(result[1].stepId).toBe(3);
+    expect(result.escalated).toBe(2);
+    expect(result.items).toHaveLength(2);
+    expect(result.items[0].pendingApprovalId).toBe(1);
+    expect(result.items[1].pendingApprovalId).toBe(2);
   });
 });

--- a/backend/src/__tests__/approval.engine.test.ts
+++ b/backend/src/__tests__/approval.engine.test.ts
@@ -108,26 +108,31 @@ describe('ApprovalEngineService.resolveApprover', () => {
 });
 
 describe('ApprovalEngineService.processEscalations', () => {
-  it('returns overdue workflow steps', async () => {
+  it('escalates overdue pending approvals and returns a summary', async () => {
     const { pool, execute } = makePool();
+    // SELECT overdue rows
     execute.mockResolvedValueOnce([[
-      { workflow_id: 1, step_id: 1, change_type: 'TimeOff.Request' },
+      { id: 1, change_request_id: 10, workflow_id: 2, step_id: 3, step_order: 1,
+        assigned_to_user_id: 5, escalate_after_hours: 24, manager_id: 7 },
     ], null]);
+    execute.mockResolvedValueOnce([{ affectedRows: 1 }, null]);  // UPDATE
+    execute.mockResolvedValueOnce([{ insertId: 50 }, null]);     // INSERT
 
     const svc = new ApprovalEngineService(pool);
-    const overdue = await svc.processEscalations('2030-01-01T00:00:00Z');
+    const result = await svc.processEscalations();
 
-    expect(overdue).toHaveLength(1);
-    expect(overdue[0].changeType).toBe('TimeOff.Request');
+    expect(result.escalated).toBe(1);
+    expect(result.items[0]).toMatchObject({ pendingApprovalId: 1, changeRequestId: 10, escalatedToUserId: 7 });
   });
 
-  it('returns empty array when nothing is overdue', async () => {
+  it('returns { escalated: 0, items: [] } when nothing is overdue', async () => {
     const { pool, execute } = makePool();
     execute.mockResolvedValueOnce([[], null]);
 
     const svc = new ApprovalEngineService(pool);
-    const overdue = await svc.processEscalations('2020-01-01T00:00:00Z');
+    const result = await svc.processEscalations();
 
-    expect(overdue).toHaveLength(0);
+    expect(result.escalated).toBe(0);
+    expect(result.items).toHaveLength(0);
   });
 });

--- a/backend/src/__tests__/audit.hardening.test.ts
+++ b/backend/src/__tests__/audit.hardening.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Audit log hardening tests — immutability enforcement + export.
+ *
+ * B1 — Immutability:
+ *   - AuditLogService exposes no delete/update public methods
+ *   - write() is insert-only and never calls UPDATE or DELETE
+ *
+ * B4 — Export:
+ *   - exportAll() returns all entries matching filters (no limit/offset)
+ *   - exportAll() uses ASC ordering (chronological for compliance)
+ *   - AuditLogService.toCsv() produces correct CSV output
+ *   - AuditLogService.toCsv() escapes fields containing commas/quotes
+ *   - exportAll() with format validation (route-level tested separately)
+ */
+
+import { AuditLogService } from '../services/AuditLogService';
+
+// Shared pool helper
+const makePool = () => {
+  const execute = jest.fn();
+  return { pool: { execute } as unknown as import('mysql2/promise').Pool, execute };
+};
+
+// ---------------------------------------------------------------------------
+// B1 — Immutability
+// ---------------------------------------------------------------------------
+
+describe('AuditLogService — immutability enforcement (application layer)', () => {
+  it('does not expose a delete() method', () => {
+    const { pool } = makePool();
+    const svc = new AuditLogService(pool);
+    expect((svc as any).delete).toBeUndefined();
+    expect((svc as any).deleteById).toBeUndefined();
+  });
+
+  it('does not expose an update() method', () => {
+    const { pool } = makePool();
+    const svc = new AuditLogService(pool);
+    expect((svc as any).update).toBeUndefined();
+    expect((svc as any).updateById).toBeUndefined();
+  });
+
+  it('write() only issues INSERT statements, never UPDATE or DELETE', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValue([{ insertId: 1 }, null]);
+
+    const svc = new AuditLogService(pool);
+    await svc.write({ actorId: 1, action: 'test.action' });
+
+    for (const [sql] of execute.mock.calls as [string, ...unknown[]][]) {
+      expect(sql.toUpperCase()).not.toMatch(/^\s*(UPDATE|DELETE)\s/);
+    }
+    expect(execute.mock.calls[0][0]).toContain('INSERT INTO audit_logs');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// B4 — Export
+// ---------------------------------------------------------------------------
+
+const entry = (overrides: Record<string, unknown> = {}) => ({
+  id: 1,
+  user_id: 10,
+  on_behalf_of_user_id: null,
+  action: 'role.grant',
+  entity_type: 'user',
+  entity_id: 5,
+  description: 'Role 2 granted',
+  justification: 'Team restructuring',
+  before_snapshot: null,
+  after_snapshot: JSON.stringify({ roleId: 2 }),
+  ip_address: '127.0.0.1',
+  user_agent: 'test-agent',
+  request_id: 'req-abc',
+  created_at: '2026-06-01T10:00:00.000Z',
+  ...overrides,
+});
+
+describe('AuditLogService.exportAll', () => {
+  it('returns all entries without limit/offset', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[entry(), entry({ id: 2 }), entry({ id: 3 })], null]);
+
+    const svc = new AuditLogService(pool);
+    const result = await svc.exportAll({});
+
+    expect(result).toHaveLength(3);
+    // Verify SELECT does NOT contain LIMIT or OFFSET clauses.
+    const [sql] = execute.mock.calls[0] as [string, ...unknown[]];
+    expect(sql.toUpperCase()).not.toContain('LIMIT');
+    expect(sql.toUpperCase()).not.toContain('OFFSET');
+  });
+
+  it('uses ASC ordering for chronological compliance record', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[], null]);
+
+    const svc = new AuditLogService(pool);
+    await svc.exportAll({});
+
+    const [sql] = execute.mock.calls[0] as [string, ...unknown[]];
+    expect(sql).toContain('ORDER BY created_at ASC');
+  });
+
+  it('applies userId filter to the query', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[], null]);
+
+    const svc = new AuditLogService(pool);
+    await svc.exportAll({ userId: 42 });
+
+    const [sql, params] = execute.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain('user_id = ?');
+    expect(params).toContain(42);
+  });
+
+  it('applies fromDate and toDate filters', async () => {
+    const { pool, execute } = makePool();
+    execute.mockResolvedValueOnce([[], null]);
+
+    const svc = new AuditLogService(pool);
+    await svc.exportAll({ fromDate: '2026-01-01', toDate: '2026-12-31' });
+
+    const [, params] = execute.mock.calls[0] as [string, unknown[]];
+    expect(params).toContain('2026-01-01');
+    expect(params).toContain('2026-12-31');
+  });
+});
+
+describe('AuditLogService.toCsv', () => {
+  it('produces a header row plus one data row per entry', () => {
+    const entries = [entry(), entry({ id: 2 })].map((e) => ({
+      id: e.id as number,
+      userId: e.user_id as number | null,
+      onBehalfOfUserId: e.on_behalf_of_user_id as number | null,
+      action: e.action as string,
+      entityType: e.entity_type as string | null,
+      entityId: e.entity_id as number | null,
+      description: e.description as string | null,
+      justification: e.justification as string | null,
+      beforeSnapshot: null,
+      afterSnapshot: { roleId: 2 },
+      ipAddress: e.ip_address as string | null,
+      userAgent: e.user_agent as string | null,
+      requestId: e.request_id as string | null,
+      createdAt: e.created_at as string,
+    }));
+
+    const csv = AuditLogService.toCsv(entries);
+    const lines = csv.split('\r\n').filter(Boolean);
+
+    expect(lines).toHaveLength(3); // 1 header + 2 data rows
+    expect(lines[0]).toContain('id');
+    expect(lines[0]).toContain('action');
+    expect(lines[0]).toContain('justification');
+  });
+
+  it('wraps fields containing commas in double quotes', () => {
+    const e = {
+      id: 1,
+      userId: null, onBehalfOfUserId: null,
+      action: 'test',
+      entityType: null, entityId: null,
+      description: 'Changed name, title',
+      justification: null,
+      beforeSnapshot: null, afterSnapshot: null,
+      ipAddress: null, userAgent: null, requestId: null,
+      createdAt: '2026-01-01T00:00:00Z',
+    };
+    const csv = AuditLogService.toCsv([e]);
+    expect(csv).toContain('"Changed name, title"');
+  });
+
+  it('escapes internal double quotes by doubling them', () => {
+    const e = {
+      id: 1,
+      userId: null, onBehalfOfUserId: null,
+      action: 'test',
+      entityType: null, entityId: null,
+      description: 'He said "approved"',
+      justification: null,
+      beforeSnapshot: null, afterSnapshot: null,
+      ipAddress: null, userAgent: null, requestId: null,
+      createdAt: '2026-01-01T00:00:00Z',
+    };
+    const csv = AuditLogService.toCsv([e]);
+    expect(csv).toContain('"He said ""approved"""');
+  });
+
+  it('returns only the header row for an empty entry array', () => {
+    const csv = AuditLogService.toCsv([]);
+    const lines = csv.split('\r\n').filter(Boolean);
+    expect(lines).toHaveLength(1);
+  });
+});

--- a/backend/src/__tests__/changeRequest.service.test.ts
+++ b/backend/src/__tests__/changeRequest.service.test.ts
@@ -156,6 +156,9 @@ describe('ChangeRequestService.create', () => {
       .mockResolvedValueOnce([{ insertId: 7, affectedRows: 1 }, null])  // INSERT change_request
       .mockResolvedValueOnce([[buildRow({ id: 7 })], null])               // getById
       .mockResolvedValueOnce([{ insertId: 99, affectedRows: 1 }, null])   // audit.write
+      .mockResolvedValueOnce([[], null])                                   // resolveProposerContext — orgUnit
+      .mockResolvedValueOnce([[], null])                                   // resolveProposerContext — depts
+      .mockResolvedValueOnce([[], null])                                   // resolveProposerContext — roles
       .mockResolvedValueOnce([[], null]);                                  // getWorkflowByChangeType → no workflow
 
     const svc = new ChangeRequestService(pool);
@@ -178,6 +181,9 @@ describe('ChangeRequestService.create', () => {
       .mockResolvedValueOnce([{ insertId: 1, affectedRows: 1 }, null])
       .mockResolvedValueOnce([[buildRow()], null])
       .mockResolvedValueOnce([{ insertId: 1, affectedRows: 1 }, null])   // audit
+      .mockResolvedValueOnce([[], null])                                   // resolveProposerContext — orgUnit
+      .mockResolvedValueOnce([[], null])                                   // resolveProposerContext — depts
+      .mockResolvedValueOnce([[], null])                                   // resolveProposerContext — roles
       .mockResolvedValueOnce([[], null]);                                  // getWorkflowByChangeType → no workflow
 
     const svc = new ChangeRequestService(pool);
@@ -198,6 +204,9 @@ describe('ChangeRequestService.create', () => {
       .mockResolvedValueOnce([{ insertId: 1, affectedRows: 1 }, null])
       .mockResolvedValueOnce([[buildRow()], null])
       .mockResolvedValueOnce([{ insertId: 99, affectedRows: 1 }, null])
+      .mockResolvedValueOnce([[], null])  // resolveProposerContext — orgUnit
+      .mockResolvedValueOnce([[], null])  // resolveProposerContext — depts
+      .mockResolvedValueOnce([[], null])  // resolveProposerContext — roles
       .mockResolvedValueOnce([[], null]); // getWorkflowByChangeType → no workflow
 
     const svc = new ChangeRequestService(pool);
@@ -206,7 +215,7 @@ describe('ChangeRequestService.create', () => {
       5
     );
 
-    expect(execute).toHaveBeenCalledTimes(4);
+    expect(execute).toHaveBeenCalledTimes(7);
     const [auditSql] = execute.mock.calls[2];
     expect(auditSql).toContain('INSERT INTO audit_logs');
   });
@@ -226,6 +235,9 @@ describe('ChangeRequestService.create', () => {
       .mockResolvedValueOnce([{ insertId: 7 }, null])          // INSERT change_request
       .mockResolvedValueOnce([[buildRow({ id: 7 })], null])     // getById
       .mockResolvedValueOnce([{ insertId: 99 }, null])          // audit.write
+      .mockResolvedValueOnce([[], null])                         // resolveProposerContext — orgUnit
+      .mockResolvedValueOnce([[], null])                         // resolveProposerContext — depts
+      .mockResolvedValueOnce([[], null])                         // resolveProposerContext — roles
       .mockResolvedValueOnce([[workflowRow], null])              // getWorkflowByChangeType
       .mockResolvedValueOnce([[stepRow], null])                  // hydrateWorkflow steps
       .mockResolvedValueOnce([[stepRow], null])                  // resolveApproverForStep SELECT
@@ -503,6 +515,9 @@ describe('ChangeRequestService.advancePendingApproval', () => {
       .mockResolvedValueOnce([{ affectedRows: 1 }, null])        // UPDATE pending_approval → approved
       .mockResolvedValueOnce([[buildRow()], null])                // getById change_request
       .mockResolvedValueOnce([[nextStepRow], null])               // SELECT next step from approval_steps
+      .mockResolvedValueOnce([[], null])                          // resolveProposerContext — orgUnit
+      .mockResolvedValueOnce([[], null])                          // resolveProposerContext — depts
+      .mockResolvedValueOnce([[], null])                          // resolveProposerContext — roles
       .mockResolvedValueOnce([[nextStepFullRow], null])           // resolveApproverForStep SELECT
       .mockResolvedValueOnce([{ insertId: 6 }, null])            // INSERT next pending_approval
       .mockResolvedValueOnce([[buildPaRow({ status: 'approved' })], null])  // getPendingApprovalById refresh

--- a/backend/src/__tests__/delegation.service.extended.test.ts
+++ b/backend/src/__tests__/delegation.service.extended.test.ts
@@ -51,7 +51,7 @@ describe('DelegationService.createDelegation — additional paths', () => {
     const { pool, execute } = makePool();
     execute
       .mockResolvedValueOnce([{ insertId: 1, affectedRows: 1 }, null])  // INSERT delegation
-      .mockResolvedValueOnce([[], null])                                  // audit_logs INSERT
+      .mockResolvedValueOnce([{ insertId: 1 }, null])                    // audit_logs INSERT
       .mockResolvedValueOnce([[makeDelegationRow()], null]);               // getDelegationById
 
     const svc = new DelegationService(pool);
@@ -71,7 +71,7 @@ describe('DelegationService.createDelegation — additional paths', () => {
     const { pool, execute } = makePool();
     execute
       .mockResolvedValueOnce([{ insertId: 42, affectedRows: 1 }, null])  // INSERT delegation
-      .mockResolvedValueOnce([[], null])                                   // audit INSERT
+      .mockResolvedValueOnce([{ insertId: 1 }, null])                     // audit INSERT
       .mockResolvedValueOnce([[makeDelegationRow({ id: 42 })], null]);     // getDelegationById
 
     const svc = new DelegationService(pool);
@@ -84,7 +84,7 @@ describe('DelegationService.createDelegation — additional paths', () => {
     // Second execute call should be the audit_logs INSERT
     expect(execute.mock.calls[1][0]).toContain('INSERT INTO audit_logs');
     const auditArgs = execute.mock.calls[1][1] as unknown[];
-    expect(auditArgs[1]).toBe('delegation.grant');
+    expect(auditArgs[2]).toBe('delegation.grant');
   });
 
   it('still resolves even if audit log INSERT fails (silent error)', async () => {
@@ -116,7 +116,7 @@ describe('DelegationService.revokeDelegation — happy path', () => {
     execute
       .mockResolvedValueOnce([[{ id: 1, delegator_id: 10 }], null])  // SELECT
       .mockResolvedValueOnce([{ affectedRows: 1 }, null])             // UPDATE is_active
-      .mockResolvedValueOnce([[], null]);                              // audit INSERT
+      .mockResolvedValueOnce([{ insertId: 1 }, null]);                // audit INSERT
 
     const svc = new DelegationService(pool);
     await expect(svc.revokeDelegation(1, 10)).resolves.toBeUndefined();
@@ -127,7 +127,7 @@ describe('DelegationService.revokeDelegation — happy path', () => {
 
     // Audit log call
     expect(execute.mock.calls[2][0]).toContain('INSERT INTO audit_logs');
-    expect(execute.mock.calls[2][1]![1]).toBe('delegation.revoke');
+    expect(execute.mock.calls[2][1]![2]).toBe('delegation.revoke');
   });
 });
 

--- a/backend/src/__tests__/module.service.test.ts
+++ b/backend/src/__tests__/module.service.test.ts
@@ -112,7 +112,8 @@ describe('ModuleService.getByCode', () => {
 describe('ModuleService.setEnabled', () => {
   it('throws when the module code does not exist (affectedRows = 0)', async () => {
     const { pool, execute } = makePool();
-    execute.mockResolvedValueOnce([{ affectedRows: 0 }, null]);
+    execute.mockResolvedValueOnce([[], null]);                   // getByCode before-snapshot
+    execute.mockResolvedValueOnce([{ affectedRows: 0 }, null]); // UPDATE
 
     const svc = new ModuleService(pool);
     await expect(svc.setEnabled('ghost', true)).rejects.toThrow(/Module not found/);
@@ -120,28 +121,36 @@ describe('ModuleService.setEnabled', () => {
 
   it('enables a module, invalidates the cache, and returns the updated module', async () => {
     const { pool, execute } = makePool();
+    // getByCode before-snapshot
+    execute.mockResolvedValueOnce([[enabledRow], null]);
     // UPDATE
     execute.mockResolvedValueOnce([{ affectedRows: 1 }, null]);
     // getByCode after update
     execute.mockResolvedValueOnce([[enabledRow], null]);
+    // audit.write INSERT
+    execute.mockResolvedValueOnce([{ insertId: 1 }, null]);
 
     const svc = new ModuleService(pool);
     const result = await svc.setEnabled('delegation', true);
 
-    expect(execute.mock.calls[0][0]).toContain('UPDATE modules SET is_enabled');
-    expect(execute.mock.calls[0][1]).toEqual([1, 'delegation']);
+    expect(execute.mock.calls[1][0]).toContain('UPDATE modules SET is_enabled');
+    expect(execute.mock.calls[1][1]).toEqual([1, 'delegation']);
     expect(result.isEnabled).toBe(true);
   });
 
   it('disables a module, invalidates the cache, and returns the updated module', async () => {
     const { pool, execute } = makePool();
+    // getByCode before-snapshot
+    execute.mockResolvedValueOnce([[enabledRow], null]);
     execute.mockResolvedValueOnce([{ affectedRows: 1 }, null]);
     execute.mockResolvedValueOnce([[{ ...disabledRow, code: 'delegation', is_enabled: 0 }], null]);
+    // audit.write INSERT
+    execute.mockResolvedValueOnce([{ insertId: 1 }, null]);
 
     const svc = new ModuleService(pool);
     const result = await svc.setEnabled('delegation', false);
 
-    expect(execute.mock.calls[0][1]).toEqual([0, 'delegation']);
+    expect(execute.mock.calls[1][1]).toEqual([0, 'delegation']);
     expect(result.isEnabled).toBe(false);
   });
 });
@@ -200,10 +209,14 @@ describe('ModuleService.isEnabled', () => {
     const { pool, execute } = makePool();
     // First isEnabled → buildCache via list()
     execute.mockResolvedValueOnce([[enabledRow], null]);
+    // setEnabled: getByCode before-snapshot
+    execute.mockResolvedValueOnce([[enabledRow], null]);
     // setEnabled UPDATE
     execute.mockResolvedValueOnce([{ affectedRows: 1 }, null]);
-    // setEnabled getByCode
+    // setEnabled getByCode after update
     execute.mockResolvedValueOnce([[{ ...enabledRow, is_enabled: 0 }], null]);
+    // setEnabled audit.write INSERT
+    execute.mockResolvedValueOnce([{ insertId: 1 }, null]);
     // Second isEnabled → cache was nulled → buildCache via list() again
     execute.mockResolvedValueOnce([[{ ...enabledRow, is_enabled: 0 }], null]);
 
@@ -216,8 +229,8 @@ describe('ModuleService.isEnabled', () => {
     const after = await svc.isEnabled('delegation');
     expect(after).toBe(false);
 
-    // Total execute calls: list (1) + UPDATE (1) + getByCode (1) + list (1) = 4
-    expect(execute).toHaveBeenCalledTimes(4);
+    // Total: list (1) + getByCode-before (1) + UPDATE (1) + getByCode-after (1) + audit-insert (1) + list (1) = 6
+    expect(execute).toHaveBeenCalledTimes(6);
   });
 });
 

--- a/backend/src/__tests__/pagination.test.ts
+++ b/backend/src/__tests__/pagination.test.ts
@@ -94,6 +94,7 @@ jest.mock('../middleware/auth', () => ({
   authenticate: (_req: any, _res: any, next: any) => next(),
   requirePermission: () => (_req: any, _res: any, next: any) => next(),
   requireModule: () => (_req: any, _res: any, next: any) => next(),
+  requireModuleForUser: () => (_req: any, _res: any, next: any) => next(),
   userHasPermission: () => true,
 }));
 jest.mock('../services/ScheduleService');

--- a/backend/src/__tests__/routes.approvalWorkflows.test.ts
+++ b/backend/src/__tests__/routes.approvalWorkflows.test.ts
@@ -29,6 +29,7 @@ jest.mock('../middleware/auth', () => ({
     next();
   },
   requireModule: () => (_req: any, _res: any, next: any) => next(),
+  requireModuleForUser: () => (_req: any, _res: any, next: any) => next(),
   userHasPermission: (user: any, code: string) =>
     Boolean(user && user.permissions && user.permissions.includes(code)),
 }));
@@ -327,10 +328,10 @@ describe('approval workflows DELETE /:id', () => {
 
 describe('approval workflows POST /escalate', () => {
   it('returns 200 with overdue escalations', async () => {
-    const overdue = [{ workflowId: 1, stepId: 2, changeType: 'shift_swap' }];
+    const mockResult = { escalated: 1, items: [{ pendingApprovalId: 10, changeRequestId: 5, escalatedToUserId: 3 }] };
     (ApprovalEngineService.prototype.processEscalations as jest.Mock) = jest
       .fn()
-      .mockResolvedValue(overdue);
+      .mockResolvedValue(mockResult);
 
     const res = await request(mountApp())
       .post('/api/approval-workflows/escalate')
@@ -338,22 +339,23 @@ describe('approval workflows POST /escalate', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.success).toBe(true);
-    expect(res.body.data.count).toBe(1);
-    expect(res.body.data.overdue).toHaveLength(1);
+    expect(res.body.data.escalated).toBe(1);
+    expect(res.body.data.items).toHaveLength(1);
   });
 
-  it('returns 200 with a custom now timestamp', async () => {
+  it('returns 200 with no escalations', async () => {
+    const mockResult = { escalated: 0, items: [] };
     (ApprovalEngineService.prototype.processEscalations as jest.Mock) = jest
       .fn()
-      .mockResolvedValue([]);
+      .mockResolvedValue(mockResult);
 
     const res = await request(mountApp())
       .post('/api/approval-workflows/escalate')
-      .send({ now: '2026-06-07T10:00:00Z' });
+      .send({});
 
     expect(res.status).toBe(200);
-    expect(res.body.data.count).toBe(0);
-    expect(ApprovalEngineService.prototype.processEscalations).toHaveBeenCalledWith('2026-06-07T10:00:00Z');
+    expect(res.body.data.escalated).toBe(0);
+    expect(ApprovalEngineService.prototype.processEscalations).toHaveBeenCalledWith();
   });
 
   it('returns 500 on service error', async () => {

--- a/backend/src/__tests__/routes.auditLogs.test.ts
+++ b/backend/src/__tests__/routes.auditLogs.test.ts
@@ -28,6 +28,8 @@ jest.mock('../middleware/auth', () => ({
     next(),
   requireModule: (_code: string) => (_req: Request, _res: Response, next: () => void) =>
     next(),
+  requireModuleForUser: (_code: string) => (_req: Request, _res: Response, next: () => void) =>
+    next(),
 }));
 
 jest.mock('../services/AuditLogService');

--- a/backend/src/__tests__/routes.batch2.test.ts
+++ b/backend/src/__tests__/routes.batch2.test.ts
@@ -33,6 +33,7 @@ jest.mock('../middleware/auth', () => ({
   },
   requirePermission: () => (_req: any, _res: any, next: any) => next(),
   requireModule: () => (_req: any, _res: any, next: any) => next(),
+  requireModuleForUser: () => (_req: any, _res: any, next: any) => next(),
   userHasPermission: (user: any, code: string) =>
     Boolean(user?.permissions?.includes(code)),
 }));

--- a/backend/src/__tests__/routes.delegations.test.ts
+++ b/backend/src/__tests__/routes.delegations.test.ts
@@ -32,6 +32,7 @@ jest.mock('../middleware/auth', () => ({
   },
   requirePermission: () => (_req: any, _res: any, next: any) => next(),
   requireModule: () => (_req: any, _res: any, next: any) => next(),
+  requireModuleForUser: () => (_req: any, _res: any, next: any) => next(),
   userHasPermission: (user: any, code: string) =>
     Boolean(user && user.permissions && user.permissions.includes(code)),
 }));
@@ -238,7 +239,8 @@ describe('delegations router POST /', () => {
     expect(createFn).toHaveBeenCalledWith(
       1,
       expect.any(Array),
-      expect.objectContaining({ scopeOrgUnitId: 5 })
+      expect.objectContaining({ scopeOrgUnitId: 5 }),
+      null
     );
   });
 
@@ -251,7 +253,8 @@ describe('delegations router POST /', () => {
     expect(createFn).toHaveBeenCalledWith(
       1,
       expect.any(Array),
-      expect.objectContaining({ scopeOrgUnitId: null })
+      expect.objectContaining({ scopeOrgUnitId: null }),
+      null
     );
   });
 });
@@ -320,6 +323,6 @@ describe('delegations router DELETE /:id', () => {
 
     await request(mountApp()).delete('/api/delegations/7');
 
-    expect(revokeFn).toHaveBeenCalledWith(7, 3);
+    expect(revokeFn).toHaveBeenCalledWith(7, 3, null);
   });
 });

--- a/backend/src/__tests__/routes.error-handlers.test.ts
+++ b/backend/src/__tests__/routes.error-handlers.test.ts
@@ -33,6 +33,7 @@ jest.mock('../middleware/auth', () => ({
   },
   requirePermission: () => (_req: any, _res: any, next: any) => next(),
   requireModule: () => (_req: any, _res: any, next: any) => next(),
+  requireModuleForUser: () => (_req: any, _res: any, next: any) => next(),
   userHasPermission: () => true,
 }));
 

--- a/backend/src/__tests__/routes.expanded.test.ts
+++ b/backend/src/__tests__/routes.expanded.test.ts
@@ -22,6 +22,7 @@ jest.mock('../middleware/auth', () => ({
   },
   requirePermission: () => (_req: any, _res: any, next: any) => next(),
   requireModule: () => (_req: any, _res: any, next: any) => next(),
+  requireModuleForUser: () => (_req: any, _res: any, next: any) => next(),
   userHasPermission: (user: any, code: string) =>
     Boolean(user && user.permissions && user.permissions.includes(code)),
 }));

--- a/backend/src/__tests__/routes.feature.happy.test.ts
+++ b/backend/src/__tests__/routes.feature.happy.test.ts
@@ -16,6 +16,7 @@ jest.mock('../middleware/auth', () => ({
   },
   requirePermission: () => (_req: any, _res: any, next: any) => next(),
   requireModule: () => (_req: any, _res: any, next: any) => next(),
+  requireModuleForUser: () => (_req: any, _res: any, next: any) => next(),
   userHasPermission: (user: any, code: string) =>
     Boolean(user && user.permissions && user.permissions.includes(code)),
 }));

--- a/backend/src/__tests__/routes.modules.test.ts
+++ b/backend/src/__tests__/routes.modules.test.ts
@@ -45,6 +45,7 @@ jest.mock('../middleware/auth', () => ({
     next();
   },
   requireModule: () => (_req: any, _res: any, next: any) => next(),
+  requireModuleForUser: () => (_req: any, _res: any, next: any) => next(),
   userHasPermission: (user: any, code: string) =>
     Boolean(user && user.permissions && user.permissions.includes(code)),
 }));
@@ -233,6 +234,6 @@ describe('modules router PUT /:code', () => {
 
     await request(mountApp()).put('/api/modules/approvals').send({ isEnabled: false });
 
-    expect(setFn).toHaveBeenCalledWith('approvals', false);
+    expect(setFn).toHaveBeenCalledWith('approvals', false, 1, null);
   });
 });

--- a/backend/src/__tests__/routes.rbac.test.ts
+++ b/backend/src/__tests__/routes.rbac.test.ts
@@ -31,6 +31,7 @@ jest.mock('../middleware/auth', () => ({
     next();
   },
   requireModule: () => (_req: any, _res: any, next: any) => next(),
+  requireModuleForUser: () => (_req: any, _res: any, next: any) => next(),
   userHasPermission: (user: any, code: string) =>
     Boolean(user && user.permissions && user.permissions.includes(code)),
 }));
@@ -319,7 +320,7 @@ describe('rbac POST /roles/users/:userId', () => {
 
     expect(res.status).toBe(201);
     expect(res.body.success).toBe(true);
-    expect(RbacService.prototype.assignRole).toHaveBeenCalledWith(7, 2, null, null, 1);
+    expect(RbacService.prototype.assignRole).toHaveBeenCalledWith(7, 2, null, null, 1, null);
   });
 
   it('returns 201 with optional scope and expiry', async () => {
@@ -332,7 +333,7 @@ describe('rbac POST /roles/users/:userId', () => {
       .send({ roleId: 3, scopeOrgUnitId: 5, expiresAt: '2027-01-01T00:00:00Z' });
 
     expect(res.status).toBe(201);
-    expect(RbacService.prototype.assignRole).toHaveBeenCalledWith(7, 3, 5, '2027-01-01T00:00:00Z', 1);
+    expect(RbacService.prototype.assignRole).toHaveBeenCalledWith(7, 3, 5, '2027-01-01T00:00:00Z', 1, null);
   });
 
   it('returns 400 when roleId is missing', async () => {
@@ -369,7 +370,7 @@ describe('rbac DELETE /roles/users/:userId/:roleId', () => {
     const res = await request(mountApp()).delete('/api/roles/users/7/2');
     expect(res.status).toBe(200);
     expect(res.body.success).toBe(true);
-    expect(RbacService.prototype.removeRole).toHaveBeenCalledWith(7, 2, null, 1);
+    expect(RbacService.prototype.removeRole).toHaveBeenCalledWith(7, 2, null, 1, null);
   });
 
   it('returns 200 when scope query param is provided', async () => {
@@ -379,7 +380,7 @@ describe('rbac DELETE /roles/users/:userId/:roleId', () => {
 
     const res = await request(mountApp()).delete('/api/roles/users/7/2?scopeOrgUnitId=5');
     expect(res.status).toBe(200);
-    expect(RbacService.prototype.removeRole).toHaveBeenCalledWith(7, 2, 5, 1);
+    expect(RbacService.prototype.removeRole).toHaveBeenCalledWith(7, 2, 5, 1, null);
   });
 
   it('returns 400 on service error', async () => {

--- a/backend/src/__tests__/services.batch4.test.ts
+++ b/backend/src/__tests__/services.batch4.test.ts
@@ -124,8 +124,9 @@ describe('ModuleService.setEnabled — null after update', () => {
   it('throws Failed to retrieve module after update when getByCode returns null', async () => {
     const { pool, execute } = makePool();
     execute
-      .mockResolvedValueOnce([{ affectedRows: 1 }, null] as Tuple) // UPDATE modules
-      .mockResolvedValueOnce([[], null] as Tuple);                  // getByCode → null
+      .mockResolvedValueOnce([[], null] as Tuple)                   // getByCode before-snapshot → null
+      .mockResolvedValueOnce([{ affectedRows: 1 }, null] as Tuple)  // UPDATE modules
+      .mockResolvedValueOnce([[], null] as Tuple);                  // getByCode after → null
     const svc = new ModuleService(pool);
     await expect(svc.setEnabled('notifications', true)).rejects.toThrow('Failed to retrieve module after update');
   });

--- a/backend/src/__tests__/validation.middleware.test.ts
+++ b/backend/src/__tests__/validation.middleware.test.ts
@@ -121,6 +121,7 @@ jest.mock('../middleware/auth', () => ({
   authenticate: (_req: any, _res: any, next: any) => next(),
   requirePermission: () => (_req: any, _res: any, next: any) => next(),
   requireModule: () => (_req: any, _res: any, next: any) => next(),
+  requireModuleForUser: () => (_req: any, _res: any, next: any) => next(),
   userHasPermission: () => false,
 }));
 jest.mock('../services/ScheduleService');

--- a/backend/src/routes/auditLogs.ts
+++ b/backend/src/routes/auditLogs.ts
@@ -9,7 +9,7 @@ import { Router, Request, Response } from 'express';
 import { authenticate, requirePermission, requireModuleForUser } from '../middleware/auth';
 import { validateParams } from '../middleware/validation';
 import { idParam } from '../schemas';
-import { AuditLogService } from '../services/AuditLogService';
+import { AuditLogService, AuditLogFilters } from '../services/AuditLogService';
 import { logger } from '../config/logger';
 
 export const createAuditLogsRouter = (pool: Pool): Router => {
@@ -83,6 +83,57 @@ export const createAuditLogsRouter = (pool: Pool): Router => {
     } catch (error) {
       logger.error('Get audit log error:', error);
       res.status(500).json({ success: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to retrieve audit log entry' } });
+    }
+  });
+
+  /**
+   * GET /export?format=csv|json&...filters
+   *
+   * Exports all matching audit log entries without row limit. Supported
+   * formats: `csv` (application/octet-stream) and `json` (default).
+   * Same filters as GET / but without limit/offset pagination.
+   */
+  router.get('/export', async (req: Request, res: Response) => {
+    try {
+      const format = (req.query.format as string | undefined)?.toLowerCase() ?? 'json';
+      if (format !== 'csv' && format !== 'json') {
+        return res.status(400).json({ success: false, error: { code: 'VALIDATION_ERROR', message: 'format must be csv or json' } });
+      }
+
+      const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+      const rawFromDate = req.query.fromDate as string | undefined;
+      const rawToDate = req.query.toDate as string | undefined;
+      if (rawFromDate && !ISO_DATE_RE.test(rawFromDate)) {
+        return res.status(400).json({ success: false, error: { code: 'VALIDATION_ERROR', message: 'fromDate must be YYYY-MM-DD' } });
+      }
+      if (rawToDate && !ISO_DATE_RE.test(rawToDate)) {
+        return res.status(400).json({ success: false, error: { code: 'VALIDATION_ERROR', message: 'toDate must be YYYY-MM-DD' } });
+      }
+
+      const filters: Omit<AuditLogFilters, 'limit' | 'offset'> = {
+        userId: req.query.userId ? Number(req.query.userId) : undefined,
+        onBehalfOfUserId: req.query.onBehalfOfUserId ? Number(req.query.onBehalfOfUserId) : undefined,
+        action: req.query.action as string | undefined,
+        entityType: req.query.entityType as string | undefined,
+        entityId: req.query.entityId ? Number(req.query.entityId) : undefined,
+        fromDate: rawFromDate,
+        toDate: rawToDate,
+        requestId: req.query.requestId as string | undefined,
+      };
+
+      const entries = await service.exportAll(filters);
+
+      if (format === 'csv') {
+        const csv = AuditLogService.toCsv(entries);
+        res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+        res.setHeader('Content-Disposition', 'attachment; filename="audit_log_export.csv"');
+        return res.send(csv);
+      }
+
+      res.json({ success: true, data: entries, meta: { total: entries.length } });
+    } catch (error) {
+      logger.error('Audit log export error:', error);
+      res.status(500).json({ success: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to export audit logs' } });
     }
   });
 

--- a/backend/src/services/AuditLogService.ts
+++ b/backend/src/services/AuditLogService.ts
@@ -56,7 +56,7 @@ export interface WriteAuditLogInput {
   throwOnFailure?: boolean;
 }
 
-interface AuditLogFilters {
+export interface AuditLogFilters {
   userId?: number;
   onBehalfOfUserId?: number;
   action?: string;
@@ -177,6 +177,65 @@ export class AuditLogService {
       [id]
     );
     return rows.length === 0 ? null : mapRow(rows[0]);
+  }
+
+  /**
+   * Exports all audit log entries matching the given filters — without row
+   * limit. Intended for compliance exports; callers should stream or buffer
+   * the result themselves. Returns entries ordered by created_at ASC so the
+   * chronological record is preserved.
+   *
+   * @param filters Same filter options as list(), but limit/offset are ignored.
+   */
+  async exportAll(filters: Omit<AuditLogFilters, 'limit' | 'offset'> = {}): Promise<AuditLogEntry[]> {
+    const conditions: string[] = [];
+    const params: Array<string | number> = [];
+
+    if (filters.userId !== undefined) { conditions.push('user_id = ?'); params.push(filters.userId); }
+    if (filters.onBehalfOfUserId !== undefined) { conditions.push('on_behalf_of_user_id = ?'); params.push(filters.onBehalfOfUserId); }
+    if (filters.action) { conditions.push('action = ?'); params.push(filters.action); }
+    if (filters.entityType) { conditions.push('entity_type = ?'); params.push(filters.entityType); }
+    if (filters.entityId !== undefined) { conditions.push('entity_id = ?'); params.push(filters.entityId); }
+    if (filters.fromDate) { conditions.push('created_at >= ?'); params.push(filters.fromDate); }
+    if (filters.toDate) { conditions.push('created_at <= ?'); params.push(filters.toDate); }
+    if (filters.requestId) { conditions.push('request_id = ?'); params.push(filters.requestId); }
+
+    const where = conditions.length ? ` WHERE ${conditions.join(' AND ')}` : '';
+    const [rows] = await this.pool.execute<RowDataPacket[]>(
+      `SELECT * FROM audit_logs${where} ORDER BY created_at ASC`,
+      params
+    );
+    return (rows as RowDataPacket[]).map(mapRow);
+  }
+
+  /**
+   * Serialises an array of audit log entries to CSV. Includes a header row.
+   * Snapshot fields are rendered as compact JSON strings.
+   */
+  static toCsv(entries: AuditLogEntry[]): string {
+    const HEADER = [
+      'id', 'created_at', 'user_id', 'on_behalf_of_user_id', 'action',
+      'entity_type', 'entity_id', 'description', 'justification',
+      'ip_address', 'user_agent', 'request_id',
+      'before_snapshot', 'after_snapshot',
+    ];
+    const escape = (v: unknown): string => {
+      if (v === null || v === undefined) return '';
+      const s = typeof v === 'object' ? JSON.stringify(v) : String(v);
+      return s.includes(',') || s.includes('"') || s.includes('\n')
+        ? `"${s.replace(/"/g, '""')}"`
+        : s;
+    };
+    const lines = [HEADER.join(',')];
+    for (const e of entries) {
+      lines.push([
+        e.id, e.createdAt, e.userId, e.onBehalfOfUserId, e.action,
+        e.entityType, e.entityId, e.description, e.justification,
+        e.ipAddress, e.userAgent, e.requestId,
+        e.beforeSnapshot, e.afterSnapshot,
+      ].map(escape).join(','));
+    }
+    return lines.join('\r\n');
   }
 
   /**


### PR DESCRIPTION
## Summary

- Adds MySQL `BEFORE UPDATE` and `BEFORE DELETE` triggers on `audit_logs` — any attempt to mutate a log row raises `SQLSTATE '45000'`, enforcing immutability at the DB layer regardless of application code path
- `AuditLogService.exportAll(filters)` — new method that returns all matching entries without row limit, ordered ASC for compliance records
- `AuditLogService.toCsv(entries)` — static method serialising audit entries to RFC 4180 CSV with proper comma/quote escaping
- `GET /api/audit-logs/export?format=csv|json` — new export endpoint supporting the same filter set as the list endpoint; returns a CSV attachment or a JSON array
- Fixes all existing tests broken by signature changes introduced across the four feature branches (requireModuleForUser auth mocks, updated call assertions, extra DB mock calls for resolveProposerContext)

## Test plan

- [ ] `audit.hardening.test.ts` — 11 tests for immutability enforcement (application layer) and export correctness
- [ ] All 1895 tests pass

Refs: builds on [#231](https://github.com/lucaosti/StaffScheduler/pull/231); completes the four-feature series starting at [#229](https://github.com/lucaosti/StaffScheduler/pull/229)