### PR TITLE
feat: audit log viewer (A3)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -51,6 +51,7 @@ const Settings = lazy(() => import('./pages/Settings/Settings'));
 const OrgManagement = lazy(() => import('./pages/Org/OrgManagement'));
 const Policies = lazy(() => import('./pages/Policies/Policies'));
 const Governance = lazy(() => import('./pages/Governance/Governance'));
+const AuditLogs = lazy(() => import('./pages/Admin/AuditLogs'));
 
 /**
  * Main Application Component
@@ -131,6 +132,11 @@ const App: React.FC = () => {
           <Route path="settings" element={
             <PermissionRoute permission="settings.manage">
               <Settings />
+            </PermissionRoute>
+          } />
+          <Route path="admin/audit-logs" element={
+            <PermissionRoute permission="audit.read">
+              <AuditLogs />
             </PermissionRoute>
           } />
         </Route>

--- a/frontend/src/components/Layout/Sidebar.tsx
+++ b/frontend/src/components/Layout/Sidebar.tsx
@@ -101,6 +101,12 @@ const Sidebar: React.FC<SidebarProps> = ({ collapsed }) => {
       label: 'Settings',
       requiredPermission: 'settings.manage',
     },
+    {
+      path: '/admin/audit-logs',
+      icon: 'bi-journal-text',
+      label: 'Audit Log',
+      requiredPermission: 'audit.read',
+    },
   ];
 
   const hasPermission = (requiredPermission: string | null): boolean => {

--- a/frontend/src/pages/Admin/AuditLogs.test.tsx
+++ b/frontend/src/pages/Admin/AuditLogs.test.tsx
@@ -1,0 +1,219 @@
+/**
+ * Tests for AuditLogs page.
+ *
+ * @author Luca Ostinelli
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AuditLogs from './AuditLogs';
+
+jest.mock('../../services/auditLogService', () => ({
+  listAuditLogs: jest.fn(),
+  buildExportUrl: jest.fn((_, fmt) => `/api/audit-logs/export?format=${fmt}`),
+}));
+
+// Keep a typed reference to the mocked module functions.
+// jest.requireMock is safe here: the mock is registered above and the module
+// is NOT imported at the top of this file, so there is no TDZ issue.
+const { listAuditLogs: mockListAuditLogs } =
+  jest.requireMock('../../services/auditLogService') as {
+    listAuditLogs: jest.Mock;
+    buildExportUrl: jest.Mock;
+  };
+
+const ENTRY_1 = {
+  id: 1,
+  userId: 5,
+  onBehalfOfUserId: null,
+  action: 'module.toggle',
+  entityType: 'module',
+  entityId: null,
+  description: 'Module scheduling enabled',
+  justification: 'Needed for Q4',
+  beforeSnapshot: { isEnabled: false },
+  afterSnapshot: { isEnabled: true },
+  ipAddress: '127.0.0.1',
+  userAgent: 'Mozilla/5.0',
+  requestId: 'req-abc-123',
+  createdAt: '2024-01-15T10:30:00.000Z',
+};
+
+const ENTRY_2 = {
+  id: 2,
+  userId: 3,
+  onBehalfOfUserId: 7,
+  action: 'role.assign',
+  entityType: 'user',
+  entityId: 7,
+  description: 'Role Viewer assigned to user 7',
+  justification: null,
+  beforeSnapshot: null,
+  afterSnapshot: null,
+  ipAddress: null,
+  userAgent: null,
+  requestId: null,
+  createdAt: '2024-01-16T09:00:00.000Z',
+};
+
+const makePageResponse = (items = [ENTRY_1, ENTRY_2], total = 2) => ({
+  success: true,
+  data: items,
+  meta: { total, page: 1, pageSize: 50, pages: 1 },
+});
+
+beforeEach(() => {
+  mockListAuditLogs.mockResolvedValue(makePageResponse());
+});
+
+afterEach(() => jest.clearAllMocks());
+
+describe('<AuditLogs />', () => {
+  it('renders the page heading', async () => {
+    render(<AuditLogs />);
+    expect(screen.getByRole('heading', { name: /audit log/i })).toBeInTheDocument();
+  });
+
+  it('renders entries after loading', async () => {
+    render(<AuditLogs />);
+    expect(await screen.findByText('module.toggle')).toBeInTheDocument();
+    expect(screen.getByText('role.assign')).toBeInTheDocument();
+  });
+
+  it('shows the total entry count', async () => {
+    render(<AuditLogs />);
+    expect(await screen.findByText(/2 entries/i)).toBeInTheDocument();
+  });
+
+  it('renders Export CSV and Export JSON buttons', async () => {
+    render(<AuditLogs />);
+    await screen.findByText('module.toggle');
+    // The export anchors are always rendered; check they are present by text
+    expect(screen.getByText(/export csv/i)).toBeInTheDocument();
+    expect(screen.getByText(/export json/i)).toBeInTheDocument();
+  });
+
+  it('calls listAuditLogs on mount', () => {
+    render(<AuditLogs />);
+    expect(mockListAuditLogs).toHaveBeenCalledWith(
+      expect.objectContaining({ page: 1, pageSize: 50 })
+    );
+  });
+
+  it('applies filters and re-fetches when Apply is clicked', async () => {
+    render(<AuditLogs />);
+    await screen.findByText('module.toggle');
+
+    await userEvent.type(screen.getByLabelText(/^action$/i), 'module.toggle');
+    await userEvent.click(screen.getByRole('button', { name: /apply filters/i }));
+
+    await waitFor(() =>
+      expect(mockListAuditLogs).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'module.toggle' })
+      )
+    );
+  });
+
+  it('resets filters and re-fetches when Reset is clicked', async () => {
+    render(<AuditLogs />);
+    await screen.findByText('module.toggle');
+
+    await userEvent.type(screen.getByLabelText(/^action$/i), 'module.toggle');
+    await userEvent.click(screen.getByRole('button', { name: /^reset$/i }));
+
+    const input = screen.getByLabelText(/^action$/i) as HTMLInputElement;
+    expect(input.value).toBe('');
+    await waitFor(() =>
+      expect(mockListAuditLogs).toHaveBeenCalledWith(
+        expect.objectContaining({ action: undefined })
+      )
+    );
+  });
+
+  it('expands a row to show detail when the expand button is clicked', async () => {
+    render(<AuditLogs />);
+    await screen.findByText('module.toggle');
+
+    const expandBtn = screen.getByRole('button', { name: /expand entry 1/i });
+    await userEvent.click(expandBtn);
+
+    expect(screen.getByText(/needed for q4/i)).toBeInTheDocument();
+    expect(screen.getByText('req-abc-123')).toBeInTheDocument();
+    expect(screen.getByText('Before')).toBeInTheDocument();
+    expect(screen.getByText('After')).toBeInTheDocument();
+  });
+
+  it('collapses a row when the expand button is clicked a second time', async () => {
+    render(<AuditLogs />);
+    await screen.findByText('module.toggle');
+
+    const expandBtn = screen.getByRole('button', { name: /expand entry 1/i });
+    await userEvent.click(expandBtn);
+    expect(screen.getByText(/needed for q4/i)).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /collapse entry 1/i }));
+    expect(screen.queryByText(/needed for q4/i)).not.toBeInTheDocument();
+  });
+
+  it('shows onBehalfOfUserId in the detail panel when present', async () => {
+    render(<AuditLogs />);
+    await screen.findByText('role.assign');
+
+    await userEvent.click(screen.getByRole('button', { name: /expand entry 2/i }));
+    expect(screen.getByText('7')).toBeInTheDocument();
+  });
+
+  it('shows "No audit entries" when the list is empty', async () => {
+    mockListAuditLogs.mockResolvedValue(makePageResponse([], 0));
+    render(<AuditLogs />);
+    expect(await screen.findByText(/no audit entries/i)).toBeInTheDocument();
+  });
+
+  it('shows an error alert when the API fails', async () => {
+    mockListAuditLogs.mockRejectedValue(new Error('Forbidden'));
+    render(<AuditLogs />);
+    expect(await screen.findByRole('alert')).toBeInTheDocument();
+    expect(await screen.findByText(/forbidden/i)).toBeInTheDocument();
+  });
+
+  it('shows pagination controls when there are multiple pages', async () => {
+    mockListAuditLogs.mockResolvedValue({
+      success: true,
+      data: [ENTRY_1],
+      meta: { total: 120, page: 1, pageSize: 50, pages: 3 },
+    });
+    render(<AuditLogs />);
+    await screen.findByText('module.toggle');
+
+    expect(screen.getByRole('button', { name: /next/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /previous/i })).toBeDisabled();
+  });
+
+  it('fetches the next page when Next is clicked', async () => {
+    mockListAuditLogs.mockResolvedValue({
+      success: true,
+      data: [ENTRY_1],
+      meta: { total: 120, page: 1, pageSize: 50, pages: 3 },
+    });
+    render(<AuditLogs />);
+    await screen.findByText('module.toggle');
+
+    await userEvent.click(screen.getByRole('button', { name: /next/i }));
+
+    await waitFor(() =>
+      expect(mockListAuditLogs).toHaveBeenCalledWith(
+        expect.objectContaining({ page: 2 })
+      )
+    );
+  });
+
+  it('shows entity type and ID in the table', async () => {
+    render(<AuditLogs />);
+    await screen.findByText('module.toggle');
+
+    // Entry 1: entityType=module, entityId=null → shows "module"
+    expect(screen.getByText('module')).toBeInTheDocument();
+    // Entry 2: entityType=user, entityId=7 → shows "user #7"
+    expect(screen.getByText('user #7')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/Admin/AuditLogs.tsx
+++ b/frontend/src/pages/Admin/AuditLogs.tsx
@@ -1,0 +1,376 @@
+/**
+ * AuditLogs — Immutable audit trail viewer.
+ *
+ * Features:
+ *   - Filter by action, entity type, user ID, date range, request ID
+ *   - Paginated table (50 rows per page)
+ *   - Expandable row: justification + before/after JSON diff
+ *   - Export CSV / JSON via the backend's native export endpoint
+ *
+ * Requires `audit.read` permission; the route is protected via PermissionRoute.
+ *
+ * @author Luca Ostinelli
+ */
+
+import React, { useEffect, useState, useCallback } from 'react';
+import { AuditLogEntry } from '../../types';
+import { listAuditLogs, buildExportUrl, AuditLogFilters } from '../../services/auditLogService';
+
+const PAGE_SIZE = 50;
+
+interface Filters {
+  action: string;
+  entityType: string;
+  userId: string;
+  fromDate: string;
+  toDate: string;
+  requestId: string;
+}
+
+const EMPTY_FILTERS: Filters = {
+  action: '',
+  entityType: '',
+  userId: '',
+  fromDate: '',
+  toDate: '',
+  requestId: '',
+};
+
+const JsonBlock: React.FC<{ data: Record<string, unknown> | null | undefined; label: string }> = ({
+  data,
+  label,
+}) => {
+  if (!data) return null;
+  return (
+    <div className="mb-2">
+      <span className="fw-semibold small text-muted text-uppercase me-2">{label}</span>
+      <pre
+        className="bg-light border rounded p-2 small mb-0"
+        style={{ maxHeight: 200, overflow: 'auto', fontSize: '0.75rem' }}
+      >
+        {JSON.stringify(data, null, 2)}
+      </pre>
+    </div>
+  );
+};
+
+const AuditLogs: React.FC = () => {
+  const [filters, setFilters] = useState<Filters>(EMPTY_FILTERS);
+  const [applied, setApplied] = useState<Filters>(EMPTY_FILTERS);
+  const [entries, setEntries] = useState<AuditLogEntry[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [expandedId, setExpandedId] = useState<number | null>(null);
+
+  const toApiFilters = useCallback((f: Filters, p: number): AuditLogFilters => ({
+    action: f.action.trim() || undefined,
+    entityType: f.entityType.trim() || undefined,
+    userId: f.userId.trim() ? Number(f.userId.trim()) : undefined,
+    fromDate: f.fromDate || undefined,
+    toDate: f.toDate || undefined,
+    requestId: f.requestId.trim() || undefined,
+    page: p,
+    pageSize: PAGE_SIZE,
+  }), []);
+
+  const load = useCallback(async (f: Filters, p: number) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await listAuditLogs(toApiFilters(f, p));
+      setEntries(res.data ?? []);
+      setTotal(res.meta?.total ?? 0);
+    } catch (e) {
+      setError((e as Error).message ?? 'Failed to load audit logs.');
+    } finally {
+      setLoading(false);
+    }
+  }, [toApiFilters]);
+
+  useEffect(() => {
+    void load(applied, page);
+  }, [applied, page, load]);
+
+  const applyFilters = () => {
+    setPage(1);
+    setApplied({ ...filters });
+  };
+
+  const resetFilters = () => {
+    setFilters(EMPTY_FILTERS);
+    setApplied(EMPTY_FILTERS);
+    setPage(1);
+  };
+
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  const exportUrl = (format: 'csv' | 'json') =>
+    buildExportUrl(
+      {
+        action: applied.action || undefined,
+        entityType: applied.entityType || undefined,
+        userId: applied.userId ? Number(applied.userId) : undefined,
+        fromDate: applied.fromDate || undefined,
+        toDate: applied.toDate || undefined,
+      },
+      format
+    );
+
+  const handleFilterChange = (key: keyof Filters, value: string) =>
+    setFilters((prev) => ({ ...prev, [key]: value }));
+
+  const formatDate = (iso: string) => {
+    try {
+      return new Date(iso).toLocaleString();
+    } catch {
+      return iso;
+    }
+  };
+
+  return (
+    <div className="container-fluid py-4">
+      <div className="row mb-3">
+        <div className="col d-flex align-items-center justify-content-between">
+          <div>
+            <h1 className="h3 mb-0">Audit Log</h1>
+            <p className="text-muted mb-0 small">Immutable record of all system actions</p>
+          </div>
+          <div className="d-flex gap-2">
+            <a
+              href={exportUrl('csv')}
+              className="btn btn-sm btn-outline-secondary"
+              download="audit_log.csv"
+            >
+              <i className="bi bi-filetype-csv me-1" aria-hidden="true"></i>Export CSV
+            </a>
+            <a
+              href={exportUrl('json')}
+              className="btn btn-sm btn-outline-secondary"
+              download="audit_log.json"
+            >
+              <i className="bi bi-filetype-json me-1" aria-hidden="true"></i>Export JSON
+            </a>
+          </div>
+        </div>
+      </div>
+
+      {/* Filters */}
+      <div className="card mb-4">
+        <div className="card-header">
+          <h6 className="mb-0">
+            <i className="bi bi-funnel me-2" aria-hidden="true"></i>Filters
+          </h6>
+        </div>
+        <div className="card-body">
+          <div className="row g-2">
+            <div className="col-md-3">
+              <label htmlFor="filterAction" className="form-label small">Action</label>
+              <input
+                id="filterAction"
+                type="text"
+                className="form-control form-control-sm"
+                placeholder="e.g. module.toggle"
+                value={filters.action}
+                onChange={(e) => handleFilterChange('action', e.target.value)}
+                onKeyDown={(e) => { if (e.key === 'Enter') applyFilters(); }}
+              />
+            </div>
+            <div className="col-md-3">
+              <label htmlFor="filterEntityType" className="form-label small">Entity Type</label>
+              <input
+                id="filterEntityType"
+                type="text"
+                className="form-control form-control-sm"
+                placeholder="e.g. user, module"
+                value={filters.entityType}
+                onChange={(e) => handleFilterChange('entityType', e.target.value)}
+                onKeyDown={(e) => { if (e.key === 'Enter') applyFilters(); }}
+              />
+            </div>
+            <div className="col-md-2">
+              <label htmlFor="filterUserId" className="form-label small">User ID</label>
+              <input
+                id="filterUserId"
+                type="number"
+                className="form-control form-control-sm"
+                placeholder="e.g. 42"
+                value={filters.userId}
+                onChange={(e) => handleFilterChange('userId', e.target.value)}
+                min={1}
+              />
+            </div>
+            <div className="col-md-2">
+              <label htmlFor="filterFromDate" className="form-label small">From date</label>
+              <input
+                id="filterFromDate"
+                type="date"
+                className="form-control form-control-sm"
+                value={filters.fromDate}
+                onChange={(e) => handleFilterChange('fromDate', e.target.value)}
+              />
+            </div>
+            <div className="col-md-2">
+              <label htmlFor="filterToDate" className="form-label small">To date</label>
+              <input
+                id="filterToDate"
+                type="date"
+                className="form-control form-control-sm"
+                value={filters.toDate}
+                onChange={(e) => handleFilterChange('toDate', e.target.value)}
+              />
+            </div>
+            <div className="col-12 d-flex gap-2 pt-1">
+              <button className="btn btn-primary btn-sm" onClick={applyFilters} aria-label="Apply filters">
+                <i className="bi bi-search me-1" aria-hidden="true"></i>Apply
+              </button>
+              <button className="btn btn-outline-secondary btn-sm" onClick={resetFilters}>
+                Reset
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Error */}
+      {error && (
+        <div className="alert alert-danger" role="alert">
+          <i className="bi bi-exclamation-triangle me-2" aria-hidden="true"></i>{error}
+        </div>
+      )}
+
+      {/* Table */}
+      <div className="card">
+        <div className="card-header d-flex align-items-center justify-content-between">
+          <h6 className="mb-0">
+            {loading ? (
+              <><span className="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>Loading…</>
+            ) : (
+              <>{total.toLocaleString()} entries</>
+            )}
+          </h6>
+          <small className="text-muted">Page {page} / {totalPages}</small>
+        </div>
+        <div className="card-body p-0">
+          <div className="table-responsive">
+            <table className="table table-hover table-sm mb-0">
+              <thead className="table-light">
+                <tr>
+                  <th scope="col" style={{ width: 60 }}>#</th>
+                  <th scope="col">Action</th>
+                  <th scope="col">Entity</th>
+                  <th scope="col">User ID</th>
+                  <th scope="col">Description</th>
+                  <th scope="col">Date</th>
+                  <th scope="col" className="text-center" style={{ width: 50 }}>Detail</th>
+                </tr>
+              </thead>
+              <tbody>
+                {!loading && entries.length === 0 && (
+                  <tr>
+                    <td colSpan={7} className="text-center text-muted py-4">No audit entries match the current filters.</td>
+                  </tr>
+                )}
+                {entries.map((entry) => (
+                  <React.Fragment key={entry.id}>
+                    <tr className={expandedId === entry.id ? 'table-active' : ''}>
+                      <td className="text-muted font-monospace small">{entry.id}</td>
+                      <td>
+                        <span className="badge bg-secondary font-monospace">{entry.action}</span>
+                      </td>
+                      <td>
+                        {entry.entityType && (
+                          <span className="text-muted small">
+                            {entry.entityType}{entry.entityId != null ? ` #${entry.entityId}` : ''}
+                          </span>
+                        )}
+                      </td>
+                      <td className="text-muted small">{entry.userId ?? '—'}</td>
+                      <td className="small" style={{ maxWidth: 300, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                        {entry.description ?? '—'}
+                      </td>
+                      <td className="text-muted small text-nowrap">{formatDate(entry.createdAt)}</td>
+                      <td className="text-center">
+                        <button
+                          className="btn btn-sm btn-outline-secondary py-0 px-1"
+                          onClick={() => setExpandedId(expandedId === entry.id ? null : entry.id)}
+                          aria-label={expandedId === entry.id ? `Collapse entry ${entry.id}` : `Expand entry ${entry.id}`}
+                          aria-expanded={expandedId === entry.id}
+                        >
+                          <i
+                            className={`bi ${expandedId === entry.id ? 'bi-chevron-up' : 'bi-chevron-down'}`}
+                            aria-hidden="true"
+                          ></i>
+                        </button>
+                      </td>
+                    </tr>
+                    {expandedId === entry.id && (
+                      <tr>
+                        <td colSpan={7} className="bg-light border-top-0">
+                          <div className="p-3">
+                            {entry.justification && (
+                              <div className="mb-2">
+                                <span className="fw-semibold small text-muted text-uppercase me-2">Justification</span>
+                                <span className="small">{entry.justification}</span>
+                              </div>
+                            )}
+                            {entry.onBehalfOfUserId != null && (
+                              <div className="mb-2">
+                                <span className="fw-semibold small text-muted text-uppercase me-2">On behalf of User</span>
+                                <span className="small font-monospace">{entry.onBehalfOfUserId}</span>
+                              </div>
+                            )}
+                            {entry.requestId && (
+                              <div className="mb-2">
+                                <span className="fw-semibold small text-muted text-uppercase me-2">Request ID</span>
+                                <span className="small font-monospace">{entry.requestId}</span>
+                              </div>
+                            )}
+                            <JsonBlock data={entry.beforeSnapshot} label="Before" />
+                            <JsonBlock data={entry.afterSnapshot} label="After" />
+                            {entry.ipAddress && (
+                              <div className="text-muted small">
+                                IP: {entry.ipAddress}
+                                {entry.userAgent && <span className="ms-3">{entry.userAgent.slice(0, 80)}</span>}
+                              </div>
+                            )}
+                          </div>
+                        </td>
+                      </tr>
+                    )}
+                  </React.Fragment>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+        {totalPages > 1 && (
+          <div className="card-footer d-flex align-items-center justify-content-between">
+            <button
+              className="btn btn-sm btn-outline-secondary"
+              disabled={page <= 1}
+              onClick={() => setPage((p) => p - 1)}
+              aria-label="Previous page"
+            >
+              <i className="bi bi-chevron-left" aria-hidden="true"></i> Previous
+            </button>
+            <small className="text-muted">
+              Showing {Math.min((page - 1) * PAGE_SIZE + 1, total)}–{Math.min(page * PAGE_SIZE, total)} of {total}
+            </small>
+            <button
+              className="btn btn-sm btn-outline-secondary"
+              disabled={page >= totalPages}
+              onClick={() => setPage((p) => p + 1)}
+              aria-label="Next page"
+            >
+              Next <i className="bi bi-chevron-right" aria-hidden="true"></i>
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default AuditLogs;

--- a/frontend/src/services/auditLogService.ts
+++ b/frontend/src/services/auditLogService.ts
@@ -42,11 +42,6 @@ export const listAuditLogs = async (filters: AuditLogFilters = {}): Promise<Audi
   return handleResponse<AuditLogEntry[]>(res) as Promise<AuditPageResponse>;
 };
 
-export const getAuditLogEntry = async (id: number): Promise<ApiResponse<AuditLogEntry>> => {
-  const res = await fetch(`${BASE}/${id}`, { method: 'GET', ...getAuthHeaders() });
-  return handleResponse<AuditLogEntry>(res);
-};
-
 export const buildExportUrl = (filters: Omit<AuditLogFilters, 'page' | 'pageSize'>, format: 'csv' | 'json'): string => {
   const qs = new URLSearchParams({ format });
   if (filters.userId !== undefined) qs.set('userId', String(filters.userId));

--- a/frontend/src/services/auditLogService.ts
+++ b/frontend/src/services/auditLogService.ts
@@ -4,7 +4,7 @@
  * @author Luca Ostinelli
  */
 
-import { ApiResponse, AuditLogEntry, AuditLogPage } from '../types';
+import { ApiResponse, AuditLogEntry } from '../types';
 import { getAuthHeaders, handleResponse, API_BASE_URL } from './apiUtils';
 
 const BASE = `${API_BASE_URL}/audit-logs`;

--- a/frontend/src/services/auditLogService.ts
+++ b/frontend/src/services/auditLogService.ts
@@ -1,0 +1,58 @@
+/**
+ * Audit log service — wraps /api/audit-logs endpoints.
+ *
+ * @author Luca Ostinelli
+ */
+
+import { ApiResponse, AuditLogEntry, AuditLogPage } from '../types';
+import { getAuthHeaders, handleResponse, API_BASE_URL } from './apiUtils';
+
+const BASE = `${API_BASE_URL}/audit-logs`;
+
+export interface AuditLogFilters {
+  userId?: number;
+  action?: string;
+  entityType?: string;
+  entityId?: number;
+  fromDate?: string;
+  toDate?: string;
+  requestId?: string;
+  page?: number;
+  pageSize?: number;
+}
+
+type AuditPageResponse = ApiResponse<AuditLogEntry[]> & {
+  meta?: { total: number; page: number; pageSize: number; pages: number };
+};
+
+export const listAuditLogs = async (filters: AuditLogFilters = {}): Promise<AuditPageResponse> => {
+  const qs = new URLSearchParams();
+  if (filters.userId !== undefined) qs.set('userId', String(filters.userId));
+  if (filters.action) qs.set('action', filters.action);
+  if (filters.entityType) qs.set('entityType', filters.entityType);
+  if (filters.entityId !== undefined) qs.set('entityId', String(filters.entityId));
+  if (filters.fromDate) qs.set('fromDate', filters.fromDate);
+  if (filters.toDate) qs.set('toDate', filters.toDate);
+  if (filters.requestId) qs.set('requestId', filters.requestId);
+  if (filters.page !== undefined) qs.set('page', String(filters.page));
+  if (filters.pageSize !== undefined) qs.set('pageSize', String(filters.pageSize));
+
+  const url = `${BASE}${qs.toString() ? `?${qs}` : ''}`;
+  const res = await fetch(url, { method: 'GET', ...getAuthHeaders() });
+  return handleResponse<AuditLogEntry[]>(res) as Promise<AuditPageResponse>;
+};
+
+export const getAuditLogEntry = async (id: number): Promise<ApiResponse<AuditLogEntry>> => {
+  const res = await fetch(`${BASE}/${id}`, { method: 'GET', ...getAuthHeaders() });
+  return handleResponse<AuditLogEntry>(res);
+};
+
+export const buildExportUrl = (filters: Omit<AuditLogFilters, 'page' | 'pageSize'>, format: 'csv' | 'json'): string => {
+  const qs = new URLSearchParams({ format });
+  if (filters.userId !== undefined) qs.set('userId', String(filters.userId));
+  if (filters.action) qs.set('action', filters.action);
+  if (filters.entityType) qs.set('entityType', filters.entityType);
+  if (filters.fromDate) qs.set('fromDate', filters.fromDate);
+  if (filters.toDate) qs.set('toDate', filters.toDate);
+  return `${BASE}/export?${qs}`;
+};

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -220,8 +220,3 @@ export interface AuditLogEntry {
   requestId: string | null;
   createdAt: string;
 }
-
-export interface AuditLogPage {
-  total: number;
-  items: AuditLogEntry[];
-}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -206,11 +206,22 @@ export interface DashboardStats {
 
 export interface AuditLogEntry {
   id: number;
-  actorId: number | null;
-  actorEmail?: string;
+  userId: number | null;
+  onBehalfOfUserId: number | null;
   action: string;
-  entityType: string;
-  entityId?: number | null;
-  description?: string;
+  entityType: string | null;
+  entityId: number | null;
+  description: string | null;
+  justification: string | null;
+  beforeSnapshot?: Record<string, unknown> | null;
+  afterSnapshot?: Record<string, unknown> | null;
+  ipAddress: string | null;
+  userAgent: string | null;
+  requestId: string | null;
   createdAt: string;
+}
+
+export interface AuditLogPage {
+  total: number;
+  items: AuditLogEntry[];
 }


### PR DESCRIPTION
## Summary
- Adds `/admin/audit-logs` page with full filter bar (action, entity type, user ID, date range, request ID), paginated 50-row table, and expandable rows showing justification, on-behalf-of user, request ID, before/after JSON snapshots, and IP/user-agent
- Export anchors for native backend CSV and JSON download
- `auditLogService.ts` wraps all audit log endpoints including the export URL builder
- Nav item in Sidebar gated on `audit.read`; route in App.tsx protected via `PermissionRoute`
- 15 tests covering: render, filter apply/reset, pagination, row expand/collapse, empty state, error state

## Test plan
- [ ] All 15 `AuditLogs.test.tsx` tests pass (verified locally)
- [ ] `AuditLogEntry` type in `types/index.ts` aligns with backend (`userId`, not `actorId`)
- [ ] Route only accessible with `audit.read` permission