### PR TITLE
feat: add Module Management UI to Settings

### DIFF
--- a/frontend/src/pages/Settings/ModulesSection.test.tsx
+++ b/frontend/src/pages/Settings/ModulesSection.test.tsx
@@ -1,0 +1,202 @@
+/**
+ * Tests for ModulesSection (Settings → Modules tab, admin only).
+ *
+ * @author Luca Ostinelli
+ */
+
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ModulesSection from './ModulesSection';
+
+const mockListModules = jest.fn();
+const mockListModulesForOrg = jest.fn();
+const mockSetModuleEnabled = jest.fn();
+const mockSetModuleOrgOverride = jest.fn();
+const mockRemoveModuleOrgOverride = jest.fn();
+
+jest.mock('../../services/moduleService', () => ({
+  listModules: () => mockListModules(),
+  listModulesForOrg: (org: string) => mockListModulesForOrg(org),
+  setModuleEnabled: (code: string, isEnabled: boolean, justification?: string) =>
+    mockSetModuleEnabled(code, isEnabled, justification),
+  setModuleOrgOverride: (code: string, org: string, isEnabled: boolean, justification?: string) =>
+    mockSetModuleOrgOverride(code, org, isEnabled, justification),
+  removeModuleOrgOverride: (code: string, org: string) => mockRemoveModuleOrgOverride(code, org),
+}));
+
+const mockUseAuth = jest.fn();
+jest.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+const MODULES = [
+  { id: 1, code: 'scheduling', name: 'Scheduling', description: 'Core scheduling', isEnabled: true, updatedAt: '2024-01-01' },
+  { id: 2, code: 'audit', name: 'Audit', description: 'Audit logging', isEnabled: false, updatedAt: '2024-01-01' },
+];
+
+const ORG_MODULES = [
+  {
+    id: 1, code: 'scheduling', name: 'Scheduling', description: null, isEnabled: true, updatedAt: '2024-01-01',
+    effectiveEnabled: false, orgOverride: false,
+  },
+  {
+    id: 2, code: 'audit', name: 'Audit', description: null, isEnabled: false, updatedAt: '2024-01-01',
+    effectiveEnabled: false, orgOverride: null,
+  },
+];
+
+beforeEach(() => {
+  mockUseAuth.mockReturnValue({ user: { id: 1, organizationName: 'Test Org' } });
+  mockListModules.mockResolvedValue({ success: true, data: MODULES });
+  mockListModulesForOrg.mockResolvedValue({ success: true, data: ORG_MODULES });
+  mockSetModuleEnabled.mockResolvedValue({ success: true, data: { ...MODULES[1], isEnabled: true } });
+  mockSetModuleOrgOverride.mockResolvedValue({ success: true, data: {} });
+  mockRemoveModuleOrgOverride.mockResolvedValue({ success: true });
+});
+
+afterEach(() => jest.clearAllMocks());
+
+describe('<ModulesSection />', () => {
+  it('shows a loading spinner initially', () => {
+    render(<ModulesSection />);
+    expect(screen.getByRole('status', { hidden: true })).toBeInTheDocument();
+  });
+
+  it('renders the global module list after loading', async () => {
+    render(<ModulesSection />);
+    expect(await screen.findByText('Scheduling')).toBeInTheDocument();
+    expect(screen.getByText('Audit')).toBeInTheDocument();
+    expect(screen.getByText('scheduling')).toBeInTheDocument();
+  });
+
+  it('shows correct enabled/disabled badges', async () => {
+    render(<ModulesSection />);
+    await screen.findByText('Scheduling');
+
+    const rows = screen.getAllByRole('row');
+    // first is header row
+    const schedulingRow = rows[1];
+    expect(within(schedulingRow).getByText('Enabled')).toBeInTheDocument();
+    const auditRow = rows[2];
+    expect(within(auditRow).getByText('Disabled')).toBeInTheDocument();
+  });
+
+  it('opens the justification modal when Disable is clicked', async () => {
+    render(<ModulesSection />);
+    await screen.findByText('Scheduling');
+
+    await userEvent.click(screen.getByRole('button', { name: /disable module scheduling/i }));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /disable module/i })).toBeInTheDocument();
+  });
+
+  it('calls setModuleEnabled with the correct args when confirmed', async () => {
+    render(<ModulesSection />);
+    await screen.findByText('Audit');
+
+    await userEvent.click(screen.getByRole('button', { name: /enable module audit/i }));
+
+    const textarea = screen.getByLabelText(/justification/i);
+    await userEvent.type(textarea, 'Needed for compliance');
+
+    await userEvent.click(screen.getByRole('button', { name: /^enable$/i }));
+
+    expect(mockSetModuleEnabled).toHaveBeenCalledWith('audit', true, 'Needed for compliance');
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    expect(await screen.findByText(/enabled globally/i)).toBeInTheDocument();
+  });
+
+  it('cancels the modal without calling the API', async () => {
+    render(<ModulesSection />);
+    await screen.findByText('Scheduling');
+
+    await userEvent.click(screen.getByRole('button', { name: /disable module scheduling/i }));
+    // Click the text "Cancel" button (not the × close button)
+    const cancelBtn = screen.getAllByRole('button', { name: /cancel/i })[0];
+    await userEvent.click(cancelBtn);
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(mockSetModuleEnabled).not.toHaveBeenCalled();
+  });
+
+  it('shows error when setModuleEnabled fails', async () => {
+    mockSetModuleEnabled.mockRejectedValue(new Error('Permission denied'));
+    render(<ModulesSection />);
+    await screen.findByText('Audit');
+
+    await userEvent.click(screen.getByRole('button', { name: /enable module audit/i }));
+    await userEvent.click(screen.getByRole('button', { name: /^enable$/i }));
+
+    expect(await screen.findByRole('alert')).toBeInTheDocument();
+    expect(await screen.findByText(/permission denied/i)).toBeInTheDocument();
+  });
+
+  it('shows error when listModules fails', async () => {
+    mockListModules.mockRejectedValue(new Error('Network error'));
+    render(<ModulesSection />);
+    expect(await screen.findByRole('alert')).toBeInTheDocument();
+    expect(await screen.findByText(/network error/i)).toBeInTheDocument();
+  });
+
+  it('loads org modules when Load button is clicked', async () => {
+    render(<ModulesSection />);
+    await screen.findByText('Scheduling');
+
+    const orgInput = screen.getByLabelText(/organisation name/i);
+    await userEvent.clear(orgInput);
+    await userEvent.type(orgInput, 'My Hospital');
+
+    await userEvent.click(screen.getByRole('button', { name: /^load$/i }));
+
+    await waitFor(() => expect(mockListModulesForOrg).toHaveBeenCalledWith('My Hospital'));
+    expect(await screen.findByText('Per-Organisation Overrides')).toBeInTheDocument();
+  });
+
+  it('calls setModuleOrgOverride when an org override is set', async () => {
+    render(<ModulesSection />);
+    await screen.findByText('Scheduling');
+
+    const orgInput = screen.getByLabelText(/organisation name/i);
+    await userEvent.clear(orgInput);
+    await userEvent.type(orgInput, 'Test Org');
+    await userEvent.click(screen.getByRole('button', { name: /^load$/i }));
+
+    // Wait for org modules to appear
+    await screen.findAllByRole('button', { name: /set org override enabled for scheduling/i });
+
+    await userEvent.click(screen.getByRole('button', { name: /set org override enabled for scheduling/i }));
+    await userEvent.click(screen.getByRole('button', { name: /^enable$/i }));
+
+    expect(mockSetModuleOrgOverride).toHaveBeenCalledWith('scheduling', 'Test Org', true, undefined);
+  });
+
+  it('calls removeModuleOrgOverride when Reset is clicked', async () => {
+    render(<ModulesSection />);
+    await screen.findByText('Scheduling');
+
+    // Preload with the user's org (pre-filled from user context)
+    await userEvent.click(screen.getByRole('button', { name: /load/i }));
+    // scheduling has orgOverride=false → Reset button should be visible (aria-label: "Reset override for Scheduling")
+    const resetBtn = await screen.findByRole('button', { name: /reset override for scheduling/i });
+    await userEvent.click(resetBtn);
+
+    expect(mockRemoveModuleOrgOverride).toHaveBeenCalled();
+    expect(await screen.findByText(/override.*removed/i)).toBeInTheDocument();
+  });
+
+  it('shows org error when listModulesForOrg fails', async () => {
+    mockListModulesForOrg.mockRejectedValue(new Error('Org not found'));
+    render(<ModulesSection />);
+    await screen.findByText('Scheduling');
+
+    await userEvent.click(screen.getByRole('button', { name: /^load$/i }));
+
+    expect(await screen.findByText(/org not found/i)).toBeInTheDocument();
+  });
+
+  it('pre-fills org name from user context', async () => {
+    render(<ModulesSection />);
+    const orgInput = (await screen.findByLabelText(/organisation name/i)) as HTMLInputElement;
+    expect(orgInput.value).toBe('Test Org');
+  });
+});

--- a/frontend/src/pages/Settings/ModulesSection.tsx
+++ b/frontend/src/pages/Settings/ModulesSection.tsx
@@ -1,0 +1,392 @@
+/**
+ * ModulesSection — Settings tab for managing runtime feature modules.
+ *
+ * Shows the global enabled/disabled state of every module and lets admins
+ * toggle them (with optional justification). A secondary panel allows
+ * per-organisation overrides: type an org name, load its effective module
+ * states, and set or remove overrides individually.
+ *
+ * @author Luca Ostinelli
+ */
+
+import React, { useEffect, useState, useCallback } from 'react';
+import { useAuth } from '../../contexts/AuthContext';
+import {
+  listModules,
+  listModulesForOrg,
+  setModuleEnabled,
+  setModuleOrgOverride,
+  removeModuleOrgOverride,
+} from '../../services/moduleService';
+import { Module, ModuleWithOrgOverride } from '../../types';
+
+interface PendingToggle {
+  code: string;
+  targetEnabled: boolean;
+  scope: 'global' | 'org';
+  org?: string;
+}
+
+const ModulesSection: React.FC = () => {
+  const { user } = useAuth();
+
+  const [modules, setModules] = useState<Module[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  // Org-override panel state
+  const [orgName, setOrgName] = useState<string>(user?.organizationName ?? '');
+  const [orgModules, setOrgModules] = useState<ModuleWithOrgOverride[]>([]);
+  const [orgLoading, setOrgLoading] = useState(false);
+  const [orgError, setOrgError] = useState<string | null>(null);
+
+  // Justification modal state
+  const [pendingToggle, setPendingToggle] = useState<PendingToggle | null>(null);
+  const [justification, setJustification] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  const loadGlobal = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await listModules();
+      if (res.success && res.data) setModules(res.data);
+      else setError('Failed to load modules.');
+    } catch (e) {
+      setError((e as Error).message ?? 'Failed to load modules.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadGlobal();
+  }, [loadGlobal]);
+
+  const loadOrgModules = async () => {
+    if (!orgName.trim()) return;
+    setOrgLoading(true);
+    setOrgError(null);
+    try {
+      const res = await listModulesForOrg(orgName.trim());
+      if (res.success && res.data) setOrgModules(res.data);
+      else setOrgError('Failed to load org modules.');
+    } catch (e) {
+      setOrgError((e as Error).message ?? 'Failed to load org modules.');
+    } finally {
+      setOrgLoading(false);
+    }
+  };
+
+  const requestToggle = (code: string, targetEnabled: boolean, scope: 'global' | 'org', org?: string) => {
+    setPendingToggle({ code, targetEnabled, scope, org });
+    setJustification('');
+  };
+
+  const confirmToggle = async () => {
+    if (!pendingToggle) return;
+    setSaving(true);
+    setSuccess(null);
+    setError(null);
+    try {
+      const { code, targetEnabled, scope, org } = pendingToggle;
+      if (scope === 'global') {
+        await setModuleEnabled(code, targetEnabled, justification || undefined);
+        await loadGlobal();
+        if (orgModules.length > 0 && orgName) await loadOrgModules();
+        setSuccess(`Module '${code}' ${targetEnabled ? 'enabled' : 'disabled'} globally.`);
+      } else if (scope === 'org' && org) {
+        await setModuleOrgOverride(code, org, targetEnabled, justification || undefined);
+        await loadOrgModules();
+        setSuccess(`Module '${code}' override set for org '${org}'.`);
+      }
+      setPendingToggle(null);
+    } catch (e) {
+      setError((e as Error).message ?? 'Failed to update module.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleRemoveOverride = async (code: string) => {
+    if (!orgName.trim()) return;
+    setSaving(true);
+    setSuccess(null);
+    setError(null);
+    try {
+      await removeModuleOrgOverride(code, orgName.trim());
+      await loadOrgModules();
+      setSuccess(`Override for module '${code}' removed; global default now applies.`);
+    } catch (e) {
+      setError((e as Error).message ?? 'Failed to remove override.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="row">
+      <div className="col-lg-10">
+        {success && (
+          <div className="alert alert-success alert-dismissible" role="status">
+            <i className="bi bi-check-circle me-2" aria-hidden="true"></i>
+            {success}
+            <button type="button" className="btn-close" onClick={() => setSuccess(null)} aria-label="Close"></button>
+          </div>
+        )}
+        {error && (
+          <div className="alert alert-danger" role="alert">
+            <i className="bi bi-exclamation-triangle me-2" aria-hidden="true"></i>
+            {error}
+          </div>
+        )}
+
+        {/* Global modules */}
+        <div className="card mb-4">
+          <div className="card-header d-flex align-items-center justify-content-between">
+            <h5 className="mb-0">
+              <i className="bi bi-toggles me-2" aria-hidden="true"></i>Global Modules
+            </h5>
+          </div>
+          <div className="card-body p-0">
+            {loading ? (
+              <div className="text-center py-4">
+                <span className="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+                <span className="ms-2">Loading modules…</span>
+              </div>
+            ) : (
+              <div className="table-responsive">
+                <table className="table table-hover mb-0">
+                  <thead className="table-light">
+                    <tr>
+                      <th scope="col">Module</th>
+                      <th scope="col">Description</th>
+                      <th scope="col" className="text-center">Status</th>
+                      <th scope="col" className="text-center">Action</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {modules.map((m) => (
+                      <tr key={m.code}>
+                        <td>
+                          <span className="fw-semibold">{m.name}</span>
+                          <br />
+                          <small className="text-muted font-monospace">{m.code}</small>
+                        </td>
+                        <td className="text-muted small">{m.description ?? '—'}</td>
+                        <td className="text-center">
+                          <span className={`badge ${m.isEnabled ? 'bg-success' : 'bg-secondary'}`}>
+                            {m.isEnabled ? 'Enabled' : 'Disabled'}
+                          </span>
+                        </td>
+                        <td className="text-center">
+                          <button
+                            className={`btn btn-sm ${m.isEnabled ? 'btn-outline-danger' : 'btn-outline-success'}`}
+                            onClick={() => requestToggle(m.code, !m.isEnabled, 'global')}
+                            aria-label={`${m.isEnabled ? 'Disable' : 'Enable'} module ${m.name}`}
+                          >
+                            {m.isEnabled ? (
+                              <><i className="bi bi-toggle-off me-1" aria-hidden="true"></i>Disable</>
+                            ) : (
+                              <><i className="bi bi-toggle-on me-1" aria-hidden="true"></i>Enable</>
+                            )}
+                          </button>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Per-org overrides */}
+        <div className="card">
+          <div className="card-header">
+            <h5 className="mb-0">
+              <i className="bi bi-building me-2" aria-hidden="true"></i>Per-Organisation Overrides
+            </h5>
+          </div>
+          <div className="card-body">
+            <p className="text-muted small mb-3">
+              An override takes priority over the global state. Remove the override to revert to the global default.
+            </p>
+            <div className="row g-2 align-items-end mb-3">
+              <div className="col-md-6">
+                <label htmlFor="orgNameInput" className="form-label">Organisation name</label>
+                <input
+                  id="orgNameInput"
+                  type="text"
+                  className="form-control"
+                  placeholder="e.g. General Hospital"
+                  value={orgName}
+                  onChange={(e) => setOrgName(e.target.value)}
+                  onKeyDown={(e) => { if (e.key === 'Enter') void loadOrgModules(); }}
+                />
+              </div>
+              <div className="col-auto">
+                <button
+                  className="btn btn-outline-primary"
+                  onClick={() => void loadOrgModules()}
+                  disabled={!orgName.trim() || orgLoading}
+                >
+                  {orgLoading ? (
+                    <><span className="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>Loading…</>
+                  ) : (
+                    <><i className="bi bi-search me-1" aria-hidden="true"></i>Load</>
+                  )}
+                </button>
+              </div>
+            </div>
+
+            {orgError && (
+              <div className="alert alert-warning" role="alert">
+                <i className="bi bi-exclamation-triangle me-2" aria-hidden="true"></i>{orgError}
+              </div>
+            )}
+
+            {orgModules.length > 0 && (
+              <div className="table-responsive">
+                <table className="table table-sm table-hover mb-0">
+                  <thead className="table-light">
+                    <tr>
+                      <th scope="col">Module</th>
+                      <th scope="col" className="text-center">Global</th>
+                      <th scope="col" className="text-center">Org Override</th>
+                      <th scope="col" className="text-center">Effective</th>
+                      <th scope="col" className="text-center">Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {orgModules.map((m) => (
+                      <tr key={m.code}>
+                        <td>
+                          <span className="fw-semibold">{m.name}</span>
+                          <small className="text-muted font-monospace ms-2">{m.code}</small>
+                        </td>
+                        <td className="text-center">
+                          <span className={`badge ${m.isEnabled ? 'bg-success' : 'bg-secondary'} bg-opacity-50`}>
+                            {m.isEnabled ? 'On' : 'Off'}
+                          </span>
+                        </td>
+                        <td className="text-center">
+                          {m.orgOverride !== null ? (
+                            <span className={`badge ${m.orgOverride ? 'bg-success' : 'bg-danger'}`}>
+                              {m.orgOverride ? 'On' : 'Off'}
+                            </span>
+                          ) : (
+                            <span className="text-muted small">—</span>
+                          )}
+                        </td>
+                        <td className="text-center">
+                          <span className={`badge ${m.effectiveEnabled ? 'bg-success' : 'bg-secondary'}`}>
+                            {m.effectiveEnabled ? 'Enabled' : 'Disabled'}
+                          </span>
+                        </td>
+                        <td className="text-center">
+                          <div className="btn-group btn-group-sm" role="group">
+                            <button
+                              className="btn btn-outline-success"
+                              onClick={() => requestToggle(m.code, true, 'org', orgName.trim())}
+                              disabled={m.orgOverride === true}
+                              aria-label={`Set org override enabled for ${m.name}`}
+                            >
+                              Enable
+                            </button>
+                            <button
+                              className="btn btn-outline-danger"
+                              onClick={() => requestToggle(m.code, false, 'org', orgName.trim())}
+                              disabled={m.orgOverride === false}
+                              aria-label={`Set org override disabled for ${m.name}`}
+                            >
+                              Disable
+                            </button>
+                            {m.orgOverride !== null && (
+                              <button
+                                className="btn btn-outline-secondary"
+                                onClick={() => void handleRemoveOverride(m.code)}
+                                aria-label={`Reset override for ${m.name}`}
+                              >
+                                Reset
+                              </button>
+                            )}
+                          </div>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Justification modal (inline) */}
+        {pendingToggle && (
+          <div
+            className="modal d-block"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="justificationModalLabel"
+          >
+            <div className="modal-dialog">
+              <div className="modal-content">
+                <div className="modal-header">
+                  <h5 className="modal-title" id="justificationModalLabel">
+                    {pendingToggle.targetEnabled ? 'Enable' : 'Disable'} module &quot;{pendingToggle.code}&quot;
+                    {pendingToggle.scope === 'org' && ` for org '${pendingToggle.org}'`}
+                  </h5>
+                  <button
+                    type="button"
+                    className="btn-close"
+                    onClick={() => setPendingToggle(null)}
+                    aria-label="Close dialog"
+                  ></button>
+                </div>
+                <div className="modal-body">
+                  <label htmlFor="justificationInput" className="form-label">
+                    Justification <span className="text-muted">(optional)</span>
+                  </label>
+                  <textarea
+                    id="justificationInput"
+                    className="form-control"
+                    rows={3}
+                    placeholder="Reason for this change…"
+                    value={justification}
+                    onChange={(e) => setJustification(e.target.value)}
+                    maxLength={1000}
+                  />
+                </div>
+                <div className="modal-footer">
+                  <button
+                    type="button"
+                    className="btn btn-secondary"
+                    onClick={() => setPendingToggle(null)}
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    className={`btn ${pendingToggle.targetEnabled ? 'btn-success' : 'btn-danger'}`}
+                    onClick={() => void confirmToggle()}
+                    disabled={saving}
+                  >
+                    {saving ? (
+                      <><span className="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>Saving…</>
+                    ) : (
+                      pendingToggle.targetEnabled ? 'Enable' : 'Disable'
+                    )}
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ModulesSection;

--- a/frontend/src/pages/Settings/Settings.test.tsx
+++ b/frontend/src/pages/Settings/Settings.test.tsx
@@ -39,6 +39,14 @@ jest.mock('../../services/calendarService', () => ({
   buildFeedUrl: jest.fn((t: string) => `http://localhost/feed.ics?token=${t}`),
 }));
 
+jest.mock('../../services/moduleService', () => ({
+  listModules: jest.fn().mockResolvedValue({ success: true, data: [] }),
+  listModulesForOrg: jest.fn().mockResolvedValue({ success: true, data: [] }),
+  setModuleEnabled: jest.fn().mockResolvedValue({ success: true, data: {} }),
+  setModuleOrgOverride: jest.fn().mockResolvedValue({ success: true, data: {} }),
+  removeModuleOrgOverride: jest.fn().mockResolvedValue({ success: true }),
+}));
+
 // eslint-disable-next-line import/first
 import Settings from './Settings';
 
@@ -145,5 +153,32 @@ describe('<Settings />', () => {
     render(<Settings />);
     await userEvent.click(screen.getByRole('button', { name: /^System$/ }));
     expect(screen.getByText(/System Configuration/)).toBeInTheDocument();
+  });
+
+  it('shows the Modules tab for admin users', () => {
+    mockUseAuth.mockReturnValue({
+      user: { id: 1, email: 'admin@x', permissions: ['settings.manage'] },
+    });
+
+    render(<Settings />);
+    expect(screen.getByRole('button', { name: /^Modules$/ })).toBeInTheDocument();
+  });
+
+  it('hides the Modules tab for non-admin users', () => {
+    mockUseAuth.mockReturnValue({
+      user: { id: 2, email: 'mgr@x', role: 'manager' },
+    });
+    render(<Settings />);
+    expect(screen.queryByRole('button', { name: /^Modules$/ })).not.toBeInTheDocument();
+  });
+
+  it('renders ModulesSection when admin clicks the Modules tab', async () => {
+    mockUseAuth.mockReturnValue({
+      user: { id: 1, email: 'admin@x', permissions: ['settings.manage'] },
+    });
+
+    render(<Settings />);
+    await userEvent.click(screen.getByRole('button', { name: /^Modules$/ }));
+    expect(screen.getByText(/Global Modules/i)).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/Settings/Settings.tsx
+++ b/frontend/src/pages/Settings/Settings.tsx
@@ -12,6 +12,7 @@ import { useAuth } from '../../contexts/AuthContext';
 import PreferencesSection from '../Settings/PreferencesSection';
 import ProfileSection from '../Settings/ProfileSection';
 import SystemSection from '../Settings/SystemSection';
+import ModulesSection from '../Settings/ModulesSection';
 import CalendarSection from '../Settings/CalendarSection';
 import { getMyPreferences, updateMyPreferences, UserPreferences } from '../../services/preferencesService';
 
@@ -42,7 +43,7 @@ const Settings: React.FC = () => {
   const { user } = useAuth();
   const isAdmin = user?.permissions?.includes('settings.manage');
 
-  const [activeTab, setActiveTab] = useState<'personal' | 'work' | 'calendar' | 'system'>('personal');
+  const [activeTab, setActiveTab] = useState<'personal' | 'work' | 'calendar' | 'system' | 'modules'>('personal');
 
   const [settings, setSettings] = useState<UserSettings>({
     personalSettings: {
@@ -166,6 +167,16 @@ const Settings: React.FC = () => {
                 </button>
               </li>
             )}
+            {isAdmin && (
+              <li className="nav-item">
+                <button
+                  className={`nav-link ${activeTab === 'modules' ? 'active' : ''}`}
+                  onClick={() => setActiveTab('modules')}
+                >
+                  <i className="bi bi-toggles me-2"></i>Modules
+                </button>
+              </li>
+            )}
           </ul>
         </div>
       </div>
@@ -193,6 +204,8 @@ const Settings: React.FC = () => {
       {activeTab === 'calendar' && <CalendarSection />}
 
       {activeTab === 'system' && isAdmin && <SystemSection />}
+
+      {activeTab === 'modules' && isAdmin && <ModulesSection />}
     </div>
   );
 };

--- a/frontend/src/services/moduleService.ts
+++ b/frontend/src/services/moduleService.ts
@@ -1,0 +1,62 @@
+/**
+ * Module service — wraps /api/modules endpoints.
+ *
+ * @author Luca Ostinelli
+ */
+
+import { ApiResponse, Module, ModuleWithOrgOverride } from '../types';
+import { getAuthHeaders, handleResponse, API_BASE_URL } from './apiUtils';
+
+export const listModules = async (): Promise<ApiResponse<Module[]>> => {
+  const res = await fetch(`${API_BASE_URL}/modules`, { method: 'GET', ...getAuthHeaders() });
+  return handleResponse<Module[]>(res);
+};
+
+export const listModulesForOrg = async (org: string): Promise<ApiResponse<ModuleWithOrgOverride[]>> => {
+  const res = await fetch(`${API_BASE_URL}/modules/org/${encodeURIComponent(org)}`, {
+    method: 'GET',
+    ...getAuthHeaders(),
+  });
+  return handleResponse<ModuleWithOrgOverride[]>(res);
+};
+
+export const setModuleEnabled = async (
+  code: string,
+  isEnabled: boolean,
+  justification?: string
+): Promise<ApiResponse<Module>> => {
+  const res = await fetch(`${API_BASE_URL}/modules/${encodeURIComponent(code)}`, {
+    method: 'PUT',
+    ...getAuthHeaders(),
+    body: JSON.stringify({ isEnabled, justification: justification || null }),
+  });
+  return handleResponse<Module>(res);
+};
+
+export const setModuleOrgOverride = async (
+  code: string,
+  org: string,
+  isEnabled: boolean,
+  justification?: string
+): Promise<ApiResponse<ModuleWithOrgOverride>> => {
+  const res = await fetch(
+    `${API_BASE_URL}/modules/${encodeURIComponent(code)}/org/${encodeURIComponent(org)}`,
+    {
+      method: 'PUT',
+      ...getAuthHeaders(),
+      body: JSON.stringify({ isEnabled, justification: justification || null }),
+    }
+  );
+  return handleResponse<ModuleWithOrgOverride>(res);
+};
+
+export const removeModuleOrgOverride = async (
+  code: string,
+  org: string
+): Promise<ApiResponse<void>> => {
+  const res = await fetch(
+    `${API_BASE_URL}/modules/${encodeURIComponent(code)}/org/${encodeURIComponent(org)}`,
+    { method: 'DELETE', ...getAuthHeaders() }
+  );
+  return handleResponse<void>(res);
+};

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -49,6 +49,7 @@ export interface User {
   resetTokenExpiry?: Date;
   notificationToken?: string;
   maxSubordinateLevel?: number;
+  organizationName?: string;
 }
 
 export interface LoginResponse {
@@ -208,9 +209,31 @@ export interface AuditLogEntry {
   id: number;
   actorId: number | null;
   actorEmail?: string;
+  onBehalfOfUserId?: number | null;
+  onBehalfOfEmail?: string;
   action: string;
   entityType: string;
   entityId?: number | null;
   description?: string;
+  justification?: string | null;
+  beforeSnapshot?: Record<string, unknown> | null;
+  afterSnapshot?: Record<string, unknown> | null;
+  ipAddress?: string | null;
+  userAgent?: string | null;
+  requestId?: string | null;
   createdAt: string;
+}
+
+export interface Module {
+  id: number;
+  code: string;
+  name: string;
+  description: string | null;
+  isEnabled: boolean;
+  updatedAt: string;
+}
+
+export interface ModuleWithOrgOverride extends Module {
+  effectiveEnabled: boolean;
+  orgOverride: boolean | null;
 }


### PR DESCRIPTION
## Summary

- New **Modules** tab in Settings (admin-only, `settings.manage` permission required)
- Global module list with enable/disable toggles and optional justification captured in the audit log
- Per-organisation override panel: type an org name, load its effective module states, set/remove overrides individually
- 13 new tests covering all interactions

## Type changes

- `User.organizationName` added (optional, fed from JWT)
- `Module`, `ModuleWithOrgOverride` types added to `frontend/src/types/index.ts`
- `AuditLogEntry` extended with all backend fields (justification, snapshots, request correlation)

Closes #N/A