### PR TITLE
feat: add RBAC Management UI and GET user roles endpoint

### DIFF
--- a/backend/src/routes/rbac.ts
+++ b/backend/src/routes/rbac.ts
@@ -123,6 +123,16 @@ export const createRbacRouter = (pool: Pool): { roles: Router; permissions: Rout
     }
   });
 
+  roles.get('/users/:userId', validateParams(userIdParam), async (_req: Request, res: Response) => {
+    try {
+      const assignments = await rbac.getUserRoles(res.locals.params.userId);
+      res.json({ success: true, data: assignments });
+    } catch (err) {
+      logger.error('get user roles failed', err);
+      respondError(res, 500, 'INTERNAL_ERROR', 'Failed to get user roles');
+    }
+  });
+
   roles.post('/users/:userId', validateParams(userIdParam), validateBody(assignRoleBody), async (req: Request, res: Response) => {
     try {
       const { roleId, scopeOrgUnitId, expiresAt, justification } = res.locals.body;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -51,6 +51,7 @@ const Settings = lazy(() => import('./pages/Settings/Settings'));
 const OrgManagement = lazy(() => import('./pages/Org/OrgManagement'));
 const Policies = lazy(() => import('./pages/Policies/Policies'));
 const Governance = lazy(() => import('./pages/Governance/Governance'));
+const RbacManagement = lazy(() => import('./pages/Admin/RbacManagement'));
 
 /**
  * Main Application Component
@@ -126,6 +127,11 @@ const App: React.FC = () => {
           <Route path="governance" element={
             <PermissionRoute permission="responsibility.read">
               <Governance />
+            </PermissionRoute>
+          } />
+          <Route path="admin/rbac" element={
+            <PermissionRoute permission="role.manage">
+              <RbacManagement />
             </PermissionRoute>
           } />
           <Route path="settings" element={

--- a/frontend/src/components/Layout/Sidebar.tsx
+++ b/frontend/src/components/Layout/Sidebar.tsx
@@ -96,6 +96,12 @@ const Sidebar: React.FC<SidebarProps> = ({ collapsed }) => {
       requiredPermission: 'responsibility.read',
     },
     {
+      path: '/admin/rbac',
+      icon: 'bi-person-badge',
+      label: 'Roles',
+      requiredPermission: 'role.manage',
+    },
+    {
       path: '/settings',
       icon: 'bi-gear',
       label: 'Settings',

--- a/frontend/src/pages/Admin/RbacManagement.test.tsx
+++ b/frontend/src/pages/Admin/RbacManagement.test.tsx
@@ -1,0 +1,241 @@
+/**
+ * Tests for RbacManagement page.
+ *
+ * @author Luca Ostinelli
+ */
+
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import RbacManagement from './RbacManagement';
+
+// ---- Service mocks ----
+const mockListRoles = jest.fn();
+const mockListPermissions = jest.fn();
+const mockCreateRole = jest.fn();
+const mockUpdateRole = jest.fn();
+const mockDeleteRole = jest.fn();
+const mockGetUserRoles = jest.fn();
+const mockAssignRole = jest.fn();
+const mockRemoveRole = jest.fn();
+
+jest.mock('../../services/rbacService', () => ({
+  listRoles: () => mockListRoles(),
+  listPermissions: () => mockListPermissions(),
+  createRole: (b: unknown) => mockCreateRole(b),
+  updateRole: (id: number, b: unknown) => mockUpdateRole(id, b),
+  deleteRole: (id: number) => mockDeleteRole(id),
+  getUserRoles: (uid: number) => mockGetUserRoles(uid),
+  assignRole: (uid: number, b: unknown) => mockAssignRole(uid, b),
+  removeRole: (uid: number, rid: number, scope: unknown, just: unknown) => mockRemoveRole(uid, rid, scope, just),
+}));
+
+const mockListUnits = jest.fn();
+jest.mock('../../services/orgService', () => ({
+  listUnits: () => mockListUnits(),
+}));
+
+const mockGetEmployees = jest.fn();
+jest.mock('../../services/employeeService', () => ({
+  getEmployees: (f: unknown) => mockGetEmployees(f),
+}));
+
+// ---- Fixtures ----
+const PERMISSIONS = [
+  { id: 1, code: 'employee.read', resource: 'employee', action: 'read', description: 'Read employees' },
+  { id: 2, code: 'schedule.manage', resource: 'schedule', action: 'manage', description: 'Manage schedules' },
+];
+
+const ROLES = [
+  { id: 1, name: 'Admin', description: 'Full access', isSystem: true, permissions: ['employee.read', 'schedule.manage'] },
+  { id: 2, name: 'Viewer', description: 'Read only', isSystem: false, permissions: ['employee.read'] },
+];
+
+const ORG_UNITS = [
+  { id: 10, name: 'HR Dept', description: null, parentId: null, managerUserId: null, isActive: true, createdAt: '', updatedAt: '' },
+];
+
+const EMPLOYEES = [
+  { id: 99, firstName: 'Alice', lastName: 'Smith', email: 'alice@test.com', isActive: true, createdAt: '', updatedAt: '' },
+];
+
+const USER_ROLES: Array<{ roleId: number; roleName: string; scopeOrgUnitId: null; expiresAt: null }> = [
+  { roleId: 2, roleName: 'Viewer', scopeOrgUnitId: null, expiresAt: null },
+];
+
+beforeEach(() => {
+  mockListRoles.mockResolvedValue({ success: true, data: ROLES });
+  mockListPermissions.mockResolvedValue({ success: true, data: PERMISSIONS });
+  mockListUnits.mockResolvedValue({ success: true, data: ORG_UNITS });
+  mockGetEmployees.mockResolvedValue({ success: true, data: EMPLOYEES });
+  mockGetUserRoles.mockResolvedValue({ success: true, data: USER_ROLES });
+  mockCreateRole.mockResolvedValue({ success: true, data: { id: 3, name: 'New', isSystem: false, permissions: [] } });
+  mockUpdateRole.mockResolvedValue({ success: true, data: ROLES[1] });
+  mockDeleteRole.mockResolvedValue({ success: true });
+  mockAssignRole.mockResolvedValue({ success: true });
+  mockRemoveRole.mockResolvedValue({ success: true });
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('<RbacManagement />', () => {
+  // ---- Roles tab ----
+
+  it('renders the page header and Roles tab by default', async () => {
+    render(<RbacManagement />);
+    expect(screen.getByRole('heading', { name: /roles & permissions/i })).toBeInTheDocument();
+    expect(await screen.findByText('Admin')).toBeInTheDocument();
+    expect(screen.getByText('Viewer')).toBeInTheDocument();
+  });
+
+  it('shows system badge for system roles and disables Delete for them', async () => {
+    render(<RbacManagement />);
+    await screen.findByText('Admin');
+
+    const rows = screen.getAllByRole('row');
+    const adminRow = rows[1];
+    expect(within(adminRow).getByText('System')).toBeInTheDocument();
+    expect(within(adminRow).getByRole('button', { name: /delete role admin/i })).toBeDisabled();
+
+    const viewerRow = rows[2];
+    expect(within(viewerRow).getByRole('button', { name: /delete role viewer/i })).not.toBeDisabled();
+  });
+
+  it('opens create modal and calls createRole', async () => {
+    render(<RbacManagement />);
+    await screen.findByText('Admin');
+
+    await userEvent.click(screen.getByRole('button', { name: /new role/i }));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    await userEvent.type(screen.getByLabelText(/^name/i), 'My Role');
+    await userEvent.click(screen.getByRole('button', { name: /create role/i }));
+
+    expect(mockCreateRole).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'My Role' })
+    );
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    expect(await screen.findByText(/created/i)).toBeInTheDocument();
+  });
+
+  it('opens edit modal pre-filled with role data', async () => {
+    render(<RbacManagement />);
+    await screen.findByText('Viewer');
+
+    await userEvent.click(screen.getByRole('button', { name: /edit role viewer/i }));
+
+    const nameInput = screen.getByLabelText(/^name/i) as HTMLInputElement;
+    expect(nameInput.value).toBe('Viewer');
+    expect(screen.getByLabelText(/description/i)).toHaveValue('Read only');
+  });
+
+  it('calls updateRole when Save Changes is clicked', async () => {
+    render(<RbacManagement />);
+    await screen.findByText('Viewer');
+
+    await userEvent.click(screen.getByRole('button', { name: /edit role viewer/i }));
+    const nameInput = screen.getByLabelText(/^name/i);
+    await userEvent.clear(nameInput);
+    await userEvent.type(nameInput, 'Updated Viewer');
+    await userEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+    expect(mockUpdateRole).toHaveBeenCalledWith(2, expect.objectContaining({ name: 'Updated Viewer' }));
+  });
+
+  it('shows delete confirm modal and calls deleteRole', async () => {
+    render(<RbacManagement />);
+    await screen.findByText('Viewer');
+
+    await userEvent.click(screen.getByRole('button', { name: /delete role viewer/i }));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /delete role/i })).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /^delete$/i }));
+    expect(mockDeleteRole).toHaveBeenCalledWith(2);
+    expect(await screen.findByText(/deleted/i)).toBeInTheDocument();
+  });
+
+  it('shows error when listRoles fails', async () => {
+    mockListRoles.mockRejectedValue(new Error('Server error'));
+    render(<RbacManagement />);
+    expect(await screen.findByRole('alert')).toBeInTheDocument();
+    expect(await screen.findByText(/server error/i)).toBeInTheDocument();
+  });
+
+  // ---- User Roles tab ----
+
+  it('switches to User Role Grants tab', async () => {
+    render(<RbacManagement />);
+    await screen.findByText('Admin');
+
+    await userEvent.click(screen.getByRole('button', { name: /user role grants/i }));
+    expect(screen.getByLabelText(/search by name or email/i)).toBeInTheDocument();
+  });
+
+  it('shows employee suggestions when typing in the search box', async () => {
+    render(<RbacManagement />);
+    await screen.findByText('Admin');
+
+    await userEvent.click(screen.getByRole('button', { name: /user role grants/i }));
+    const input = screen.getByLabelText(/search by name or email/i);
+    await userEvent.type(input, 'Alice');
+
+    // Debounce is 300ms — wait for the search to fire
+    await waitFor(() => expect(mockGetEmployees).toHaveBeenCalled(), { timeout: 2000 });
+    // Dropdown option contains "Alice Smith" + email — role="option" is the reliable selector
+    expect(await screen.findByRole('option')).toBeInTheDocument();
+  }, 10000);
+
+  it('loads user roles when an employee is selected', async () => {
+    render(<RbacManagement />);
+    await screen.findByText('Admin');
+
+    await userEvent.click(screen.getByRole('button', { name: /user role grants/i }));
+    await userEvent.type(screen.getByLabelText(/search by name or email/i), 'Ali');
+
+    await waitFor(() => expect(mockGetEmployees).toHaveBeenCalled(), { timeout: 2000 });
+    await userEvent.click(await screen.findByRole('option'));
+
+    expect(mockGetUserRoles).toHaveBeenCalledWith(99);
+    // "Never" only appears in the Expires column of the grants table
+    expect(await screen.findByText('Never')).toBeInTheDocument();
+    expect(screen.getByText('Current Role Grants')).toBeInTheDocument();
+  }, 10000);
+
+  it('calls assignRole when Grant Role is submitted', async () => {
+    render(<RbacManagement />);
+    await screen.findByText('Admin');
+
+    await userEvent.click(screen.getByRole('button', { name: /user role grants/i }));
+    await userEvent.type(screen.getByLabelText(/search/i), 'Ali');
+    await waitFor(() => expect(mockGetEmployees).toHaveBeenCalled(), { timeout: 2000 });
+    await userEvent.click(await screen.findByRole('option'));
+    await screen.findByText('Current Role Grants');
+
+    await userEvent.selectOptions(screen.getByLabelText(/^role/i), '1');
+    await userEvent.click(screen.getByRole('button', { name: /grant role/i }));
+
+    expect(mockAssignRole).toHaveBeenCalledWith(99, expect.objectContaining({ roleId: 1 }));
+    expect(await screen.findByText(/granted successfully/i)).toBeInTheDocument();
+  }, 10000);
+
+  it('calls removeRole after revoke confirm', async () => {
+    render(<RbacManagement />);
+    await screen.findByText('Admin');
+
+    await userEvent.click(screen.getByRole('button', { name: /user role grants/i }));
+    await userEvent.type(screen.getByLabelText(/search/i), 'Ali');
+    await waitFor(() => expect(mockGetEmployees).toHaveBeenCalled(), { timeout: 2000 });
+    await userEvent.click(await screen.findByRole('option'));
+    // Wait for grants table to load ("Never" is unique to the Expires column)
+    await screen.findByText('Never');
+
+    await userEvent.click(screen.getByRole('button', { name: /revoke role viewer/i }));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /^revoke$/i }));
+    expect(mockRemoveRole).toHaveBeenCalledWith(99, 2, null, undefined);
+    expect(await screen.findByText(/revoked/i)).toBeInTheDocument();
+  }, 10000);
+});

--- a/frontend/src/pages/Admin/RbacManagement.tsx
+++ b/frontend/src/pages/Admin/RbacManagement.tsx
@@ -1,0 +1,789 @@
+/**
+ * RbacManagement — Admin page for managing roles, permissions, and user role grants.
+ *
+ * Two tabs:
+ *   Roles      — list, create, edit (name + permission set), delete non-system roles
+ *   User Roles — search employees, view current role grants, add or revoke grants
+ *
+ * Requires the `role.manage` permission; the route is protected via PermissionRoute.
+ *
+ * @author Luca Ostinelli
+ */
+
+import React, { useEffect, useState, useCallback } from 'react';
+import { Permission, Role, UserRoleAssignment, Employee } from '../../types';
+import { OrgUnit, listUnits } from '../../services/orgService';
+import {
+  listPermissions,
+  listRoles,
+  createRole,
+  updateRole,
+  deleteRole,
+  getUserRoles,
+  assignRole,
+  removeRole,
+} from '../../services/rbacService';
+import { getEmployees } from '../../services/employeeService';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type Tab = 'roles' | 'user-roles';
+
+interface RoleFormState {
+  name: string;
+  description: string;
+  permissionCodes: string[];
+}
+
+const EMPTY_FORM: RoleFormState = { name: '', description: '', permissionCodes: [] };
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+const RbacManagement: React.FC = () => {
+  const [activeTab, setActiveTab] = useState<Tab>('roles');
+
+  // ---- Roles tab state ----
+  const [roles, setRoles] = useState<Role[]>([]);
+  const [permissions, setPermissions] = useState<Permission[]>([]);
+  const [rolesLoading, setRolesLoading] = useState(true);
+  const [rolesError, setRolesError] = useState<string | null>(null);
+  const [rolesSuccess, setRolesSuccess] = useState<string | null>(null);
+
+  const [roleModal, setRoleModal] = useState<{ open: boolean; editing: Role | null }>({
+    open: false,
+    editing: null,
+  });
+  const [roleForm, setRoleForm] = useState<RoleFormState>(EMPTY_FORM);
+  const [roleSaving, setRoleSaving] = useState(false);
+
+  const [deleteConfirm, setDeleteConfirm] = useState<Role | null>(null);
+  const [deleting, setDeleting] = useState(false);
+
+  // ---- User-roles tab state ----
+  const [orgUnits, setOrgUnits] = useState<OrgUnit[]>([]);
+  const [employeeSearch, setEmployeeSearch] = useState('');
+  const [employees, setEmployees] = useState<Employee[]>([]);
+  const [empLoading, setEmpLoading] = useState(false);
+  const [selectedUser, setSelectedUser] = useState<Employee | null>(null);
+  const [userRoles, setUserRoles] = useState<UserRoleAssignment[]>([]);
+  const [userRolesLoading, setUserRolesLoading] = useState(false);
+  const [userRolesError, setUserRolesError] = useState<string | null>(null);
+  const [userRolesSuccess, setUserRolesSuccess] = useState<string | null>(null);
+
+  const [grantForm, setGrantForm] = useState<{
+    roleId: number | '';
+    scopeOrgUnitId: number | '';
+    expiresAt: string;
+    justification: string;
+  }>({ roleId: '', scopeOrgUnitId: '', expiresAt: '', justification: '' });
+  const [granting, setGranting] = useState(false);
+
+  const [revokeTarget, setRevokeTarget] = useState<UserRoleAssignment | null>(null);
+  const [revokeJustification, setRevokeJustification] = useState('');
+  const [revoking, setRevoking] = useState(false);
+
+  // ---------------------------------------------------------------------------
+  // Data loading
+  // ---------------------------------------------------------------------------
+
+  const loadRoles = useCallback(async () => {
+    setRolesLoading(true);
+    setRolesError(null);
+    try {
+      const [rolesRes, permsRes] = await Promise.all([listRoles(), listPermissions()]);
+      if (rolesRes.success && rolesRes.data) setRoles(rolesRes.data);
+      if (permsRes.success && permsRes.data) setPermissions(permsRes.data);
+    } catch (e) {
+      setRolesError((e as Error).message ?? 'Failed to load roles.');
+    } finally {
+      setRolesLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadRoles();
+    listUnits().then((res) => {
+      if (res.success && res.data) setOrgUnits(res.data);
+    }).catch(() => {});
+  }, [loadRoles]);
+
+  const searchEmployees = useCallback(async (q: string) => {
+    if (!q.trim()) { setEmployees([]); return; }
+    setEmpLoading(true);
+    try {
+      const res = await getEmployees({ search: q.trim() } as any);
+      if (res.success && res.data) setEmployees(res.data);
+    } catch {
+      setEmployees([]);
+    } finally {
+      setEmpLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    const t = setTimeout(() => void searchEmployees(employeeSearch), 300);
+    return () => clearTimeout(t);
+  }, [employeeSearch, searchEmployees]);
+
+  const loadUserRoles = async (userId: number) => {
+    setUserRolesLoading(true);
+    setUserRolesError(null);
+    try {
+      const res = await getUserRoles(userId);
+      if (res.success && res.data) setUserRoles(res.data);
+      else setUserRolesError('Failed to load user roles.');
+    } catch (e) {
+      setUserRolesError((e as Error).message ?? 'Failed to load user roles.');
+    } finally {
+      setUserRolesLoading(false);
+    }
+  };
+
+  const handleSelectUser = (emp: Employee) => {
+    setSelectedUser(emp);
+    setEmployees([]);
+    setEmployeeSearch('');
+    setUserRolesSuccess(null);
+    setUserRolesError(null);
+    void loadUserRoles(Number(emp.id));
+  };
+
+  // ---------------------------------------------------------------------------
+  // Role CRUD
+  // ---------------------------------------------------------------------------
+
+  const openCreate = () => {
+    setRoleForm(EMPTY_FORM);
+    setRoleModal({ open: true, editing: null });
+  };
+
+  const openEdit = (role: Role) => {
+    setRoleForm({
+      name: role.name,
+      description: role.description ?? '',
+      permissionCodes: role.permissions ?? [],
+    });
+    setRoleModal({ open: true, editing: role });
+  };
+
+  const togglePermission = (code: string) => {
+    setRoleForm((prev) => ({
+      ...prev,
+      permissionCodes: prev.permissionCodes.includes(code)
+        ? prev.permissionCodes.filter((c) => c !== code)
+        : [...prev.permissionCodes, code],
+    }));
+  };
+
+  const saveRole = async () => {
+    if (!roleForm.name.trim()) return;
+    setRoleSaving(true);
+    setRolesError(null);
+    setRolesSuccess(null);
+    try {
+      const body = {
+        name: roleForm.name.trim(),
+        description: roleForm.description.trim() || undefined,
+        permissionCodes: roleForm.permissionCodes,
+      };
+      if (roleModal.editing) {
+        await updateRole(roleModal.editing.id, body);
+        setRolesSuccess(`Role "${roleForm.name}" updated.`);
+      } else {
+        await createRole(body);
+        setRolesSuccess(`Role "${roleForm.name}" created.`);
+      }
+      setRoleModal({ open: false, editing: null });
+      await loadRoles();
+    } catch (e) {
+      setRolesError((e as Error).message ?? 'Failed to save role.');
+    } finally {
+      setRoleSaving(false);
+    }
+  };
+
+  const confirmDelete = async () => {
+    if (!deleteConfirm) return;
+    setDeleting(true);
+    setRolesError(null);
+    setRolesSuccess(null);
+    try {
+      await deleteRole(deleteConfirm.id);
+      setRolesSuccess(`Role "${deleteConfirm.name}" deleted.`);
+      setDeleteConfirm(null);
+      await loadRoles();
+    } catch (e) {
+      setRolesError((e as Error).message ?? 'Failed to delete role.');
+      setDeleteConfirm(null);
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  // ---------------------------------------------------------------------------
+  // User role grants
+  // ---------------------------------------------------------------------------
+
+  const handleGrant = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!selectedUser || grantForm.roleId === '') return;
+    setGranting(true);
+    setUserRolesError(null);
+    setUserRolesSuccess(null);
+    try {
+      await assignRole(Number(selectedUser.id), {
+        roleId: Number(grantForm.roleId),
+        scopeOrgUnitId: grantForm.scopeOrgUnitId !== '' ? Number(grantForm.scopeOrgUnitId) : null,
+        expiresAt: grantForm.expiresAt || null,
+        justification: grantForm.justification || undefined,
+      });
+      setGrantForm({ roleId: '', scopeOrgUnitId: '', expiresAt: '', justification: '' });
+      setUserRolesSuccess('Role granted successfully.');
+      await loadUserRoles(Number(selectedUser.id));
+    } catch (e) {
+      setUserRolesError((e as Error).message ?? 'Failed to grant role.');
+    } finally {
+      setGranting(false);
+    }
+  };
+
+  const confirmRevoke = async () => {
+    if (!selectedUser || !revokeTarget) return;
+    setRevoking(true);
+    setUserRolesError(null);
+    setUserRolesSuccess(null);
+    try {
+      await removeRole(
+        Number(selectedUser.id),
+        revokeTarget.roleId,
+        revokeTarget.scopeOrgUnitId,
+        revokeJustification || undefined
+      );
+      setUserRolesSuccess(`Role "${revokeTarget.roleName}" revoked.`);
+      setRevokeTarget(null);
+      setRevokeJustification('');
+      await loadUserRoles(Number(selectedUser.id));
+    } catch (e) {
+      setUserRolesError((e as Error).message ?? 'Failed to revoke role.');
+    } finally {
+      setRevoking(false);
+    }
+  };
+
+  // Group permissions by resource for the checkbox list
+  const permsByResource = permissions.reduce<Record<string, Permission[]>>((acc, p) => {
+    if (!acc[p.resource]) acc[p.resource] = [];
+    acc[p.resource].push(p);
+    return acc;
+  }, {});
+
+  // ---------------------------------------------------------------------------
+  // Render
+  // ---------------------------------------------------------------------------
+
+  return (
+    <div className="container-fluid py-4">
+      <div className="row mb-4">
+        <div className="col">
+          <h1 className="h3 mb-0">Roles &amp; Permissions</h1>
+          <p className="text-muted mb-0">Manage roles, permission sets, and user role grants</p>
+        </div>
+      </div>
+
+      <ul className="nav nav-tabs mb-4">
+        <li className="nav-item">
+          <button
+            className={`nav-link ${activeTab === 'roles' ? 'active' : ''}`}
+            onClick={() => setActiveTab('roles')}
+          >
+            <i className="bi bi-shield-check me-2" aria-hidden="true"></i>Roles
+          </button>
+        </li>
+        <li className="nav-item">
+          <button
+            className={`nav-link ${activeTab === 'user-roles' ? 'active' : ''}`}
+            onClick={() => setActiveTab('user-roles')}
+          >
+            <i className="bi bi-person-badge me-2" aria-hidden="true"></i>User Role Grants
+          </button>
+        </li>
+      </ul>
+
+      {/* ---- Roles tab ---- */}
+      {activeTab === 'roles' && (
+        <div>
+          {rolesSuccess && (
+            <div className="alert alert-success alert-dismissible" role="status">
+              <i className="bi bi-check-circle me-2" aria-hidden="true"></i>{rolesSuccess}
+              <button type="button" className="btn-close" onClick={() => setRolesSuccess(null)} aria-label="Close"></button>
+            </div>
+          )}
+          {rolesError && (
+            <div className="alert alert-danger" role="alert">
+              <i className="bi bi-exclamation-triangle me-2" aria-hidden="true"></i>{rolesError}
+            </div>
+          )}
+
+          <div className="d-flex justify-content-between align-items-center mb-3">
+            <h5 className="mb-0">All Roles</h5>
+            <button className="btn btn-primary btn-sm" onClick={openCreate}>
+              <i className="bi bi-plus me-1" aria-hidden="true"></i>New Role
+            </button>
+          </div>
+
+          {rolesLoading ? (
+            <div className="text-center py-4">
+              <span className="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+              <span className="ms-2">Loading…</span>
+            </div>
+          ) : (
+            <div className="table-responsive">
+              <table className="table table-hover">
+                <thead className="table-light">
+                  <tr>
+                    <th scope="col">Name</th>
+                    <th scope="col">Description</th>
+                    <th scope="col">Permissions</th>
+                    <th scope="col" className="text-center">System</th>
+                    <th scope="col" className="text-center">Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {roles.map((role) => (
+                    <tr key={role.id}>
+                      <td className="fw-semibold">{role.name}</td>
+                      <td className="text-muted small">{role.description ?? '—'}</td>
+                      <td>
+                        <div className="d-flex flex-wrap gap-1">
+                          {(role.permissions ?? []).length === 0 ? (
+                            <span className="text-muted small">None</span>
+                          ) : (
+                            (role.permissions ?? []).slice(0, 5).map((code) => (
+                              <span key={code} className="badge bg-light text-dark border font-monospace small">
+                                {code}
+                              </span>
+                            ))
+                          )}
+                          {(role.permissions ?? []).length > 5 && (
+                            <span className="badge bg-secondary">+{(role.permissions ?? []).length - 5} more</span>
+                          )}
+                        </div>
+                      </td>
+                      <td className="text-center">
+                        {role.isSystem ? (
+                          <span className="badge bg-warning text-dark">System</span>
+                        ) : (
+                          <span className="text-muted">—</span>
+                        )}
+                      </td>
+                      <td className="text-center">
+                        <div className="btn-group btn-group-sm">
+                          <button
+                            className="btn btn-outline-primary"
+                            onClick={() => openEdit(role)}
+                            aria-label={`Edit role ${role.name}`}
+                          >
+                            <i className="bi bi-pencil" aria-hidden="true"></i>
+                          </button>
+                          <button
+                            className="btn btn-outline-danger"
+                            onClick={() => setDeleteConfirm(role)}
+                            disabled={role.isSystem}
+                            aria-label={`Delete role ${role.name}`}
+                            title={role.isSystem ? 'System roles cannot be deleted' : undefined}
+                          >
+                            <i className="bi bi-trash" aria-hidden="true"></i>
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* ---- User Role Grants tab ---- */}
+      {activeTab === 'user-roles' && (
+        <div className="row">
+          <div className="col-lg-10">
+            {userRolesSuccess && (
+              <div className="alert alert-success alert-dismissible" role="status">
+                <i className="bi bi-check-circle me-2" aria-hidden="true"></i>{userRolesSuccess}
+                <button type="button" className="btn-close" onClick={() => setUserRolesSuccess(null)} aria-label="Close"></button>
+              </div>
+            )}
+            {userRolesError && (
+              <div className="alert alert-danger" role="alert">
+                <i className="bi bi-exclamation-triangle me-2" aria-hidden="true"></i>{userRolesError}
+              </div>
+            )}
+
+            {/* User search */}
+            <div className="card mb-4">
+              <div className="card-header"><h5 className="mb-0">Select Employee</h5></div>
+              <div className="card-body">
+                <div className="position-relative">
+                  <label htmlFor="employeeSearchInput" className="form-label">Search by name or email</label>
+                  <input
+                    id="employeeSearchInput"
+                    type="text"
+                    className="form-control"
+                    placeholder="Type to search…"
+                    value={employeeSearch}
+                    onChange={(e) => setEmployeeSearch(e.target.value)}
+                    autoComplete="off"
+                  />
+                  {empLoading && (
+                    <span
+                      className="spinner-border spinner-border-sm position-absolute"
+                      style={{ right: 12, top: 38 }}
+                      role="status"
+                      aria-hidden="true"
+                    ></span>
+                  )}
+                  {employees.length > 0 && (
+                    <ul className="list-group position-absolute w-100 z-3" style={{ top: '100%' }} role="listbox">
+                      {employees.map((emp) => (
+                        <li
+                          key={emp.id}
+                          className="list-group-item list-group-item-action"
+                          role="option"
+                          aria-selected={false}
+                          onClick={() => handleSelectUser(emp)}
+                          style={{ cursor: 'pointer' }}
+                        >
+                          {emp.firstName} {emp.lastName}
+                          <small className="text-muted ms-2">{emp.email}</small>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+                {selectedUser && (
+                  <div className="mt-3 d-flex align-items-center gap-2">
+                    <i className="bi bi-person-circle fs-4 text-primary" aria-hidden="true"></i>
+                    <div>
+                      <strong>{selectedUser.firstName} {selectedUser.lastName}</strong>
+                      <small className="text-muted ms-2">{selectedUser.email}</small>
+                    </div>
+                    <button
+                      className="btn btn-sm btn-outline-secondary ms-auto"
+                      onClick={() => { setSelectedUser(null); setUserRoles([]); }}
+                    >
+                      Change
+                    </button>
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {selectedUser && (
+              <>
+                {/* Current grants */}
+                <div className="card mb-4">
+                  <div className="card-header">
+                    <h5 className="mb-0">Current Role Grants</h5>
+                  </div>
+                  <div className="card-body p-0">
+                    {userRolesLoading ? (
+                      <div className="text-center py-3">
+                        <span className="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+                        <span className="ms-2">Loading…</span>
+                      </div>
+                    ) : userRoles.length === 0 ? (
+                      <p className="text-muted text-center py-3 mb-0">No roles assigned.</p>
+                    ) : (
+                      <table className="table table-sm table-hover mb-0">
+                        <thead className="table-light">
+                          <tr>
+                            <th scope="col">Role</th>
+                            <th scope="col">Scope (Org Unit)</th>
+                            <th scope="col">Expires</th>
+                            <th scope="col" className="text-center">Revoke</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {userRoles.map((ur, i) => (
+                            <tr key={i}>
+                              <td className="fw-semibold">{ur.roleName}</td>
+                              <td>
+                                {ur.scopeOrgUnitId
+                                  ? (orgUnits.find((u) => u.id === ur.scopeOrgUnitId)?.name ?? `Unit #${ur.scopeOrgUnitId}`)
+                                  : <span className="text-muted">Global</span>}
+                              </td>
+                              <td>
+                                {ur.expiresAt
+                                  ? new Date(ur.expiresAt).toLocaleDateString()
+                                  : <span className="text-muted">Never</span>}
+                              </td>
+                              <td className="text-center">
+                                <button
+                                  className="btn btn-sm btn-outline-danger"
+                                  onClick={() => { setRevokeTarget(ur); setRevokeJustification(''); }}
+                                  aria-label={`Revoke role ${ur.roleName}`}
+                                >
+                                  Revoke
+                                </button>
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    )}
+                  </div>
+                </div>
+
+                {/* Grant new role */}
+                <div className="card">
+                  <div className="card-header"><h5 className="mb-0">Grant Role</h5></div>
+                  <div className="card-body">
+                    <form onSubmit={(e) => void handleGrant(e)}>
+                      <div className="row g-3">
+                        <div className="col-md-4">
+                          <label htmlFor="grantRoleSelect" className="form-label">Role <span className="text-danger">*</span></label>
+                          <select
+                            id="grantRoleSelect"
+                            className="form-select"
+                            value={grantForm.roleId}
+                            onChange={(e) => setGrantForm((f) => ({ ...f, roleId: e.target.value ? Number(e.target.value) : '' }))}
+                            required
+                          >
+                            <option value="">Select role…</option>
+                            {roles.map((r) => (
+                              <option key={r.id} value={r.id}>{r.name}</option>
+                            ))}
+                          </select>
+                        </div>
+                        <div className="col-md-4">
+                          <label htmlFor="grantScopeSelect" className="form-label">Scope (Org Unit)</label>
+                          <select
+                            id="grantScopeSelect"
+                            className="form-select"
+                            value={grantForm.scopeOrgUnitId}
+                            onChange={(e) => setGrantForm((f) => ({ ...f, scopeOrgUnitId: e.target.value ? Number(e.target.value) : '' }))}
+                          >
+                            <option value="">Global (no scope)</option>
+                            {orgUnits.map((u) => (
+                              <option key={u.id} value={u.id}>{u.name}</option>
+                            ))}
+                          </select>
+                        </div>
+                        <div className="col-md-4">
+                          <label htmlFor="grantExpiresAt" className="form-label">Expires at</label>
+                          <input
+                            id="grantExpiresAt"
+                            type="datetime-local"
+                            className="form-control"
+                            value={grantForm.expiresAt}
+                            onChange={(e) => setGrantForm((f) => ({ ...f, expiresAt: e.target.value }))}
+                          />
+                        </div>
+                        <div className="col-12">
+                          <label htmlFor="grantJustification" className="form-label">Justification <span className="text-muted">(optional)</span></label>
+                          <input
+                            id="grantJustification"
+                            type="text"
+                            className="form-control"
+                            placeholder="Reason for this grant…"
+                            value={grantForm.justification}
+                            onChange={(e) => setGrantForm((f) => ({ ...f, justification: e.target.value }))}
+                            maxLength={1000}
+                          />
+                        </div>
+                        <div className="col-12">
+                          <button type="submit" className="btn btn-primary" disabled={granting || grantForm.roleId === ''}>
+                            {granting ? (
+                              <><span className="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>Granting…</>
+                            ) : (
+                              <><i className="bi bi-plus me-1" aria-hidden="true"></i>Grant Role</>
+                            )}
+                          </button>
+                        </div>
+                      </div>
+                    </form>
+                  </div>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* ---- Role create/edit modal ---- */}
+      {roleModal.open && (
+        <div className="modal d-block" role="dialog" aria-modal="true" aria-labelledby="roleModalLabel">
+          <div className="modal-dialog modal-lg">
+            <div className="modal-content">
+              <div className="modal-header">
+                <h5 className="modal-title" id="roleModalLabel">
+                  {roleModal.editing ? `Edit role "${roleModal.editing.name}"` : 'Create Role'}
+                </h5>
+                <button
+                  type="button"
+                  className="btn-close"
+                  onClick={() => setRoleModal({ open: false, editing: null })}
+                  aria-label="Close dialog"
+                ></button>
+              </div>
+              <div className="modal-body">
+                <div className="mb-3">
+                  <label htmlFor="roleNameInput" className="form-label">Name <span className="text-danger">*</span></label>
+                  <input
+                    id="roleNameInput"
+                    type="text"
+                    className="form-control"
+                    value={roleForm.name}
+                    onChange={(e) => setRoleForm((f) => ({ ...f, name: e.target.value }))}
+                    disabled={roleModal.editing?.isSystem}
+                    maxLength={100}
+                    required
+                  />
+                </div>
+                <div className="mb-3">
+                  <label htmlFor="roleDescInput" className="form-label">Description</label>
+                  <input
+                    id="roleDescInput"
+                    type="text"
+                    className="form-control"
+                    value={roleForm.description}
+                    onChange={(e) => setRoleForm((f) => ({ ...f, description: e.target.value }))}
+                    maxLength={255}
+                  />
+                </div>
+                <div>
+                  <label className="form-label">Permissions</label>
+                  {Object.entries(permsByResource).map(([resource, perms]) => (
+                    <div key={resource} className="mb-3">
+                      <h6 className="text-uppercase text-muted small mb-2">{resource}</h6>
+                      <div className="d-flex flex-wrap gap-2">
+                        {perms.map((p) => (
+                          <div key={p.code} className="form-check form-check-inline">
+                            <input
+                              className="form-check-input"
+                              type="checkbox"
+                              id={`perm-${p.code}`}
+                              checked={roleForm.permissionCodes.includes(p.code)}
+                              onChange={() => togglePermission(p.code)}
+                            />
+                            <label className="form-check-label font-monospace small" htmlFor={`perm-${p.code}`}>
+                              {p.code}
+                            </label>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+              <div className="modal-footer">
+                <button
+                  type="button"
+                  className="btn btn-secondary"
+                  onClick={() => setRoleModal({ open: false, editing: null })}
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-primary"
+                  onClick={() => void saveRole()}
+                  disabled={roleSaving || !roleForm.name.trim()}
+                >
+                  {roleSaving ? (
+                    <><span className="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>Saving…</>
+                  ) : (
+                    roleModal.editing ? 'Save Changes' : 'Create Role'
+                  )}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* ---- Delete confirm modal ---- */}
+      {deleteConfirm && (
+        <div className="modal d-block" role="dialog" aria-modal="true" aria-labelledby="deleteRoleModalLabel">
+          <div className="modal-dialog">
+            <div className="modal-content">
+              <div className="modal-header">
+                <h5 className="modal-title" id="deleteRoleModalLabel">Delete Role</h5>
+                <button
+                  type="button"
+                  className="btn-close"
+                  onClick={() => setDeleteConfirm(null)}
+                  aria-label="Close dialog"
+                ></button>
+              </div>
+              <div className="modal-body">
+                <p>Delete role <strong>{deleteConfirm.name}</strong>? This will remove all user grants for this role. This action cannot be undone.</p>
+              </div>
+              <div className="modal-footer">
+                <button type="button" className="btn btn-secondary" onClick={() => setDeleteConfirm(null)}>Cancel</button>
+                <button
+                  type="button"
+                  className="btn btn-danger"
+                  onClick={() => void confirmDelete()}
+                  disabled={deleting}
+                >
+                  {deleting ? <><span className="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>Deleting…</> : 'Delete'}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* ---- Revoke confirm modal ---- */}
+      {revokeTarget && (
+        <div className="modal d-block" role="dialog" aria-modal="true" aria-labelledby="revokeModalLabel">
+          <div className="modal-dialog">
+            <div className="modal-content">
+              <div className="modal-header">
+                <h5 className="modal-title" id="revokeModalLabel">Revoke Role Grant</h5>
+                <button
+                  type="button"
+                  className="btn-close"
+                  onClick={() => setRevokeTarget(null)}
+                  aria-label="Close dialog"
+                ></button>
+              </div>
+              <div className="modal-body">
+                <p>Revoke role <strong>{revokeTarget.roleName}</strong> from <strong>{selectedUser?.firstName} {selectedUser?.lastName}</strong>?</p>
+                <label htmlFor="revokeJustificationInput" className="form-label">Justification <span className="text-muted">(optional)</span></label>
+                <textarea
+                  id="revokeJustificationInput"
+                  className="form-control"
+                  rows={2}
+                  value={revokeJustification}
+                  onChange={(e) => setRevokeJustification(e.target.value)}
+                  maxLength={1000}
+                />
+              </div>
+              <div className="modal-footer">
+                <button type="button" className="btn btn-secondary" onClick={() => setRevokeTarget(null)}>Cancel</button>
+                <button
+                  type="button"
+                  className="btn btn-danger"
+                  onClick={() => void confirmRevoke()}
+                  disabled={revoking}
+                >
+                  {revoking ? <><span className="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>Revoking…</> : 'Revoke'}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default RbacManagement;

--- a/frontend/src/services/rbacService.ts
+++ b/frontend/src/services/rbacService.ts
@@ -1,0 +1,78 @@
+/**
+ * RBAC service — wraps /api/roles and /api/permissions endpoints.
+ *
+ * @author Luca Ostinelli
+ */
+
+import { ApiResponse, Permission, Role, UserRoleAssignment } from '../types';
+import { getAuthHeaders, handleResponse, API_BASE_URL } from './apiUtils';
+
+const ROLES = `${API_BASE_URL}/roles`;
+const PERMS = `${API_BASE_URL}/permissions`;
+
+export const listPermissions = (): Promise<ApiResponse<Permission[]>> =>
+  fetch(PERMS, { method: 'GET', ...getAuthHeaders() }).then(handleResponse<Permission[]>);
+
+export const listRoles = (): Promise<ApiResponse<Role[]>> =>
+  fetch(ROLES, { method: 'GET', ...getAuthHeaders() }).then(handleResponse<Role[]>);
+
+export const getRole = (id: number): Promise<ApiResponse<Role>> =>
+  fetch(`${ROLES}/${id}`, { method: 'GET', ...getAuthHeaders() }).then(handleResponse<Role>);
+
+export const createRole = (body: {
+  name: string;
+  description?: string;
+  permissionCodes?: string[];
+}): Promise<ApiResponse<Role>> =>
+  fetch(ROLES, {
+    method: 'POST',
+    ...getAuthHeaders(),
+    body: JSON.stringify(body),
+  }).then(handleResponse<Role>);
+
+export const updateRole = (
+  id: number,
+  body: { name?: string; description?: string; permissionCodes?: string[] }
+): Promise<ApiResponse<Role>> =>
+  fetch(`${ROLES}/${id}`, {
+    method: 'PUT',
+    ...getAuthHeaders(),
+    body: JSON.stringify(body),
+  }).then(handleResponse<Role>);
+
+export const deleteRole = (id: number): Promise<ApiResponse<void>> =>
+  fetch(`${ROLES}/${id}`, { method: 'DELETE', ...getAuthHeaders() }).then(handleResponse<void>);
+
+export const getUserRoles = (userId: number): Promise<ApiResponse<UserRoleAssignment[]>> =>
+  fetch(`${ROLES}/users/${userId}`, { method: 'GET', ...getAuthHeaders() }).then(
+    handleResponse<UserRoleAssignment[]>
+  );
+
+export const assignRole = (
+  userId: number,
+  body: {
+    roleId: number;
+    scopeOrgUnitId?: number | null;
+    expiresAt?: string | null;
+    justification?: string;
+  }
+): Promise<ApiResponse<void>> =>
+  fetch(`${ROLES}/users/${userId}`, {
+    method: 'POST',
+    ...getAuthHeaders(),
+    body: JSON.stringify(body),
+  }).then(handleResponse<void>);
+
+export const removeRole = (
+  userId: number,
+  roleId: number,
+  scopeOrgUnitId?: number | null,
+  justification?: string
+): Promise<ApiResponse<void>> => {
+  const qs = scopeOrgUnitId != null ? `?scopeOrgUnitId=${scopeOrgUnitId}` : '';
+  return fetch(`${ROLES}/users/${userId}/${roleId}${qs}`, {
+    method: 'DELETE',
+    ...getAuthHeaders(),
+    body: JSON.stringify({ justification: justification ?? null }),
+  }).then(handleResponse<void>);
+};

--- a/frontend/src/services/rbacService.ts
+++ b/frontend/src/services/rbacService.ts
@@ -16,9 +16,6 @@ export const listPermissions = (): Promise<ApiResponse<Permission[]>> =>
 export const listRoles = (): Promise<ApiResponse<Role[]>> =>
   fetch(ROLES, { method: 'GET', ...getAuthHeaders() }).then(handleResponse<Role[]>);
 
-export const getRole = (id: number): Promise<ApiResponse<Role>> =>
-  fetch(`${ROLES}/${id}`, { method: 'GET', ...getAuthHeaders() }).then(handleResponse<Role>);
-
 export const createRole = (body: {
   name: string;
   description?: string;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -204,6 +204,31 @@ export interface DashboardStats {
   employeeSatisfaction: number;
 }
 
+export interface Permission {
+  id: number;
+  code: string;
+  resource: string;
+  action: string;
+  description?: string;
+}
+
+export interface Role {
+  id: number;
+  name: string;
+  description?: string;
+  isSystem: boolean;
+  permissions?: string[];
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface UserRoleAssignment {
+  roleId: number;
+  roleName: string;
+  scopeOrgUnitId?: number | null;
+  expiresAt?: string | null;
+}
+
 export interface AuditLogEntry {
   id: number;
   actorId: number | null;


### PR DESCRIPTION
## Summary

- New admin page `/admin/rbac` (requires `role.manage` permission) with two tabs:
  - **Roles**: list, create/edit (with full permission checkbox matrix), delete non-system roles
  - **User Role Grants**: debounced employee search, view current grants (scope + expiry), add/revoke grants with optional justification
- Backend: added `GET /api/roles/users/:userId` — was missing; required by the new UI
- `rbacService.ts`: typed wrappers for all RBAC API endpoints
- Sidebar nav: added **Roles** link gated on `role.manage`
- 12 tests covering all interactions

## Type additions

`Permission`, `Role`, `UserRoleAssignment` added to `frontend/src/types/index.ts`

Closes #N/A