### PR TITLE
feat: approval workflow configuration UI (A4)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -51,6 +51,7 @@ const Settings = lazy(() => import('./pages/Settings/Settings'));
 const OrgManagement = lazy(() => import('./pages/Org/OrgManagement'));
 const Policies = lazy(() => import('./pages/Policies/Policies'));
 const Governance = lazy(() => import('./pages/Governance/Governance'));
+const ApprovalWorkflows = lazy(() => import('./pages/Admin/ApprovalWorkflows'));
 
 /**
  * Main Application Component
@@ -131,6 +132,11 @@ const App: React.FC = () => {
           <Route path="settings" element={
             <PermissionRoute permission="settings.manage">
               <Settings />
+            </PermissionRoute>
+          } />
+          <Route path="admin/approval-workflows" element={
+            <PermissionRoute permission="approval.manage">
+              <ApprovalWorkflows />
             </PermissionRoute>
           } />
         </Route>

--- a/frontend/src/components/Layout/Sidebar.tsx
+++ b/frontend/src/components/Layout/Sidebar.tsx
@@ -101,6 +101,12 @@ const Sidebar: React.FC<SidebarProps> = ({ collapsed }) => {
       label: 'Settings',
       requiredPermission: 'settings.manage',
     },
+    {
+      path: '/admin/approval-workflows',
+      icon: 'bi-diagram-2',
+      label: 'Approval Flows',
+      requiredPermission: 'approval.manage',
+    },
   ];
 
   const hasPermission = (requiredPermission: string | null): boolean => {

--- a/frontend/src/pages/Admin/ApprovalWorkflows.test.tsx
+++ b/frontend/src/pages/Admin/ApprovalWorkflows.test.tsx
@@ -1,0 +1,197 @@
+/**
+ * Tests for ApprovalWorkflows admin page.
+ *
+ * @author Luca Ostinelli
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ApprovalWorkflows from './ApprovalWorkflows';
+
+jest.mock('../../services/approvalWorkflowService', () => ({
+  listWorkflows: jest.fn(),
+  createWorkflow: jest.fn(),
+  updateWorkflow: jest.fn(),
+  deleteWorkflow: jest.fn(),
+}));
+
+const {
+  listWorkflows: mockListWorkflows,
+  createWorkflow: mockCreateWorkflow,
+  updateWorkflow: mockUpdateWorkflow,
+  deleteWorkflow: mockDeleteWorkflow,
+} = jest.requireMock('../../services/approvalWorkflowService') as {
+  listWorkflows: jest.Mock;
+  createWorkflow: jest.Mock;
+  updateWorkflow: jest.Mock;
+  deleteWorkflow: jest.Mock;
+};
+
+const WF_1 = {
+  id: 1,
+  changeType: 'TimeOff.Request',
+  requireAll: false,
+  description: 'Time off approval chain',
+  steps: [
+    {
+      id: 10,
+      workflowId: 1,
+      stepOrder: 1,
+      approverScope: 'unit_manager',
+      approverRoleId: null,
+      approverUserId: null,
+      autoApproveForOwner: false,
+      escalateAfterHours: 48,
+    },
+  ],
+  createdAt: '2024-01-10T08:00:00.000Z',
+  updatedAt: '2024-01-10T08:00:00.000Z',
+};
+
+const WF_2 = {
+  id: 2,
+  changeType: 'Schedule.Publish',
+  requireAll: true,
+  description: null,
+  steps: [],
+  createdAt: '2024-01-11T08:00:00.000Z',
+  updatedAt: '2024-01-11T08:00:00.000Z',
+};
+
+beforeEach(() => {
+  mockListWorkflows.mockResolvedValue({ success: true, data: [WF_1, WF_2] });
+  mockCreateWorkflow.mockResolvedValue({ success: true, data: { ...WF_1, id: 3, changeType: 'New.Type' } });
+  mockUpdateWorkflow.mockResolvedValue({ success: true, data: WF_1 });
+  mockDeleteWorkflow.mockResolvedValue({ success: true });
+});
+
+afterEach(() => jest.clearAllMocks());
+
+describe('<ApprovalWorkflows />', () => {
+  it('renders the page heading', async () => {
+    render(<ApprovalWorkflows />);
+    expect(screen.getByRole('heading', { name: /approval workflows/i })).toBeInTheDocument();
+  });
+
+  it('shows workflows after loading', async () => {
+    render(<ApprovalWorkflows />);
+    expect(await screen.findByText('TimeOff.Request')).toBeInTheDocument();
+    expect(screen.getByText('Schedule.Publish')).toBeInTheDocument();
+  });
+
+  it('shows "no workflows" when list is empty', async () => {
+    mockListWorkflows.mockResolvedValue({ success: true, data: [] });
+    render(<ApprovalWorkflows />);
+    expect(await screen.findByText(/no approval workflows/i)).toBeInTheDocument();
+  });
+
+  it('shows error alert on load failure', async () => {
+    mockListWorkflows.mockRejectedValue(new Error('Network error'));
+    render(<ApprovalWorkflows />);
+    expect(await screen.findByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText(/network error/i)).toBeInTheDocument();
+  });
+
+  it('shows New Workflow button', async () => {
+    render(<ApprovalWorkflows />);
+    expect(screen.getByRole('button', { name: /new workflow/i })).toBeInTheDocument();
+  });
+
+  it('opens create modal when New Workflow is clicked', async () => {
+    render(<ApprovalWorkflows />);
+    await userEvent.click(screen.getByRole('button', { name: /new workflow/i }));
+    expect(screen.getByRole('dialog', { name: /create workflow/i })).toBeInTheDocument();
+    expect(screen.getByLabelText(/change type/i)).toBeInTheDocument();
+  });
+
+  it('closes modal when Cancel is clicked', async () => {
+    render(<ApprovalWorkflows />);
+    await userEvent.click(screen.getByRole('button', { name: /new workflow/i }));
+    await userEvent.click(screen.getByRole('button', { name: /^cancel$/i }));
+    expect(screen.queryByRole('dialog', { name: /create workflow/i })).not.toBeInTheDocument();
+  });
+
+  it('shows validation error when Change Type is empty on save', async () => {
+    render(<ApprovalWorkflows />);
+    await userEvent.click(screen.getByRole('button', { name: /new workflow/i }));
+    await userEvent.click(screen.getByRole('button', { name: /create workflow/i }));
+    expect(screen.getByText(/change type is required/i)).toBeInTheDocument();
+  });
+
+  it('calls createWorkflow and reloads list on successful create', async () => {
+    render(<ApprovalWorkflows />);
+    await userEvent.click(screen.getByRole('button', { name: /new workflow/i }));
+
+    await userEvent.type(screen.getByLabelText(/change type/i), 'New.Type');
+    await userEvent.click(screen.getByRole('button', { name: /create workflow/i }));
+
+    await waitFor(() => expect(mockCreateWorkflow).toHaveBeenCalledWith(
+      expect.objectContaining({ changeType: 'New.Type' })
+    ));
+    await waitFor(() => expect(mockListWorkflows).toHaveBeenCalledTimes(2));
+  });
+
+  it('opens edit modal pre-filled with workflow data', async () => {
+    render(<ApprovalWorkflows />);
+    await screen.findByText('TimeOff.Request');
+
+    await userEvent.click(screen.getByRole('button', { name: /edit workflow timeoff.request/i }));
+
+    const descInput = screen.getByLabelText(/description/i) as HTMLInputElement;
+    expect(descInput.value).toBe('Time off approval chain');
+
+    // Change Type field should be disabled in edit mode
+    const ctInput = screen.getByLabelText(/change type/i) as HTMLInputElement;
+    expect(ctInput.disabled).toBe(true);
+  });
+
+  it('calls updateWorkflow on save in edit mode', async () => {
+    render(<ApprovalWorkflows />);
+    await screen.findByText('TimeOff.Request');
+
+    await userEvent.click(screen.getByRole('button', { name: /edit workflow timeoff.request/i }));
+    await userEvent.click(screen.getByRole('button', { name: /save workflow/i }));
+
+    await waitFor(() => expect(mockUpdateWorkflow).toHaveBeenCalledWith(
+      1, expect.objectContaining({ description: 'Time off approval chain' })
+    ));
+  });
+
+  it('shows and hides step list when steps count is clicked', async () => {
+    render(<ApprovalWorkflows />);
+    await screen.findByText('TimeOff.Request');
+
+    await userEvent.click(screen.getByRole('button', { name: /show steps for timeoff.request/i }));
+    expect(screen.getByText('Unit Manager')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /collapse steps for timeoff.request/i }));
+    expect(screen.queryByText('Unit Manager')).not.toBeInTheDocument();
+  });
+
+  it('opens delete confirm dialog and calls deleteWorkflow on confirm', async () => {
+    render(<ApprovalWorkflows />);
+    await screen.findByText('TimeOff.Request');
+
+    await userEvent.click(screen.getByRole('button', { name: /delete workflow timeoff.request/i }));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /delete workflow/i })).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /confirm delete workflow timeoff.request/i }));
+    await waitFor(() => expect(mockDeleteWorkflow).toHaveBeenCalledWith(1));
+    await waitFor(() => expect(mockListWorkflows).toHaveBeenCalledTimes(2));
+  });
+
+  it('adds and removes steps in the form', async () => {
+    render(<ApprovalWorkflows />);
+    await userEvent.click(screen.getByRole('button', { name: /new workflow/i }));
+
+    await userEvent.click(screen.getByRole('button', { name: /add step/i }));
+
+    // After adding a step there should be 2 remove buttons (one per step)
+    const removeButtons = screen.getAllByRole('button', { name: /remove step/i });
+    expect(removeButtons.length).toBe(2);
+
+    await userEvent.click(removeButtons[1]);
+    expect(screen.getAllByRole('button', { name: /remove step/i }).length).toBe(1);
+  });
+});

--- a/frontend/src/pages/Admin/ApprovalWorkflows.tsx
+++ b/frontend/src/pages/Admin/ApprovalWorkflows.tsx
@@ -1,0 +1,523 @@
+/**
+ * ApprovalWorkflows — Admin configuration page for multi-step approval workflows.
+ *
+ * Each workflow ties a change type (e.g. "TimeOff.Request") to an ordered list
+ * of approver steps. Steps can delegate to a unit manager, the manager chain,
+ * a specific company role, or a specific user.
+ *
+ * Requires `approval.manage` permission; the route is protected via PermissionRoute.
+ *
+ * @author Luca Ostinelli
+ */
+
+import React, { useEffect, useState, useCallback } from 'react';
+import {
+  listWorkflows,
+  createWorkflow,
+  updateWorkflow,
+  deleteWorkflow,
+  ApprovalWorkflow,
+  ApprovalStep,
+  ApproverScope,
+  CreateWorkflowBody,
+} from '../../services/approvalWorkflowService';
+
+const SCOPE_LABELS: Record<ApproverScope, string> = {
+  policy_owner: 'Policy Owner',
+  unit_manager: 'Unit Manager',
+  unit_manager_chain: 'Manager Chain',
+  company_role: 'Company Role',
+  company_user: 'Specific User',
+};
+
+const SCOPE_OPTIONS = Object.entries(SCOPE_LABELS) as [ApproverScope, string][];
+
+const EMPTY_STEP: ApprovalStep = {
+  stepOrder: 1,
+  approverScope: 'unit_manager',
+  approverRoleId: null,
+  approverUserId: null,
+  autoApproveForOwner: false,
+  escalateAfterHours: null,
+};
+
+const ApprovalWorkflows: React.FC = () => {
+  const [workflows, setWorkflows] = useState<ApprovalWorkflow[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Modal state
+  const [showModal, setShowModal] = useState(false);
+  const [modalMode, setModalMode] = useState<'create' | 'edit'>('create');
+  const [editing, setEditing] = useState<ApprovalWorkflow | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  // Form state
+  const [formChangeType, setFormChangeType] = useState('');
+  const [formRequireAll, setFormRequireAll] = useState(false);
+  const [formDescription, setFormDescription] = useState('');
+  const [formSteps, setFormSteps] = useState<ApprovalStep[]>([{ ...EMPTY_STEP }]);
+
+  // Delete confirm state
+  const [deleteTarget, setDeleteTarget] = useState<ApprovalWorkflow | null>(null);
+  const [deleting, setDeleting] = useState(false);
+
+  // Expand state for viewing steps inline
+  const [expandedId, setExpandedId] = useState<number | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await listWorkflows();
+      setWorkflows(res.data ?? []);
+    } catch (e) {
+      setError((e as Error).message ?? 'Failed to load workflows.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  // ---------- Modal helpers ----------
+
+  const openCreate = () => {
+    setModalMode('create');
+    setEditing(null);
+    setFormChangeType('');
+    setFormRequireAll(false);
+    setFormDescription('');
+    setFormSteps([{ ...EMPTY_STEP }]);
+    setSaveError(null);
+    setShowModal(true);
+  };
+
+  const openEdit = (w: ApprovalWorkflow) => {
+    setModalMode('edit');
+    setEditing(w);
+    setFormChangeType(w.changeType);
+    setFormRequireAll(w.requireAll);
+    setFormDescription(w.description ?? '');
+    setFormSteps(
+      w.steps.length > 0
+        ? w.steps.map((s) => ({ ...s }))
+        : [{ ...EMPTY_STEP }]
+    );
+    setSaveError(null);
+    setShowModal(true);
+  };
+
+  const handleSave = async () => {
+    if (!formChangeType.trim()) {
+      setSaveError('Change type is required.');
+      return;
+    }
+    if (formSteps.length === 0) {
+      setSaveError('At least one step is required.');
+      return;
+    }
+    setSaving(true);
+    setSaveError(null);
+    try {
+      const stepsPayload = formSteps.map((s, i) => ({
+        stepOrder: i + 1,
+        approverScope: s.approverScope,
+        approverRoleId: s.approverRoleId ?? null,
+        approverUserId: s.approverUserId ?? null,
+        autoApproveForOwner: s.autoApproveForOwner ?? false,
+        escalateAfterHours: s.escalateAfterHours ?? null,
+      }));
+      if (modalMode === 'create') {
+        const body: CreateWorkflowBody = {
+          changeType: formChangeType.trim(),
+          requireAll: formRequireAll,
+          description: formDescription.trim() || undefined,
+          steps: stepsPayload,
+        };
+        await createWorkflow(body);
+      } else if (editing) {
+        await updateWorkflow(editing.id, {
+          requireAll: formRequireAll,
+          description: formDescription.trim() || undefined,
+          steps: stepsPayload,
+        });
+      }
+      setShowModal(false);
+      await load();
+    } catch (e) {
+      setSaveError((e as Error).message ?? 'Failed to save workflow.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // ---------- Step editor helpers ----------
+
+  const addStep = () => {
+    setFormSteps((prev) => [
+      ...prev,
+      { ...EMPTY_STEP, stepOrder: prev.length + 1 },
+    ]);
+  };
+
+  const removeStep = (index: number) => {
+    setFormSteps((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  const updateStep = (index: number, patch: Partial<ApprovalStep>) => {
+    setFormSteps((prev) =>
+      prev.map((s, i) => (i === index ? { ...s, ...patch } : s))
+    );
+  };
+
+  // ---------- Delete ----------
+
+  const handleDeleteConfirm = async () => {
+    if (!deleteTarget) return;
+    setDeleting(true);
+    try {
+      await deleteWorkflow(deleteTarget.id);
+      setDeleteTarget(null);
+      await load();
+    } catch (e) {
+      setError((e as Error).message ?? 'Failed to delete workflow.');
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  return (
+    <div className="container-fluid py-4">
+      <div className="row mb-3">
+        <div className="col d-flex align-items-center justify-content-between">
+          <div>
+            <h1 className="h3 mb-0">Approval Workflows</h1>
+            <p className="text-muted mb-0 small">Configure multi-step approval chains per change type</p>
+          </div>
+          <button className="btn btn-primary btn-sm" onClick={openCreate}>
+            <i className="bi bi-plus-lg me-1" aria-hidden="true"></i>New Workflow
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="alert alert-danger" role="alert">
+          <i className="bi bi-exclamation-triangle me-2" aria-hidden="true"></i>{error}
+        </div>
+      )}
+
+      <div className="card">
+        <div className="card-body p-0">
+          {loading ? (
+            <div className="d-flex align-items-center justify-content-center py-5">
+              <span className="spinner-border me-2" role="status" aria-label="Loading workflows"></span>
+              <span>Loading…</span>
+            </div>
+          ) : workflows.length === 0 ? (
+            <div className="text-center text-muted py-5">
+              No approval workflows configured yet.
+            </div>
+          ) : (
+            <div className="table-responsive">
+              <table className="table table-hover mb-0">
+                <thead className="table-light">
+                  <tr>
+                    <th scope="col">Change Type</th>
+                    <th scope="col">Steps</th>
+                    <th scope="col">Require All</th>
+                    <th scope="col">Description</th>
+                    <th scope="col" className="text-end">Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {workflows.map((w) => (
+                    <React.Fragment key={w.id}>
+                      <tr>
+                        <td className="font-monospace small fw-semibold">{w.changeType}</td>
+                        <td>
+                          <button
+                            className="btn btn-link btn-sm p-0 text-decoration-none"
+                            onClick={() => setExpandedId(expandedId === w.id ? null : w.id)}
+                            aria-label={expandedId === w.id ? `Collapse steps for ${w.changeType}` : `Show steps for ${w.changeType}`}
+                          >
+                            {w.steps.length} step{w.steps.length !== 1 ? 's' : ''}
+                            <i
+                              className={`bi ms-1 ${expandedId === w.id ? 'bi-chevron-up' : 'bi-chevron-down'}`}
+                              aria-hidden="true"
+                            ></i>
+                          </button>
+                        </td>
+                        <td>
+                          {w.requireAll ? (
+                            <span className="badge bg-primary">All</span>
+                          ) : (
+                            <span className="badge bg-secondary">Any</span>
+                          )}
+                        </td>
+                        <td className="text-muted small">{w.description ?? '—'}</td>
+                        <td className="text-end">
+                          <button
+                            className="btn btn-sm btn-outline-secondary me-1"
+                            onClick={() => openEdit(w)}
+                            aria-label={`Edit workflow ${w.changeType}`}
+                          >
+                            <i className="bi bi-pencil" aria-hidden="true"></i>
+                          </button>
+                          <button
+                            className="btn btn-sm btn-outline-danger"
+                            onClick={() => setDeleteTarget(w)}
+                            aria-label={`Delete workflow ${w.changeType}`}
+                          >
+                            <i className="bi bi-trash" aria-hidden="true"></i>
+                          </button>
+                        </td>
+                      </tr>
+                      {expandedId === w.id && (
+                        <tr>
+                          <td colSpan={5} className="bg-light border-top-0">
+                            <div className="p-3">
+                              <h6 className="small fw-semibold text-uppercase text-muted mb-2">Steps</h6>
+                              {w.steps.length === 0 ? (
+                                <span className="text-muted small">No steps defined.</span>
+                              ) : (
+                                <ol className="mb-0 small">
+                                  {w.steps.map((s) => (
+                                    <li key={s.id}>
+                                      <span className="badge bg-secondary me-2">{SCOPE_LABELS[s.approverScope]}</span>
+                                      {s.approverRoleId != null && <span className="me-2 text-muted">role: {s.approverRoleId}</span>}
+                                      {s.approverUserId != null && <span className="me-2 text-muted">user: {s.approverUserId}</span>}
+                                      {s.autoApproveForOwner && <span className="badge bg-success me-2">auto-approve</span>}
+                                      {s.escalateAfterHours != null && (
+                                        <span className="text-muted">escalate after {s.escalateAfterHours}h</span>
+                                      )}
+                                    </li>
+                                  ))}
+                                </ol>
+                              )}
+                            </div>
+                          </td>
+                        </tr>
+                      )}
+                    </React.Fragment>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Create / Edit Modal */}
+      {showModal && (
+        <div className="modal d-block" tabIndex={-1} role="dialog" aria-modal="true" aria-label={modalMode === 'create' ? 'Create workflow' : 'Edit workflow'}>
+          <div className="modal-dialog modal-lg">
+            <div className="modal-content">
+              <div className="modal-header">
+                <h5 className="modal-title">
+                  {modalMode === 'create' ? 'New Approval Workflow' : `Edit Workflow: ${editing?.changeType}`}
+                </h5>
+                <button type="button" className="btn-close" aria-label="Close dialog" onClick={() => setShowModal(false)}></button>
+              </div>
+              <div className="modal-body">
+                {saveError && (
+                  <div className="alert alert-danger py-2 small" role="alert">{saveError}</div>
+                )}
+                <div className="mb-3">
+                  <label htmlFor="wfChangeType" className="form-label">Change Type <span className="text-danger">*</span></label>
+                  <input
+                    id="wfChangeType"
+                    type="text"
+                    className="form-control"
+                    placeholder="e.g. TimeOff.Request"
+                    value={formChangeType}
+                    onChange={(e) => setFormChangeType(e.target.value)}
+                    disabled={modalMode === 'edit'}
+                  />
+                  <div className="form-text">Unique identifier for the change type this workflow governs.</div>
+                </div>
+                <div className="mb-3">
+                  <label htmlFor="wfDescription" className="form-label">Description</label>
+                  <input
+                    id="wfDescription"
+                    type="text"
+                    className="form-control"
+                    placeholder="Optional description"
+                    value={formDescription}
+                    onChange={(e) => setFormDescription(e.target.value)}
+                  />
+                </div>
+                <div className="mb-3 form-check">
+                  <input
+                    type="checkbox"
+                    className="form-check-input"
+                    id="wfRequireAll"
+                    checked={formRequireAll}
+                    onChange={(e) => setFormRequireAll(e.target.checked)}
+                  />
+                  <label className="form-check-label" htmlFor="wfRequireAll">
+                    Require all approvers (parallel approval; otherwise any single approver suffices)
+                  </label>
+                </div>
+
+                <div className="d-flex align-items-center justify-content-between mb-2">
+                  <h6 className="mb-0">Approval Steps</h6>
+                  <button type="button" className="btn btn-sm btn-outline-primary" onClick={addStep}>
+                    <i className="bi bi-plus" aria-hidden="true"></i> Add Step
+                  </button>
+                </div>
+                {formSteps.length === 0 && (
+                  <p className="text-muted small">No steps yet. Add at least one step.</p>
+                )}
+                {formSteps.map((step, i) => (
+                  <div key={i} className="border rounded p-3 mb-2 bg-light position-relative" aria-label={`Step ${i + 1}`}>
+                    <div className="d-flex align-items-center justify-content-between mb-2">
+                      <span className="fw-semibold small">Step {i + 1}</span>
+                      <button
+                        type="button"
+                        className="btn btn-sm btn-outline-danger py-0 px-1"
+                        onClick={() => removeStep(i)}
+                        disabled={formSteps.length <= 1}
+                        aria-label={`Remove step ${i + 1}`}
+                      >
+                        <i className="bi bi-x" aria-hidden="true"></i>
+                      </button>
+                    </div>
+                    <div className="row g-2">
+                      <div className="col-md-4">
+                        <label htmlFor={`stepScope-${i}`} className="form-label small">Approver Scope</label>
+                        <select
+                          id={`stepScope-${i}`}
+                          className="form-select form-select-sm"
+                          value={step.approverScope}
+                          onChange={(e) => updateStep(i, { approverScope: e.target.value as ApproverScope })}
+                        >
+                          {SCOPE_OPTIONS.map(([val, label]) => (
+                            <option key={val} value={val}>{label}</option>
+                          ))}
+                        </select>
+                      </div>
+                      {step.approverScope === 'company_role' && (
+                        <div className="col-md-4">
+                          <label htmlFor={`stepRoleId-${i}`} className="form-label small">Role ID</label>
+                          <input
+                            id={`stepRoleId-${i}`}
+                            type="number"
+                            className="form-control form-control-sm"
+                            value={step.approverRoleId ?? ''}
+                            onChange={(e) => updateStep(i, { approverRoleId: e.target.value ? Number(e.target.value) : null })}
+                            min={1}
+                            placeholder="Role ID"
+                          />
+                        </div>
+                      )}
+                      {step.approverScope === 'company_user' && (
+                        <div className="col-md-4">
+                          <label htmlFor={`stepUserId-${i}`} className="form-label small">User ID</label>
+                          <input
+                            id={`stepUserId-${i}`}
+                            type="number"
+                            className="form-control form-control-sm"
+                            value={step.approverUserId ?? ''}
+                            onChange={(e) => updateStep(i, { approverUserId: e.target.value ? Number(e.target.value) : null })}
+                            min={1}
+                            placeholder="User ID"
+                          />
+                        </div>
+                      )}
+                      <div className="col-md-4">
+                        <label htmlFor={`stepEscalate-${i}`} className="form-label small">Escalate After (hours)</label>
+                        <input
+                          id={`stepEscalate-${i}`}
+                          type="number"
+                          className="form-control form-control-sm"
+                          value={step.escalateAfterHours ?? ''}
+                          onChange={(e) => updateStep(i, { escalateAfterHours: e.target.value ? Number(e.target.value) : null })}
+                          min={1}
+                          placeholder="Optional"
+                        />
+                      </div>
+                      <div className="col-12">
+                        <div className="form-check form-switch">
+                          <input
+                            type="checkbox"
+                            className="form-check-input"
+                            id={`stepAutoApprove-${i}`}
+                            checked={step.autoApproveForOwner ?? false}
+                            onChange={(e) => updateStep(i, { autoApproveForOwner: e.target.checked })}
+                          />
+                          <label className="form-check-label small" htmlFor={`stepAutoApprove-${i}`}>
+                            Auto-approve when the actor IS the approver (owner exception)
+                          </label>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+              <div className="modal-footer">
+                <button type="button" className="btn btn-secondary" onClick={() => setShowModal(false)}>
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-primary"
+                  onClick={handleSave}
+                  disabled={saving}
+                  aria-label={modalMode === 'create' ? 'Create workflow' : 'Save workflow'}
+                >
+                  {saving ? (
+                    <><span className="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>Saving…</>
+                  ) : (
+                    modalMode === 'create' ? 'Create' : 'Save'
+                  )}
+                </button>
+              </div>
+            </div>
+          </div>
+          <div className="modal-backdrop fade show"></div>
+        </div>
+      )}
+
+      {/* Delete Confirm Modal */}
+      {deleteTarget && (
+        <div className="modal d-block" tabIndex={-1} role="dialog" aria-modal="true">
+          <div className="modal-dialog">
+            <div className="modal-content">
+              <div className="modal-header">
+                <h5 className="modal-title">Delete Workflow</h5>
+                <button type="button" className="btn-close" aria-label="Close" onClick={() => setDeleteTarget(null)}></button>
+              </div>
+              <div className="modal-body">
+                Delete workflow <strong>{deleteTarget.changeType}</strong>?
+                <p className="mt-2 text-muted small">
+                  This will also remove all its steps and cannot be undone.
+                </p>
+              </div>
+              <div className="modal-footer">
+                <button type="button" className="btn btn-secondary" onClick={() => setDeleteTarget(null)}>Cancel</button>
+                <button
+                  type="button"
+                  className="btn btn-danger"
+                  onClick={handleDeleteConfirm}
+                  disabled={deleting}
+                  aria-label={`Confirm delete workflow ${deleteTarget.changeType}`}
+                >
+                  {deleting ? (
+                    <><span className="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>Deleting…</>
+                  ) : 'Delete'}
+                </button>
+              </div>
+            </div>
+          </div>
+          <div className="modal-backdrop fade show"></div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ApprovalWorkflows;

--- a/frontend/src/services/approvalWorkflowService.ts
+++ b/frontend/src/services/approvalWorkflowService.ts
@@ -1,0 +1,84 @@
+/**
+ * Approval workflow service — wraps /api/approval-workflows endpoints.
+ *
+ * @author Luca Ostinelli
+ */
+
+import { ApiResponse } from '../types';
+import { getAuthHeaders, handleResponse, API_BASE_URL } from './apiUtils';
+
+const BASE = `${API_BASE_URL}/approval-workflows`;
+
+export type ApproverScope =
+  | 'policy_owner'
+  | 'unit_manager'
+  | 'unit_manager_chain'
+  | 'company_role'
+  | 'company_user';
+
+export interface ApprovalStep {
+  id?: number;
+  workflowId?: number;
+  stepOrder: number;
+  approverScope: ApproverScope;
+  approverRoleId?: number | null;
+  approverUserId?: number | null;
+  autoApproveForOwner?: boolean;
+  escalateAfterHours?: number | null;
+}
+
+export interface ApprovalWorkflow {
+  id: number;
+  changeType: string;
+  requireAll: boolean;
+  description: string | null;
+  steps: ApprovalStep[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateWorkflowBody {
+  changeType: string;
+  requireAll?: boolean;
+  description?: string;
+  steps: ApprovalStep[];
+}
+
+export interface UpdateWorkflowBody {
+  requireAll?: boolean;
+  description?: string;
+  steps?: ApprovalStep[];
+}
+
+export const listWorkflows = async (): Promise<ApiResponse<ApprovalWorkflow[]>> => {
+  const res = await fetch(BASE, { method: 'GET', ...getAuthHeaders() });
+  return handleResponse<ApprovalWorkflow[]>(res);
+};
+
+export const getWorkflowByType = async (changeType: string): Promise<ApiResponse<ApprovalWorkflow>> => {
+  const res = await fetch(`${BASE}/${encodeURIComponent(changeType)}`, { method: 'GET', ...getAuthHeaders() });
+  return handleResponse<ApprovalWorkflow>(res);
+};
+
+export const createWorkflow = async (body: CreateWorkflowBody): Promise<ApiResponse<ApprovalWorkflow>> => {
+  const res = await fetch(BASE, {
+    method: 'POST',
+    ...getAuthHeaders(),
+    body: JSON.stringify(body),
+  });
+  return handleResponse<ApprovalWorkflow>(res);
+};
+
+export const updateWorkflow = async (id: number, body: UpdateWorkflowBody): Promise<ApiResponse<ApprovalWorkflow>> => {
+  const res = await fetch(`${BASE}/${id}`, {
+    method: 'PUT',
+    ...getAuthHeaders(),
+    body: JSON.stringify(body),
+  });
+  return handleResponse<ApprovalWorkflow>(res);
+};
+
+export const deleteWorkflow = async (id: number): Promise<ApiResponse<void>> => {
+  const res = await fetch(`${BASE}/${id}`, { method: 'DELETE', ...getAuthHeaders() });
+  return handleResponse<void>(res);
+};

--- a/frontend/src/services/approvalWorkflowService.ts
+++ b/frontend/src/services/approvalWorkflowService.ts
@@ -55,11 +55,6 @@ export const listWorkflows = async (): Promise<ApiResponse<ApprovalWorkflow[]>> 
   return handleResponse<ApprovalWorkflow[]>(res);
 };
 
-export const getWorkflowByType = async (changeType: string): Promise<ApiResponse<ApprovalWorkflow>> => {
-  const res = await fetch(`${BASE}/${encodeURIComponent(changeType)}`, { method: 'GET', ...getAuthHeaders() });
-  return handleResponse<ApprovalWorkflow>(res);
-};
-
 export const createWorkflow = async (body: CreateWorkflowBody): Promise<ApiResponse<ApprovalWorkflow>> => {
   const res = await fetch(BASE, {
     method: 'POST',


### PR DESCRIPTION
## Summary
- Adds \`/admin/approval-workflows\` page for managing multi-step approval chains
- Each workflow ties a \`changeType\` string to an ordered list of steps; each step defines approver scope (unit manager, manager chain, company role, specific user), optional role/user ID, escalation hours, and auto-approve flag
- Create/edit modal with inline step editor; delete confirmation dialog; inline step expansion in the table
- \`approvalWorkflowService.ts\` wraps all \`/api/approval-workflows\` CRUD endpoints
- Route protected by \`approval.manage\` permission; nav item added to Sidebar

## Test plan
- [ ] All 14 \`ApprovalWorkflows.test.tsx\` tests pass (verified locally)
- [ ] Creating a workflow with no change type shows validation error
- [ ] Edit mode disables the change type field
- [ ] Delete confirm dialog shows workflow name before deletion