### PR TITLE
fix: remove unused escalateBody schema export

### DIFF
--- a/backend/src/schemas/index.ts
+++ b/backend/src/schemas/index.ts
@@ -298,10 +298,6 @@ export const updatePolicyBody = z.object({
   isActive: z.boolean().optional(),
 });
 
-export const escalateBody = z.object({
-  now: z.string().optional(),
-});
-
 export const twoFactorCodeBody = z.object({
   code: z.string().min(1, 'code is required'),
 });


### PR DESCRIPTION
Removes the `escalateBody` Zod schema that was left over after the escalation endpoint was simplified to take no body parameters. Flagged by knip dead-code check in CI.