### PR TITLE
feat(frontend): Block B user-flow pages — pending approvals, change requests, delegations

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -51,6 +51,9 @@ const Settings = lazy(() => import('./pages/Settings/Settings'));
 const OrgManagement = lazy(() => import('./pages/Org/OrgManagement'));
 const Policies = lazy(() => import('./pages/Policies/Policies'));
 const Governance = lazy(() => import('./pages/Governance/Governance'));
+const PendingApprovals = lazy(() => import('./pages/Approvals/PendingApprovals'));
+const ChangeRequests = lazy(() => import('./pages/ChangeRequests/ChangeRequests'));
+const Delegations = lazy(() => import('./pages/Delegations/Delegations'));
 
 /**
  * Main Application Component
@@ -131,6 +134,13 @@ const App: React.FC = () => {
           <Route path="settings" element={
             <PermissionRoute permission="settings.manage">
               <Settings />
+            </PermissionRoute>
+          } />
+          <Route path="approvals/pending" element={<PendingApprovals />} />
+          <Route path="change-requests" element={<ChangeRequests />} />
+          <Route path="delegations" element={
+            <PermissionRoute permission="delegation.manage">
+              <Delegations />
             </PermissionRoute>
           } />
         </Route>

--- a/frontend/src/components/Layout/Sidebar.tsx
+++ b/frontend/src/components/Layout/Sidebar.tsx
@@ -101,6 +101,24 @@ const Sidebar: React.FC<SidebarProps> = ({ collapsed }) => {
       label: 'Settings',
       requiredPermission: 'settings.manage',
     },
+    {
+      path: '/approvals/pending',
+      icon: 'bi-inbox',
+      label: 'Pending Approvals',
+      requiredPermission: null,
+    },
+    {
+      path: '/change-requests',
+      icon: 'bi-pencil-square',
+      label: 'Change Requests',
+      requiredPermission: null,
+    },
+    {
+      path: '/delegations',
+      icon: 'bi-person-check',
+      label: 'Delegations',
+      requiredPermission: 'delegation.manage',
+    },
   ];
 
   const hasPermission = (requiredPermission: string | null): boolean => {

--- a/frontend/src/pages/Approvals/PendingApprovals.test.tsx
+++ b/frontend/src/pages/Approvals/PendingApprovals.test.tsx
@@ -1,0 +1,191 @@
+/**
+ * Tests for PendingApprovals page.
+ *
+ * @author Luca Ostinelli
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import PendingApprovals from './PendingApprovals';
+
+jest.mock('../../services/pendingApprovalService', () => ({
+  listPendingApprovals: jest.fn(),
+  approvePendingItem: jest.fn(),
+  rejectPendingItem: jest.fn(),
+}));
+
+const {
+  listPendingApprovals: mockList,
+  approvePendingItem: mockApprove,
+  rejectPendingItem: mockReject,
+} = jest.requireMock('../../services/pendingApprovalService') as {
+  listPendingApprovals: jest.Mock;
+  approvePendingItem: jest.Mock;
+  rejectPendingItem: jest.Mock;
+};
+
+const ITEM_1 = {
+  id: 1,
+  changeRequestId: 10,
+  workflowId: 1,
+  stepId: 1,
+  stepOrder: 1,
+  assignedToUserId: 5,
+  status: 'pending',
+  decidedAt: null,
+  decisionNote: null,
+  escalatedAt: null,
+  createdAt: '2024-01-15T10:00:00.000Z',
+  updatedAt: '2024-01-15T10:00:00.000Z',
+  changeType: 'TimeOff.Request',
+  targetEntityType: 'leave',
+  targetEntityId: null,
+  proposedPayload: { days: 3, type: 'vacation' },
+  justification: 'Family event',
+  proposerUserId: 3,
+};
+
+const ITEM_2 = {
+  ...ITEM_1,
+  id: 2,
+  changeRequestId: 11,
+  status: 'approved',
+  changeType: 'Schedule.Change',
+  targetEntityType: 'shift',
+  targetEntityId: 42,
+  proposedPayload: { shiftId: 42 },
+  justification: null,
+  proposerUserId: 7,
+};
+
+const makeResponse = (items = [ITEM_1, ITEM_2]) => ({
+  success: true,
+  data: { items, total: items.length },
+});
+
+beforeEach(() => {
+  mockList.mockResolvedValue(makeResponse());
+  mockApprove.mockResolvedValue({ success: true, data: { ...ITEM_1, status: 'approved' } });
+  mockReject.mockResolvedValue({ success: true, data: { ...ITEM_1, status: 'rejected' } });
+});
+
+afterEach(() => jest.clearAllMocks());
+
+describe('<PendingApprovals />', () => {
+  it('renders the page heading', async () => {
+    render(<PendingApprovals />);
+    expect(screen.getByRole('heading', { name: /pending approvals/i })).toBeInTheDocument();
+  });
+
+  it('shows items after loading', async () => {
+    render(<PendingApprovals />);
+    expect(await screen.findByText('TimeOff.Request')).toBeInTheDocument();
+    expect(screen.getByText('Schedule.Change')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no items', async () => {
+    mockList.mockResolvedValue(makeResponse([]));
+    render(<PendingApprovals />);
+    expect(await screen.findByText(/no pending approvals/i)).toBeInTheDocument();
+  });
+
+  it('shows error alert on load failure', async () => {
+    mockList.mockRejectedValue(new Error('Unauthorized'));
+    render(<PendingApprovals />);
+    expect(await screen.findByRole('alert')).toBeInTheDocument();
+  });
+
+  it('shows Approve and Reject buttons only for pending items', async () => {
+    render(<PendingApprovals />);
+    await screen.findByText('TimeOff.Request');
+
+    // ITEM_1 is pending → has approve and reject buttons
+    expect(screen.getByRole('button', { name: /approve item 1/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /reject item 1/i })).toBeInTheDocument();
+
+    // ITEM_2 is approved → no approve/reject buttons for it
+    expect(screen.queryByRole('button', { name: /approve item 2/i })).not.toBeInTheDocument();
+  });
+
+  it('opens approve modal when Approve is clicked', async () => {
+    render(<PendingApprovals />);
+    await screen.findByText('TimeOff.Request');
+
+    await userEvent.click(screen.getByRole('button', { name: /approve item 1/i }));
+    expect(screen.getByRole('dialog', { name: /approve item 1/i })).toBeInTheDocument();
+    expect(screen.getByLabelText(/note/i)).toBeInTheDocument();
+  });
+
+  it('calls approvePendingItem with note and reloads', async () => {
+    render(<PendingApprovals />);
+    await screen.findByText('TimeOff.Request');
+
+    await userEvent.click(screen.getByRole('button', { name: /approve item 1/i }));
+    await userEvent.type(screen.getByLabelText(/note/i), 'Approved by manager');
+    await userEvent.click(screen.getByRole('button', { name: /confirm approve/i }));
+
+    await waitFor(() =>
+      expect(mockApprove).toHaveBeenCalledWith(1, 'Approved by manager')
+    );
+    await waitFor(() => expect(mockList).toHaveBeenCalledTimes(2));
+    // Modal closes
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('opens reject modal when Reject is clicked', async () => {
+    render(<PendingApprovals />);
+    await screen.findByText('TimeOff.Request');
+
+    await userEvent.click(screen.getByRole('button', { name: /reject item 1/i }));
+    expect(screen.getByRole('dialog', { name: /reject item 1/i })).toBeInTheDocument();
+  });
+
+  it('calls rejectPendingItem and reloads on confirm', async () => {
+    render(<PendingApprovals />);
+    await screen.findByText('TimeOff.Request');
+
+    await userEvent.click(screen.getByRole('button', { name: /reject item 1/i }));
+    await userEvent.click(screen.getByRole('button', { name: /confirm reject/i }));
+
+    await waitFor(() => expect(mockReject).toHaveBeenCalledWith(1, undefined));
+    await waitFor(() => expect(mockList).toHaveBeenCalledTimes(2));
+  });
+
+  it('expands row to show payload when change type is clicked', async () => {
+    render(<PendingApprovals />);
+    await screen.findByText('TimeOff.Request');
+
+    await userEvent.click(screen.getByRole('button', { name: /expand details for item 1/i }));
+    expect(screen.getByText(/family event/i)).toBeInTheDocument();
+    expect(screen.getByText(/proposed payload/i)).toBeInTheDocument();
+  });
+
+  it('collapses row on second click', async () => {
+    render(<PendingApprovals />);
+    await screen.findByText('TimeOff.Request');
+
+    await userEvent.click(screen.getByRole('button', { name: /expand details for item 1/i }));
+    expect(screen.getByText(/family event/i)).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /collapse details for item 1/i }));
+    expect(screen.queryByText(/family event/i)).not.toBeInTheDocument();
+  });
+
+  it('shows All filter button and loads all statuses when clicked', async () => {
+    render(<PendingApprovals />);
+    await screen.findByText('TimeOff.Request');
+
+    await userEvent.click(screen.getByRole('button', { name: /^all$/i }));
+    await waitFor(() =>
+      expect(mockList).toHaveBeenCalledWith(undefined)
+    );
+  });
+
+  it('shows status badge for each item', async () => {
+    render(<PendingApprovals />);
+    await screen.findByText('TimeOff.Request');
+
+    expect(screen.getByText('pending')).toBeInTheDocument();
+    expect(screen.getByText('approved')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/Approvals/PendingApprovals.tsx
+++ b/frontend/src/pages/Approvals/PendingApprovals.tsx
@@ -1,0 +1,294 @@
+/**
+ * PendingApprovals — inbox for items awaiting the current user's decision.
+ *
+ * Each row shows the change type, proposer, and the proposed payload.
+ * The approver can approve or reject with an optional note, which is recorded
+ * in the audit log and advances (or closes) the workflow.
+ *
+ * Accessible to all authenticated users; the backend only returns items
+ * assigned to the current user.
+ *
+ * @author Luca Ostinelli
+ */
+
+import React, { useEffect, useState, useCallback } from 'react';
+import {
+  listPendingApprovals,
+  approvePendingItem,
+  rejectPendingItem,
+  PendingApprovalItem,
+} from '../../services/pendingApprovalService';
+
+type DecisionMode = 'approve' | 'reject';
+
+const STATUS_BADGE: Record<string, string> = {
+  pending: 'bg-warning text-dark',
+  approved: 'bg-success',
+  rejected: 'bg-danger',
+  escalated: 'bg-secondary',
+};
+
+const PendingApprovals: React.FC = () => {
+  const [items, setItems] = useState<PendingApprovalItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [filter, setFilter] = useState<'pending' | 'all'>('pending');
+
+  // Decision modal state
+  const [decisionTarget, setDecisionTarget] = useState<PendingApprovalItem | null>(null);
+  const [decisionMode, setDecisionMode] = useState<DecisionMode>('approve');
+  const [note, setNote] = useState('');
+  const [deciding, setDeciding] = useState(false);
+  const [decisionError, setDecisionError] = useState<string | null>(null);
+
+  // Expanded row for payload view
+  const [expandedId, setExpandedId] = useState<number | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const status = filter === 'pending' ? 'pending' : undefined;
+      const res = await listPendingApprovals(status as string);
+      setItems(res.data?.items ?? []);
+    } catch (e) {
+      setError((e as Error).message ?? 'Failed to load pending approvals.');
+    } finally {
+      setLoading(false);
+    }
+  }, [filter]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const openDecision = (item: PendingApprovalItem, mode: DecisionMode) => {
+    setDecisionTarget(item);
+    setDecisionMode(mode);
+    setNote('');
+    setDecisionError(null);
+  };
+
+  const handleDecisionConfirm = async () => {
+    if (!decisionTarget) return;
+    setDeciding(true);
+    setDecisionError(null);
+    try {
+      if (decisionMode === 'approve') {
+        await approvePendingItem(decisionTarget.id, note || undefined);
+      } else {
+        await rejectPendingItem(decisionTarget.id, note || undefined);
+      }
+      setDecisionTarget(null);
+      await load();
+    } catch (e) {
+      setDecisionError((e as Error).message ?? 'Action failed.');
+    } finally {
+      setDeciding(false);
+    }
+  };
+
+  const formatDate = (iso: string) => {
+    try { return new Date(iso).toLocaleString(); } catch { return iso; }
+  };
+
+  return (
+    <div className="container-fluid py-4">
+      <div className="row mb-3">
+        <div className="col d-flex align-items-center justify-content-between">
+          <div>
+            <h1 className="h3 mb-0">Pending Approvals</h1>
+            <p className="text-muted mb-0 small">Items assigned to you for review</p>
+          </div>
+          <div className="d-flex gap-2 align-items-center">
+            <div className="btn-group btn-group-sm" role="group" aria-label="Filter by status">
+              <button
+                type="button"
+                className={`btn ${filter === 'pending' ? 'btn-primary' : 'btn-outline-secondary'}`}
+                onClick={() => setFilter('pending')}
+              >
+                Pending
+              </button>
+              <button
+                type="button"
+                className={`btn ${filter === 'all' ? 'btn-primary' : 'btn-outline-secondary'}`}
+                onClick={() => setFilter('all')}
+              >
+                All
+              </button>
+            </div>
+            <button className="btn btn-sm btn-outline-secondary" onClick={load} aria-label="Refresh">
+              <i className="bi bi-arrow-clockwise" aria-hidden="true"></i>
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {error && (
+        <div className="alert alert-danger" role="alert">
+          <i className="bi bi-exclamation-triangle me-2" aria-hidden="true"></i>{error}
+        </div>
+      )}
+
+      <div className="card">
+        <div className="card-body p-0">
+          {loading ? (
+            <div className="d-flex align-items-center justify-content-center py-5">
+              <span className="spinner-border me-2" role="status" aria-label="Loading"></span>
+              <span>Loading…</span>
+            </div>
+          ) : items.length === 0 ? (
+            <div className="text-center text-muted py-5">
+              <i className="bi bi-inbox fs-3 d-block mb-2" aria-hidden="true"></i>
+              No pending approvals for you.
+            </div>
+          ) : (
+            <div className="table-responsive">
+              <table className="table table-hover mb-0">
+                <thead className="table-light">
+                  <tr>
+                    <th scope="col">#</th>
+                    <th scope="col">Change Type</th>
+                    <th scope="col">Entity</th>
+                    <th scope="col">Proposer ID</th>
+                    <th scope="col">Step</th>
+                    <th scope="col">Status</th>
+                    <th scope="col">Created</th>
+                    <th scope="col" className="text-end">Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {items.map((item) => (
+                    <React.Fragment key={item.id}>
+                      <tr>
+                        <td className="text-muted small">{item.id}</td>
+                        <td>
+                          <button
+                            className="btn btn-link btn-sm p-0 text-decoration-none fw-semibold text-start"
+                            onClick={() => setExpandedId(expandedId === item.id ? null : item.id)}
+                            aria-label={expandedId === item.id ? `Collapse details for item ${item.id}` : `Expand details for item ${item.id}`}
+                          >
+                            {item.changeType}
+                            <i className={`bi ms-1 ${expandedId === item.id ? 'bi-chevron-up' : 'bi-chevron-down'}`} aria-hidden="true"></i>
+                          </button>
+                        </td>
+                        <td className="small text-muted">
+                          {item.targetEntityType}
+                          {item.targetEntityId != null && ` #${item.targetEntityId}`}
+                        </td>
+                        <td className="small text-muted">{item.proposerUserId}</td>
+                        <td className="small">{item.stepOrder}</td>
+                        <td>
+                          <span className={`badge ${STATUS_BADGE[item.status] ?? 'bg-secondary'}`}>
+                            {item.status}
+                          </span>
+                        </td>
+                        <td className="small text-muted text-nowrap">{formatDate(item.createdAt)}</td>
+                        <td className="text-end">
+                          {item.status === 'pending' && (
+                            <>
+                              <button
+                                className="btn btn-sm btn-success me-1"
+                                onClick={() => openDecision(item, 'approve')}
+                                aria-label={`Approve item ${item.id}`}
+                              >
+                                <i className="bi bi-check" aria-hidden="true"></i>
+                              </button>
+                              <button
+                                className="btn btn-sm btn-danger"
+                                onClick={() => openDecision(item, 'reject')}
+                                aria-label={`Reject item ${item.id}`}
+                              >
+                                <i className="bi bi-x" aria-hidden="true"></i>
+                              </button>
+                            </>
+                          )}
+                        </td>
+                      </tr>
+                      {expandedId === item.id && (
+                        <tr>
+                          <td colSpan={8} className="bg-light border-top-0">
+                            <div className="p-3">
+                              {item.justification && (
+                                <div className="mb-2">
+                                  <span className="fw-semibold small text-muted text-uppercase me-2">Justification</span>
+                                  <span className="small">{item.justification}</span>
+                                </div>
+                              )}
+                              <div className="mb-0">
+                                <span className="fw-semibold small text-muted text-uppercase me-2">Proposed Payload</span>
+                                <pre className="bg-white border rounded p-2 small mb-0" style={{ maxHeight: 200, overflow: 'auto', fontSize: '0.75rem' }}>
+                                  {JSON.stringify(item.proposedPayload, null, 2)}
+                                </pre>
+                              </div>
+                            </div>
+                          </td>
+                        </tr>
+                      )}
+                    </React.Fragment>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Decision Modal */}
+      {decisionTarget && (
+        <div className="modal d-block" tabIndex={-1} role="dialog" aria-modal="true"
+          aria-label={decisionMode === 'approve' ? `Approve item ${decisionTarget.id}` : `Reject item ${decisionTarget.id}`}>
+          <div className="modal-dialog">
+            <div className="modal-content">
+              <div className="modal-header">
+                <h5 className="modal-title">
+                  {decisionMode === 'approve' ? 'Approve' : 'Reject'} — {decisionTarget.changeType}
+                </h5>
+                <button type="button" className="btn-close" aria-label="Close" onClick={() => setDecisionTarget(null)}></button>
+              </div>
+              <div className="modal-body">
+                {decisionError && (
+                  <div className="alert alert-danger py-2 small" role="alert">{decisionError}</div>
+                )}
+                <div className="mb-3">
+                  <label htmlFor="decisionNote" className="form-label">
+                    Note <span className="text-muted small">(optional)</span>
+                  </label>
+                  <textarea
+                    id="decisionNote"
+                    className="form-control"
+                    rows={3}
+                    placeholder="Optional note recorded in the audit log"
+                    value={note}
+                    onChange={(e) => setNote(e.target.value)}
+                  />
+                </div>
+              </div>
+              <div className="modal-footer">
+                <button type="button" className="btn btn-secondary" onClick={() => setDecisionTarget(null)}>
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  className={`btn ${decisionMode === 'approve' ? 'btn-success' : 'btn-danger'}`}
+                  onClick={handleDecisionConfirm}
+                  disabled={deciding}
+                  aria-label={decisionMode === 'approve' ? 'Confirm approve' : 'Confirm reject'}
+                >
+                  {deciding ? (
+                    <><span className="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>Saving…</>
+                  ) : (
+                    decisionMode === 'approve' ? 'Approve' : 'Reject'
+                  )}
+                </button>
+              </div>
+            </div>
+          </div>
+          <div className="modal-backdrop fade show"></div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default PendingApprovals;

--- a/frontend/src/pages/ChangeRequests/ChangeRequests.test.tsx
+++ b/frontend/src/pages/ChangeRequests/ChangeRequests.test.tsx
@@ -1,0 +1,230 @@
+/**
+ * Tests for ChangeRequests page.
+ *
+ * @author Luca Ostinelli
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ChangeRequests from './ChangeRequests';
+
+jest.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({
+    user: {
+      id: 1,
+      permissions: ['change_request.create', 'change_request.review', 'change_request.approve'],
+    },
+  }),
+}));
+
+jest.mock('../../services/changeRequestService', () => ({
+  listChangeRequests: jest.fn(),
+  createChangeRequest: jest.fn(),
+  approveChangeRequest: jest.fn(),
+  rejectChangeRequest: jest.fn(),
+  cancelChangeRequest: jest.fn(),
+}));
+
+const {
+  listChangeRequests: mockList,
+  createChangeRequest: mockCreate,
+  approveChangeRequest: mockApprove,
+  rejectChangeRequest: mockReject,
+  cancelChangeRequest: mockCancel,
+} = jest.requireMock('../../services/changeRequestService') as {
+  listChangeRequests: jest.Mock;
+  createChangeRequest: jest.Mock;
+  approveChangeRequest: jest.Mock;
+  rejectChangeRequest: jest.Mock;
+  cancelChangeRequest: jest.Mock;
+};
+
+const ITEM_PENDING = {
+  id: 1,
+  changeType: 'TimeOff.Request',
+  proposerUserId: 1,
+  targetEntityType: 'leave',
+  targetEntityId: null,
+  proposedPayload: { days: 3 },
+  justification: 'Family event',
+  status: 'pending',
+  approverUserId: null,
+  approvedAt: null,
+  rejectedAt: null,
+  rejectionReason: null,
+  appliedAt: null,
+  onBehalfOfUserId: null,
+  createdAt: '2024-01-15T10:00:00.000Z',
+  updatedAt: '2024-01-15T10:00:00.000Z',
+};
+
+const ITEM_APPROVED = {
+  ...ITEM_PENDING,
+  id: 2,
+  changeType: 'Schedule.Change',
+  targetEntityType: 'shift',
+  targetEntityId: 42,
+  status: 'approved',
+  proposedPayload: { shiftId: 42 },
+  justification: null,
+};
+
+const makeResponse = (items = [ITEM_PENDING, ITEM_APPROVED]) => ({
+  success: true,
+  data: { items, total: items.length },
+});
+
+beforeEach(() => {
+  mockList.mockResolvedValue(makeResponse());
+  mockCreate.mockResolvedValue({ success: true, data: { ...ITEM_PENDING, id: 99 } });
+  mockApprove.mockResolvedValue({ success: true, data: { ...ITEM_PENDING, status: 'approved' } });
+  mockReject.mockResolvedValue({ success: true, data: { ...ITEM_PENDING, status: 'rejected' } });
+  mockCancel.mockResolvedValue({ success: true, data: { ...ITEM_PENDING, status: 'cancelled' } });
+});
+
+afterEach(() => jest.clearAllMocks());
+
+describe('<ChangeRequests />', () => {
+  it('renders the page heading', async () => {
+    render(<ChangeRequests />);
+    expect(screen.getByRole('heading', { name: /change requests/i })).toBeInTheDocument();
+  });
+
+  it('shows items after loading', async () => {
+    render(<ChangeRequests />);
+    expect(await screen.findByText('TimeOff.Request')).toBeInTheDocument();
+    expect(screen.getByText('Schedule.Change')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no items', async () => {
+    mockList.mockResolvedValue(makeResponse([]));
+    render(<ChangeRequests />);
+    expect(await screen.findByText(/no change requests found/i)).toBeInTheDocument();
+  });
+
+  it('shows error alert on load failure', async () => {
+    mockList.mockRejectedValue(new Error('Network error'));
+    render(<ChangeRequests />);
+    expect(await screen.findByRole('alert')).toBeInTheDocument();
+  });
+
+  it('shows status badges', async () => {
+    render(<ChangeRequests />);
+    await screen.findByText('TimeOff.Request');
+    expect(screen.getByText('pending')).toBeInTheDocument();
+    expect(screen.getByText('approved')).toBeInTheDocument();
+  });
+
+  it('shows Approve/Reject/Cancel buttons only for pending items', async () => {
+    render(<ChangeRequests />);
+    await screen.findByText('TimeOff.Request');
+
+    expect(screen.getByRole('button', { name: /approve request 1/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /reject request 1/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /cancel request 1/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /approve request 2/i })).not.toBeInTheDocument();
+  });
+
+  it('opens approve modal when Approve is clicked', async () => {
+    render(<ChangeRequests />);
+    await screen.findByText('TimeOff.Request');
+    await userEvent.click(screen.getByRole('button', { name: /approve request 1/i }));
+    expect(screen.getByRole('dialog', { name: /approve request 1/i })).toBeInTheDocument();
+  });
+
+  it('calls approveChangeRequest and reloads on confirm', async () => {
+    render(<ChangeRequests />);
+    await screen.findByText('TimeOff.Request');
+    await userEvent.click(screen.getByRole('button', { name: /approve request 1/i }));
+    await userEvent.type(screen.getByLabelText(/justification/i), 'Good reason');
+    await userEvent.click(screen.getByRole('button', { name: /confirm approve/i }));
+
+    await waitFor(() => expect(mockApprove).toHaveBeenCalledWith(1, 'Good reason'));
+    await waitFor(() => expect(mockList).toHaveBeenCalledTimes(2));
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('opens reject modal when Reject is clicked', async () => {
+    render(<ChangeRequests />);
+    await screen.findByText('TimeOff.Request');
+    await userEvent.click(screen.getByRole('button', { name: /reject request 1/i }));
+    expect(screen.getByRole('dialog', { name: /reject request 1/i })).toBeInTheDocument();
+  });
+
+  it('shows validation error when rejecting without a reason', async () => {
+    render(<ChangeRequests />);
+    await screen.findByText('TimeOff.Request');
+    await userEvent.click(screen.getByRole('button', { name: /reject request 1/i }));
+    await userEvent.click(screen.getByRole('button', { name: /confirm reject/i }));
+
+    expect(await screen.findByText(/rejection reason is required/i)).toBeInTheDocument();
+    expect(mockReject).not.toHaveBeenCalled();
+  });
+
+  it('calls rejectChangeRequest with reason and reloads', async () => {
+    render(<ChangeRequests />);
+    await screen.findByText('TimeOff.Request');
+    await userEvent.click(screen.getByRole('button', { name: /reject request 1/i }));
+    await userEvent.type(screen.getByLabelText(/rejection reason/i), 'Not eligible');
+    await userEvent.click(screen.getByRole('button', { name: /confirm reject/i }));
+
+    await waitFor(() => expect(mockReject).toHaveBeenCalledWith(1, 'Not eligible'));
+    await waitFor(() => expect(mockList).toHaveBeenCalledTimes(2));
+  });
+
+  it('calls cancelChangeRequest on Cancel button click', async () => {
+    render(<ChangeRequests />);
+    await screen.findByText('TimeOff.Request');
+    await userEvent.click(screen.getByRole('button', { name: /cancel request 1/i }));
+
+    await waitFor(() => expect(mockCancel).toHaveBeenCalledWith(1));
+    await waitFor(() => expect(mockList).toHaveBeenCalledTimes(2));
+  });
+
+  it('expands row to show payload when change type is clicked', async () => {
+    render(<ChangeRequests />);
+    await screen.findByText('TimeOff.Request');
+    await userEvent.click(screen.getByRole('button', { name: /expand request 1/i }));
+
+    expect(screen.getByText(/family event/i)).toBeInTheDocument();
+    expect(screen.getByText(/proposed payload/i)).toBeInTheDocument();
+  });
+
+  it('collapses expanded row on second click', async () => {
+    render(<ChangeRequests />);
+    await screen.findByText('TimeOff.Request');
+    await userEvent.click(screen.getByRole('button', { name: /expand request 1/i }));
+    expect(screen.getByText(/family event/i)).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /collapse request 1/i }));
+    expect(screen.queryByText(/family event/i)).not.toBeInTheDocument();
+  });
+
+  it('opens New Request modal and submits', async () => {
+    render(<ChangeRequests />);
+    await screen.findByText('TimeOff.Request');
+
+    await userEvent.click(screen.getByRole('button', { name: /new request/i }));
+    expect(screen.getByRole('dialog', { name: /new change request/i })).toBeInTheDocument();
+
+    await userEvent.type(screen.getByLabelText(/change type/i), 'Shift.Swap');
+    await userEvent.type(screen.getByLabelText(/entity type/i), 'shift');
+
+    await userEvent.click(screen.getByRole('button', { name: /submit change request/i }));
+
+    await waitFor(() => expect(mockCreate).toHaveBeenCalled());
+    await waitFor(() => expect(mockList).toHaveBeenCalledTimes(2));
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('shows All Requests tab for reviewers and loads all when clicked', async () => {
+    render(<ChangeRequests />);
+    await screen.findByText('TimeOff.Request');
+
+    const allTab = screen.getByRole('tab', { name: /all requests/i });
+    expect(allTab).toBeInTheDocument();
+
+    await userEvent.click(allTab);
+    await waitFor(() => expect(mockList).toHaveBeenCalledTimes(2));
+  });
+});

--- a/frontend/src/pages/ChangeRequests/ChangeRequests.tsx
+++ b/frontend/src/pages/ChangeRequests/ChangeRequests.tsx
@@ -1,0 +1,489 @@
+/**
+ * ChangeRequests — page for submitting and tracking change requests.
+ *
+ * Users with `change_request.create` can submit requests that appear as
+ * proposals for review. Reviewers with `change_request.review` can approve,
+ * reject, or apply requests. Proposers can cancel their own pending requests.
+ *
+ * @author Luca Ostinelli
+ */
+
+import React, { useEffect, useState, useCallback } from 'react';
+import {
+  listChangeRequests,
+  createChangeRequest,
+  approveChangeRequest,
+  rejectChangeRequest,
+  cancelChangeRequest,
+  ChangeRequest,
+  ChangeRequestStatus,
+  CreateChangeRequestInput,
+} from '../../services/changeRequestService';
+import { useAuth } from '../../contexts/AuthContext';
+
+const STATUS_BADGE: Record<ChangeRequestStatus, string> = {
+  pending: 'bg-warning text-dark',
+  approved: 'bg-success',
+  rejected: 'bg-danger',
+  applied: 'bg-primary',
+  cancelled: 'bg-secondary',
+};
+
+const EMPTY_FORM: Omit<CreateChangeRequestInput, 'proposedPayload'> & { payloadText: string } = {
+  changeType: '',
+  targetEntityType: '',
+  targetEntityId: undefined,
+  justification: '',
+  payloadText: '{}',
+};
+
+const ChangeRequests: React.FC = () => {
+  const { user } = useAuth();
+  const [items, setItems] = useState<ChangeRequest[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [tab, setTab] = useState<'mine' | 'all'>('mine');
+  const [statusFilter, setStatusFilter] = useState<ChangeRequestStatus | ''>('');
+  const [expandedId, setExpandedId] = useState<number | null>(null);
+
+  // Create modal
+  const [showCreate, setShowCreate] = useState(false);
+  const [form, setForm] = useState({ ...EMPTY_FORM });
+  const [creating, setCreating] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+
+  // Review modal (approve/reject)
+  const [reviewTarget, setReviewTarget] = useState<ChangeRequest | null>(null);
+  const [reviewMode, setReviewMode] = useState<'approve' | 'reject'>('approve');
+  const [reviewNote, setReviewNote] = useState('');
+  const [reviewing, setReviewing] = useState(false);
+  const [reviewError, setReviewError] = useState<string | null>(null);
+
+  const canReview = user?.permissions?.includes('change_request.review') ?? false;
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = {
+        ...(tab === 'mine' ? { proposerUserId: Number(user?.id) } : {}),
+        ...(statusFilter ? { status: statusFilter as ChangeRequestStatus } : {}),
+        limit: 50,
+        offset: 0,
+      };
+      const res = await listChangeRequests(params);
+      const page = res.data;
+      setItems(page?.items ?? []);
+      setTotal(page?.total ?? 0);
+    } catch (e) {
+      setError((e as Error).message ?? 'Failed to load change requests.');
+    } finally {
+      setLoading(false);
+    }
+  }, [tab, statusFilter, user?.id]);
+
+  useEffect(() => { void load(); }, [load]);
+
+  // ---------- Create ----------
+
+  const handleCreate = async () => {
+    if (!form.changeType.trim()) { setCreateError('Change type is required.'); return; }
+    if (!form.targetEntityType.trim()) { setCreateError('Entity type is required.'); return; }
+    let payload: Record<string, unknown>;
+    try {
+      payload = JSON.parse(form.payloadText || '{}');
+    } catch {
+      setCreateError('Proposed payload must be valid JSON.');
+      return;
+    }
+    setCreating(true);
+    setCreateError(null);
+    try {
+      const body: CreateChangeRequestInput = {
+        changeType: form.changeType.trim(),
+        targetEntityType: form.targetEntityType.trim(),
+        targetEntityId: form.targetEntityId ?? null,
+        proposedPayload: payload,
+        justification: form.justification?.trim() || null,
+      };
+      await createChangeRequest(body);
+      setShowCreate(false);
+      setForm({ ...EMPTY_FORM });
+      await load();
+    } catch (e) {
+      setCreateError((e as Error).message ?? 'Failed to submit change request.');
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  // ---------- Review ----------
+
+  const openReview = (item: ChangeRequest, mode: 'approve' | 'reject') => {
+    setReviewTarget(item);
+    setReviewMode(mode);
+    setReviewNote('');
+    setReviewError(null);
+  };
+
+  const handleReview = async () => {
+    if (!reviewTarget) return;
+    if (reviewMode === 'reject' && !reviewNote.trim()) {
+      setReviewError('A rejection reason is required.');
+      return;
+    }
+    setReviewing(true);
+    setReviewError(null);
+    try {
+      if (reviewMode === 'approve') {
+        await approveChangeRequest(reviewTarget.id, reviewNote.trim() || null);
+      } else {
+        await rejectChangeRequest(reviewTarget.id, reviewNote.trim());
+      }
+      setReviewTarget(null);
+      await load();
+    } catch (e) {
+      setReviewError((e as Error).message ?? 'Action failed.');
+    } finally {
+      setReviewing(false);
+    }
+  };
+
+  // ---------- Cancel ----------
+
+  const handleCancel = async (item: ChangeRequest) => {
+    try {
+      await cancelChangeRequest(item.id);
+      await load();
+    } catch (e) {
+      setError((e as Error).message ?? 'Cancel failed.');
+    }
+  };
+
+  const formatDate = (iso: string | null) => {
+    if (!iso) return '—';
+    try { return new Date(iso).toLocaleString(); } catch { return iso; }
+  };
+
+  return (
+    <div className="container-fluid py-4">
+      <div className="row mb-3">
+        <div className="col d-flex align-items-center justify-content-between">
+          <div>
+            <h1 className="h3 mb-0">Change Requests</h1>
+            <p className="text-muted mb-0 small">Propose changes that appear as manager decisions when approved</p>
+          </div>
+          <button className="btn btn-primary btn-sm" onClick={() => { setForm({ ...EMPTY_FORM }); setCreateError(null); setShowCreate(true); }}>
+            <i className="bi bi-plus-lg me-1" aria-hidden="true"></i>New Request
+          </button>
+        </div>
+      </div>
+
+      {/* Tabs and filters */}
+      <div className="d-flex align-items-center gap-3 mb-3">
+        <ul className="nav nav-tabs mb-0 flex-shrink-0" role="tablist">
+          <li className="nav-item">
+            <button
+              className={`nav-link ${tab === 'mine' ? 'active' : ''}`}
+              role="tab"
+              onClick={() => setTab('mine')}
+            >
+              My Requests
+            </button>
+          </li>
+          {canReview && (
+            <li className="nav-item">
+              <button
+                className={`nav-link ${tab === 'all' ? 'active' : ''}`}
+                role="tab"
+                onClick={() => setTab('all')}
+              >
+                All Requests
+              </button>
+            </li>
+          )}
+        </ul>
+        <select
+          className="form-select form-select-sm w-auto"
+          value={statusFilter}
+          onChange={(e) => setStatusFilter(e.target.value as ChangeRequestStatus | '')}
+          aria-label="Filter by status"
+        >
+          <option value="">All statuses</option>
+          <option value="pending">Pending</option>
+          <option value="approved">Approved</option>
+          <option value="rejected">Rejected</option>
+          <option value="applied">Applied</option>
+          <option value="cancelled">Cancelled</option>
+        </select>
+      </div>
+
+      {error && (
+        <div className="alert alert-danger" role="alert">
+          <i className="bi bi-exclamation-triangle me-2" aria-hidden="true"></i>{error}
+        </div>
+      )}
+
+      <div className="card">
+        <div className="card-header d-flex align-items-center justify-content-between">
+          <small className="text-muted">{loading ? 'Loading…' : `${total} request${total !== 1 ? 's' : ''}`}</small>
+        </div>
+        <div className="card-body p-0">
+          {loading ? (
+            <div className="d-flex align-items-center justify-content-center py-5">
+              <span className="spinner-border me-2" role="status" aria-label="Loading"></span>
+            </div>
+          ) : items.length === 0 ? (
+            <div className="text-center text-muted py-5">No change requests found.</div>
+          ) : (
+            <div className="table-responsive">
+              <table className="table table-hover mb-0">
+                <thead className="table-light">
+                  <tr>
+                    <th scope="col">#</th>
+                    <th scope="col">Change Type</th>
+                    <th scope="col">Entity</th>
+                    <th scope="col">Status</th>
+                    <th scope="col">Submitted</th>
+                    <th scope="col" className="text-end">Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {items.map((item) => (
+                    <React.Fragment key={item.id}>
+                      <tr>
+                        <td className="text-muted small">{item.id}</td>
+                        <td>
+                          <button
+                            className="btn btn-link btn-sm p-0 text-decoration-none fw-semibold text-start"
+                            onClick={() => setExpandedId(expandedId === item.id ? null : item.id)}
+                            aria-label={expandedId === item.id ? `Collapse request ${item.id}` : `Expand request ${item.id}`}
+                          >
+                            {item.changeType}
+                            <i className={`bi ms-1 ${expandedId === item.id ? 'bi-chevron-up' : 'bi-chevron-down'}`} aria-hidden="true"></i>
+                          </button>
+                        </td>
+                        <td className="small text-muted">
+                          {item.targetEntityType}
+                          {item.targetEntityId != null && ` #${item.targetEntityId}`}
+                        </td>
+                        <td>
+                          <span className={`badge ${STATUS_BADGE[item.status]}`}>{item.status}</span>
+                        </td>
+                        <td className="small text-muted text-nowrap">{formatDate(item.createdAt)}</td>
+                        <td className="text-end">
+                          {canReview && item.status === 'pending' && (
+                            <>
+                              <button
+                                className="btn btn-sm btn-success me-1"
+                                onClick={() => openReview(item, 'approve')}
+                                aria-label={`Approve request ${item.id}`}
+                              >
+                                <i className="bi bi-check" aria-hidden="true"></i>
+                              </button>
+                              <button
+                                className="btn btn-sm btn-danger me-1"
+                                onClick={() => openReview(item, 'reject')}
+                                aria-label={`Reject request ${item.id}`}
+                              >
+                                <i className="bi bi-x" aria-hidden="true"></i>
+                              </button>
+                            </>
+                          )}
+                          {item.status === 'pending' && (
+                            <button
+                              className="btn btn-sm btn-outline-secondary"
+                              onClick={() => handleCancel(item)}
+                              aria-label={`Cancel request ${item.id}`}
+                            >
+                              <i className="bi bi-slash-circle" aria-hidden="true"></i>
+                            </button>
+                          )}
+                        </td>
+                      </tr>
+                      {expandedId === item.id && (
+                        <tr>
+                          <td colSpan={6} className="bg-light border-top-0">
+                            <div className="p-3">
+                              {item.justification && (
+                                <div className="mb-2">
+                                  <span className="fw-semibold small text-muted text-uppercase me-2">Justification</span>
+                                  <span className="small">{item.justification}</span>
+                                </div>
+                              )}
+                              {item.rejectionReason && (
+                                <div className="mb-2">
+                                  <span className="fw-semibold small text-danger text-uppercase me-2">Rejection Reason</span>
+                                  <span className="small">{item.rejectionReason}</span>
+                                </div>
+                              )}
+                              <div>
+                                <span className="fw-semibold small text-muted text-uppercase me-2">Proposed Payload</span>
+                                <pre className="bg-white border rounded p-2 small mb-0" style={{ maxHeight: 200, overflow: 'auto', fontSize: '0.75rem' }}>
+                                  {JSON.stringify(item.proposedPayload, null, 2)}
+                                </pre>
+                              </div>
+                            </div>
+                          </td>
+                        </tr>
+                      )}
+                    </React.Fragment>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Create Modal */}
+      {showCreate && (
+        <div className="modal d-block" tabIndex={-1} role="dialog" aria-modal="true" aria-label="New change request">
+          <div className="modal-dialog modal-lg">
+            <div className="modal-content">
+              <div className="modal-header">
+                <h5 className="modal-title">New Change Request</h5>
+                <button type="button" className="btn-close" aria-label="Close" onClick={() => setShowCreate(false)}></button>
+              </div>
+              <div className="modal-body">
+                {createError && (
+                  <div className="alert alert-danger py-2 small" role="alert">{createError}</div>
+                )}
+                <div className="row g-3">
+                  <div className="col-md-6">
+                    <label htmlFor="crChangeType" className="form-label">Change Type <span className="text-danger">*</span></label>
+                    <input
+                      id="crChangeType"
+                      type="text"
+                      className="form-control"
+                      placeholder="e.g. TimeOff.Request"
+                      value={form.changeType}
+                      onChange={(e) => setForm((f) => ({ ...f, changeType: e.target.value }))}
+                    />
+                  </div>
+                  <div className="col-md-6">
+                    <label htmlFor="crEntityType" className="form-label">Entity Type <span className="text-danger">*</span></label>
+                    <input
+                      id="crEntityType"
+                      type="text"
+                      className="form-control"
+                      placeholder="e.g. leave, shift"
+                      value={form.targetEntityType}
+                      onChange={(e) => setForm((f) => ({ ...f, targetEntityType: e.target.value }))}
+                    />
+                  </div>
+                  <div className="col-md-4">
+                    <label htmlFor="crEntityId" className="form-label">Entity ID <span className="text-muted small">(optional)</span></label>
+                    <input
+                      id="crEntityId"
+                      type="number"
+                      className="form-control"
+                      placeholder="Optional"
+                      value={form.targetEntityId ?? ''}
+                      onChange={(e) => setForm((f) => ({ ...f, targetEntityId: e.target.value ? Number(e.target.value) : undefined }))}
+                      min={1}
+                    />
+                  </div>
+                  <div className="col-12">
+                    <label htmlFor="crPayload" className="form-label">Proposed Payload (JSON) <span className="text-danger">*</span></label>
+                    <textarea
+                      id="crPayload"
+                      className="form-control font-monospace"
+                      rows={5}
+                      value={form.payloadText}
+                      onChange={(e) => setForm((f) => ({ ...f, payloadText: e.target.value }))}
+                      placeholder='{}'
+                    />
+                  </div>
+                  <div className="col-12">
+                    <label htmlFor="crJustification" className="form-label">Justification <span className="text-muted small">(optional)</span></label>
+                    <textarea
+                      id="crJustification"
+                      className="form-control"
+                      rows={2}
+                      value={form.justification ?? ''}
+                      onChange={(e) => setForm((f) => ({ ...f, justification: e.target.value }))}
+                      placeholder="Reason for this change request"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div className="modal-footer">
+                <button type="button" className="btn btn-secondary" onClick={() => setShowCreate(false)}>Cancel</button>
+                <button
+                  type="button"
+                  className="btn btn-primary"
+                  onClick={handleCreate}
+                  disabled={creating}
+                  aria-label="Submit change request"
+                >
+                  {creating ? (
+                    <><span className="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>Submitting…</>
+                  ) : 'Submit'}
+                </button>
+              </div>
+            </div>
+          </div>
+          <div className="modal-backdrop fade show"></div>
+        </div>
+      )}
+
+      {/* Review Modal */}
+      {reviewTarget && (
+        <div className="modal d-block" tabIndex={-1} role="dialog" aria-modal="true"
+          aria-label={reviewMode === 'approve' ? `Approve request ${reviewTarget.id}` : `Reject request ${reviewTarget.id}`}>
+          <div className="modal-dialog">
+            <div className="modal-content">
+              <div className="modal-header">
+                <h5 className="modal-title">
+                  {reviewMode === 'approve' ? 'Approve' : 'Reject'} — {reviewTarget.changeType}
+                </h5>
+                <button type="button" className="btn-close" aria-label="Close" onClick={() => setReviewTarget(null)}></button>
+              </div>
+              <div className="modal-body">
+                {reviewError && (
+                  <div className="alert alert-danger py-2 small" role="alert">{reviewError}</div>
+                )}
+                <div>
+                  <label htmlFor="reviewNote" className="form-label">
+                    {reviewMode === 'reject' ? 'Rejection Reason' : 'Justification'}
+                    {reviewMode === 'reject' && <span className="text-danger"> *</span>}
+                    {reviewMode === 'approve' && <span className="text-muted small"> (optional)</span>}
+                  </label>
+                  <textarea
+                    id="reviewNote"
+                    className="form-control"
+                    rows={3}
+                    value={reviewNote}
+                    onChange={(e) => setReviewNote(e.target.value)}
+                    placeholder={reviewMode === 'reject' ? 'Required — reason for rejection' : 'Optional justification'}
+                  />
+                </div>
+              </div>
+              <div className="modal-footer">
+                <button type="button" className="btn btn-secondary" onClick={() => setReviewTarget(null)}>Cancel</button>
+                <button
+                  type="button"
+                  className={`btn ${reviewMode === 'approve' ? 'btn-success' : 'btn-danger'}`}
+                  onClick={handleReview}
+                  disabled={reviewing}
+                  aria-label={reviewMode === 'approve' ? 'Confirm approve' : 'Confirm reject'}
+                >
+                  {reviewing ? (
+                    <><span className="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>Saving…</>
+                  ) : (
+                    reviewMode === 'approve' ? 'Approve' : 'Reject'
+                  )}
+                </button>
+              </div>
+            </div>
+          </div>
+          <div className="modal-backdrop fade show"></div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ChangeRequests;

--- a/frontend/src/pages/Delegations/Delegations.test.tsx
+++ b/frontend/src/pages/Delegations/Delegations.test.tsx
@@ -1,0 +1,171 @@
+/**
+ * Tests for Delegations page.
+ *
+ * @author Luca Ostinelli
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Delegations from './Delegations';
+
+jest.mock('../../services/delegationService', () => ({
+  listDelegations: jest.fn(),
+  createDelegation: jest.fn(),
+  revokeDelegation: jest.fn(),
+}));
+
+const {
+  listDelegations: mockList,
+  createDelegation: mockCreate,
+  revokeDelegation: mockRevoke,
+} = jest.requireMock('../../services/delegationService') as {
+  listDelegations: jest.Mock;
+  createDelegation: jest.Mock;
+  revokeDelegation: jest.Mock;
+};
+
+const ACTIVE = {
+  id: 1,
+  delegatorId: 5,
+  delegateeId: 7,
+  permissionCodes: ['schedule.manage', 'employee.read'],
+  scopeOrgUnitId: null,
+  startsAt: '2024-01-10T00:00:00.000Z',
+  expiresAt: '2024-02-10T00:00:00.000Z',
+  isActive: true,
+  createdAt: '2024-01-10T00:00:00.000Z',
+  updatedAt: '2024-01-10T00:00:00.000Z',
+};
+
+const INACTIVE = {
+  ...ACTIVE,
+  id: 2,
+  delegateeId: 9,
+  permissionCodes: ['audit.read'],
+  isActive: false,
+};
+
+const makeResponse = (items = [ACTIVE, INACTIVE]) => ({
+  success: true,
+  data: items,
+});
+
+beforeEach(() => {
+  mockList.mockResolvedValue(makeResponse());
+  mockCreate.mockResolvedValue({ success: true, data: { ...ACTIVE, id: 99 } });
+  mockRevoke.mockResolvedValue({ success: true, data: null });
+});
+
+afterEach(() => jest.clearAllMocks());
+
+describe('<Delegations />', () => {
+  it('renders the page heading', async () => {
+    render(<Delegations />);
+    expect(screen.getByRole('heading', { name: /delegations/i })).toBeInTheDocument();
+  });
+
+  it('shows delegations after loading', async () => {
+    render(<Delegations />);
+    expect(await screen.findByText('schedule.manage')).toBeInTheDocument();
+    expect(screen.getByText('employee.read')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no delegations', async () => {
+    mockList.mockResolvedValue(makeResponse([]));
+    render(<Delegations />);
+    expect(await screen.findByText(/no delegations found/i)).toBeInTheDocument();
+  });
+
+  it('shows error alert on load failure', async () => {
+    mockList.mockRejectedValue(new Error('Unauthorized'));
+    render(<Delegations />);
+    expect(await screen.findByRole('alert')).toBeInTheDocument();
+  });
+
+  it('shows Revoke button only for active delegations', async () => {
+    render(<Delegations />);
+    await screen.findByText('schedule.manage');
+
+    expect(screen.getByRole('button', { name: /revoke delegation 1/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /revoke delegation 2/i })).not.toBeInTheDocument();
+  });
+
+  it('shows Active/Inactive status badges', async () => {
+    render(<Delegations />);
+    await screen.findByText('schedule.manage');
+
+    // getAllByText because the column header <th>Active</th> also matches; verify at least one badge
+    expect(screen.getAllByText('Active').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('Inactive')).toBeInTheDocument();
+  });
+
+  it('opens revoke modal when Revoke is clicked', async () => {
+    render(<Delegations />);
+    await screen.findByText('schedule.manage');
+
+    await userEvent.click(screen.getByRole('button', { name: /revoke delegation 1/i }));
+    expect(screen.getByRole('dialog', { name: /revoke delegation 1/i })).toBeInTheDocument();
+    expect(screen.getByLabelText(/justification/i)).toBeInTheDocument();
+  });
+
+  it('calls revokeDelegation and reloads on confirm', async () => {
+    render(<Delegations />);
+    await screen.findByText('schedule.manage');
+
+    await userEvent.click(screen.getByRole('button', { name: /revoke delegation 1/i }));
+    await userEvent.type(screen.getByLabelText(/justification/i), 'User left team');
+    await userEvent.click(screen.getByRole('button', { name: /confirm revoke/i }));
+
+    await waitFor(() => expect(mockRevoke).toHaveBeenCalledWith(1, 'User left team'));
+    await waitFor(() => expect(mockList).toHaveBeenCalledTimes(2));
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('calls revokeDelegation with null justification when note is empty', async () => {
+    render(<Delegations />);
+    await screen.findByText('schedule.manage');
+
+    await userEvent.click(screen.getByRole('button', { name: /revoke delegation 1/i }));
+    await userEvent.click(screen.getByRole('button', { name: /confirm revoke/i }));
+
+    await waitFor(() => expect(mockRevoke).toHaveBeenCalledWith(1, null));
+  });
+
+  it('opens New Delegation modal', async () => {
+    render(<Delegations />);
+    await screen.findByText('schedule.manage');
+
+    await userEvent.click(screen.getByRole('button', { name: /new delegation/i }));
+    expect(screen.getByRole('dialog', { name: /new delegation/i })).toBeInTheDocument();
+  });
+
+  it('validates required fields before creating', async () => {
+    render(<Delegations />);
+    await screen.findByText('schedule.manage');
+
+    await userEvent.click(screen.getByRole('button', { name: /new delegation/i }));
+    await userEvent.click(screen.getByRole('button', { name: /submit delegation/i }));
+
+    expect(await screen.findByText(/delegatee user id is required/i)).toBeInTheDocument();
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it('creates a delegation and reloads', async () => {
+    render(<Delegations />);
+    await screen.findByText('schedule.manage');
+
+    await userEvent.click(screen.getByRole('button', { name: /new delegation/i }));
+    await userEvent.type(screen.getByLabelText(/delegatee user id/i), '7');
+    // Add a permission code
+    await userEvent.type(screen.getByLabelText(/permission code input/i), 'audit.read');
+    await userEvent.click(screen.getByRole('button', { name: /add permission code/i }));
+    // Set expiry
+    await userEvent.type(screen.getByLabelText(/expires at/i), '2025-12-31T00:00');
+
+    await userEvent.click(screen.getByRole('button', { name: /submit delegation/i }));
+
+    await waitFor(() => expect(mockCreate).toHaveBeenCalled());
+    await waitFor(() => expect(mockList).toHaveBeenCalledTimes(2));
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/Delegations/Delegations.tsx
+++ b/frontend/src/pages/Delegations/Delegations.tsx
@@ -1,0 +1,391 @@
+/**
+ * Delegations — manage temporary permission transfers to other users.
+ *
+ * Delegators can grant a subset of their own permissions to a delegate for
+ * a bounded time window. All active delegations are visible here. Revoking
+ * a delegation marks it inactive in the audit trail.
+ *
+ * @author Luca Ostinelli
+ */
+
+import React, { useEffect, useState, useCallback } from 'react';
+import {
+  listDelegations,
+  createDelegation,
+  revokeDelegation,
+  Delegation,
+  CreateDelegationBody,
+} from '../../services/delegationService';
+
+const EMPTY_FORM: CreateDelegationBody & { permissionInput: string } = {
+  delegateeId: 0,
+  permissionCodes: [],
+  expiresAt: '',
+  scopeOrgUnitId: null,
+  justification: '',
+  permissionInput: '',
+};
+
+const Delegations: React.FC = () => {
+  const [items, setItems] = useState<Delegation[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Create modal
+  const [showCreate, setShowCreate] = useState(false);
+  const [form, setForm] = useState({ ...EMPTY_FORM });
+  const [creating, setCreating] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+
+  // Revoke modal
+  const [revokeTarget, setRevokeTarget] = useState<Delegation | null>(null);
+  const [revokeNote, setRevokeNote] = useState('');
+  const [revoking, setRevoking] = useState(false);
+  const [revokeError, setRevokeError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await listDelegations();
+      setItems(res.data ?? []);
+    } catch (e) {
+      setError((e as Error).message ?? 'Failed to load delegations.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { void load(); }, [load]);
+
+  // ---------- Create ----------
+
+  const addPermission = () => {
+    const code = form.permissionInput.trim();
+    if (!code || form.permissionCodes.includes(code)) return;
+    setForm((f) => ({ ...f, permissionCodes: [...f.permissionCodes, code], permissionInput: '' }));
+  };
+
+  const removePermission = (code: string) => {
+    setForm((f) => ({ ...f, permissionCodes: f.permissionCodes.filter((c) => c !== code) }));
+  };
+
+  const handleCreate = async () => {
+    if (!form.delegateeId || form.delegateeId <= 0) { setCreateError('Delegatee user ID is required.'); return; }
+    if (form.permissionCodes.length === 0) { setCreateError('At least one permission code is required.'); return; }
+    if (!form.expiresAt) { setCreateError('Expiry date/time is required.'); return; }
+
+    setCreating(true);
+    setCreateError(null);
+    try {
+      await createDelegation({
+        delegateeId: form.delegateeId,
+        permissionCodes: form.permissionCodes,
+        expiresAt: form.expiresAt,
+        scopeOrgUnitId: form.scopeOrgUnitId ?? null,
+        justification: form.justification?.trim() || null,
+      });
+      setShowCreate(false);
+      setForm({ ...EMPTY_FORM });
+      await load();
+    } catch (e) {
+      setCreateError((e as Error).message ?? 'Failed to create delegation.');
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  // ---------- Revoke ----------
+
+  const openRevoke = (item: Delegation) => {
+    setRevokeTarget(item);
+    setRevokeNote('');
+    setRevokeError(null);
+  };
+
+  const handleRevoke = async () => {
+    if (!revokeTarget) return;
+    setRevoking(true);
+    setRevokeError(null);
+    try {
+      await revokeDelegation(revokeTarget.id, revokeNote.trim() || null);
+      setRevokeTarget(null);
+      await load();
+    } catch (e) {
+      setRevokeError((e as Error).message ?? 'Failed to revoke delegation.');
+    } finally {
+      setRevoking(false);
+    }
+  };
+
+  const formatDate = (iso: string | null) => {
+    if (!iso) return '—';
+    try { return new Date(iso).toLocaleString(); } catch { return iso; }
+  };
+
+  return (
+    <div className="container-fluid py-4">
+      <div className="row mb-3">
+        <div className="col d-flex align-items-center justify-content-between">
+          <div>
+            <h1 className="h3 mb-0">Delegations</h1>
+            <p className="text-muted mb-0 small">Temporarily grant your permissions to another user</p>
+          </div>
+          <button
+            className="btn btn-primary btn-sm"
+            onClick={() => { setForm({ ...EMPTY_FORM }); setCreateError(null); setShowCreate(true); }}
+          >
+            <i className="bi bi-plus-lg me-1" aria-hidden="true"></i>New Delegation
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="alert alert-danger" role="alert">
+          <i className="bi bi-exclamation-triangle me-2" aria-hidden="true"></i>{error}
+        </div>
+      )}
+
+      <div className="card">
+        <div className="card-body p-0">
+          {loading ? (
+            <div className="d-flex align-items-center justify-content-center py-5">
+              <span className="spinner-border me-2" role="status" aria-label="Loading"></span>
+            </div>
+          ) : items.length === 0 ? (
+            <div className="text-center text-muted py-5">
+              <i className="bi bi-people fs-3 d-block mb-2" aria-hidden="true"></i>
+              No delegations found.
+            </div>
+          ) : (
+            <div className="table-responsive">
+              <table className="table table-hover mb-0">
+                <thead className="table-light">
+                  <tr>
+                    <th scope="col">#</th>
+                    <th scope="col">Delegatee ID</th>
+                    <th scope="col">Permissions</th>
+                    <th scope="col">Scope Org Unit</th>
+                    <th scope="col">Active</th>
+                    <th scope="col">Expires</th>
+                    <th scope="col" className="text-end">Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {items.map((item) => (
+                    <tr key={item.id}>
+                      <td className="text-muted small">{item.id}</td>
+                      <td className="small">{item.delegateeId}</td>
+                      <td>
+                        <div className="d-flex flex-wrap gap-1">
+                          {item.permissionCodes.map((code) => (
+                            <span key={code} className="badge bg-primary-subtle text-primary small">{code}</span>
+                          ))}
+                        </div>
+                      </td>
+                      <td className="small text-muted">
+                        {item.scopeOrgUnitId != null ? `Unit #${item.scopeOrgUnitId}` : 'Global'}
+                      </td>
+                      <td>
+                        <span className={`badge ${item.isActive ? 'bg-success' : 'bg-secondary'}`}>
+                          {item.isActive ? 'Active' : 'Inactive'}
+                        </span>
+                      </td>
+                      <td className="small text-muted text-nowrap">{formatDate(item.expiresAt)}</td>
+                      <td className="text-end">
+                        {item.isActive && (
+                          <button
+                            className="btn btn-sm btn-outline-danger"
+                            onClick={() => openRevoke(item)}
+                            aria-label={`Revoke delegation ${item.id}`}
+                          >
+                            <i className="bi bi-x-circle me-1" aria-hidden="true"></i>Revoke
+                          </button>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Create Modal */}
+      {showCreate && (
+        <div className="modal d-block" tabIndex={-1} role="dialog" aria-modal="true" aria-label="New delegation">
+          <div className="modal-dialog modal-lg">
+            <div className="modal-content">
+              <div className="modal-header">
+                <h5 className="modal-title">New Delegation</h5>
+                <button type="button" className="btn-close" aria-label="Close" onClick={() => setShowCreate(false)}></button>
+              </div>
+              <div className="modal-body">
+                {createError && (
+                  <div className="alert alert-danger py-2 small" role="alert">{createError}</div>
+                )}
+                <div className="row g-3">
+                  <div className="col-md-6">
+                    <label htmlFor="delegDelegateeId" className="form-label">Delegatee User ID <span className="text-danger">*</span></label>
+                    <input
+                      id="delegDelegateeId"
+                      type="number"
+                      className="form-control"
+                      min={1}
+                      value={form.delegateeId || ''}
+                      onChange={(e) => setForm((f) => ({ ...f, delegateeId: Number(e.target.value) }))}
+                    />
+                  </div>
+                  <div className="col-md-6">
+                    <label htmlFor="delegExpiry" className="form-label">Expires At <span className="text-danger">*</span></label>
+                    <input
+                      id="delegExpiry"
+                      type="datetime-local"
+                      className="form-control"
+                      value={form.expiresAt}
+                      onChange={(e) => setForm((f) => ({ ...f, expiresAt: e.target.value }))}
+                    />
+                  </div>
+                  <div className="col-12">
+                    <label className="form-label">Permission Codes <span className="text-danger">*</span></label>
+                    <div className="input-group">
+                      <input
+                        id="delegPermissionInput"
+                        type="text"
+                        className="form-control"
+                        placeholder="e.g. schedule.manage"
+                        value={form.permissionInput}
+                        onChange={(e) => setForm((f) => ({ ...f, permissionInput: e.target.value }))}
+                        onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); addPermission(); } }}
+                        aria-label="Permission code input"
+                      />
+                      <button className="btn btn-outline-secondary" type="button" onClick={addPermission} aria-label="Add permission code">
+                        Add
+                      </button>
+                    </div>
+                    {form.permissionCodes.length > 0 && (
+                      <div className="d-flex flex-wrap gap-1 mt-2">
+                        {form.permissionCodes.map((code) => (
+                          <span key={code} className="badge bg-primary d-flex align-items-center gap-1">
+                            {code}
+                            <button
+                              type="button"
+                              className="btn-close btn-close-white"
+                              aria-label={`Remove permission ${code}`}
+                              onClick={() => removePermission(code)}
+                              style={{ fontSize: '0.55rem' }}
+                            ></button>
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                  <div className="col-md-6">
+                    <label htmlFor="delegScopeOrgUnit" className="form-label">Scope Org Unit ID <span className="text-muted small">(optional)</span></label>
+                    <input
+                      id="delegScopeOrgUnit"
+                      type="number"
+                      className="form-control"
+                      min={1}
+                      placeholder="Optional — leave blank for global"
+                      value={form.scopeOrgUnitId ?? ''}
+                      onChange={(e) => setForm((f) => ({
+                        ...f,
+                        scopeOrgUnitId: e.target.value ? Number(e.target.value) : null,
+                      }))}
+                    />
+                  </div>
+                  <div className="col-12">
+                    <label htmlFor="delegJustification" className="form-label">Justification <span className="text-muted small">(optional)</span></label>
+                    <textarea
+                      id="delegJustification"
+                      className="form-control"
+                      rows={2}
+                      value={form.justification ?? ''}
+                      onChange={(e) => setForm((f) => ({ ...f, justification: e.target.value }))}
+                      placeholder="Reason for this delegation"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div className="modal-footer">
+                <button type="button" className="btn btn-secondary" onClick={() => setShowCreate(false)}>Cancel</button>
+                <button
+                  type="button"
+                  className="btn btn-primary"
+                  onClick={handleCreate}
+                  disabled={creating}
+                  aria-label="Submit delegation"
+                >
+                  {creating ? (
+                    <><span className="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>Saving…</>
+                  ) : 'Create'}
+                </button>
+              </div>
+            </div>
+          </div>
+          <div className="modal-backdrop fade show"></div>
+        </div>
+      )}
+
+      {/* Revoke Modal */}
+      {revokeTarget && (
+        <div
+          className="modal d-block"
+          tabIndex={-1}
+          role="dialog"
+          aria-modal="true"
+          aria-label={`Revoke delegation ${revokeTarget.id}`}
+        >
+          <div className="modal-dialog">
+            <div className="modal-content">
+              <div className="modal-header">
+                <h5 className="modal-title">Revoke Delegation #{revokeTarget.id}</h5>
+                <button type="button" className="btn-close" aria-label="Close" onClick={() => setRevokeTarget(null)}></button>
+              </div>
+              <div className="modal-body">
+                {revokeError && (
+                  <div className="alert alert-danger py-2 small" role="alert">{revokeError}</div>
+                )}
+                <p className="small text-muted mb-3">
+                  This will immediately deactivate the delegation. The action is recorded in the audit log.
+                </p>
+                <div>
+                  <label htmlFor="revokeNote" className="form-label">
+                    Justification <span className="text-muted small">(optional)</span>
+                  </label>
+                  <textarea
+                    id="revokeNote"
+                    className="form-control"
+                    rows={3}
+                    value={revokeNote}
+                    onChange={(e) => setRevokeNote(e.target.value)}
+                    placeholder="Reason for revocation"
+                  />
+                </div>
+              </div>
+              <div className="modal-footer">
+                <button type="button" className="btn btn-secondary" onClick={() => setRevokeTarget(null)}>Cancel</button>
+                <button
+                  type="button"
+                  className="btn btn-danger"
+                  onClick={handleRevoke}
+                  disabled={revoking}
+                  aria-label="Confirm revoke"
+                >
+                  {revoking ? (
+                    <><span className="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>Revoking…</>
+                  ) : 'Revoke'}
+                </button>
+              </div>
+            </div>
+          </div>
+          <div className="modal-backdrop fade show"></div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Delegations;

--- a/frontend/src/services/delegationService.ts
+++ b/frontend/src/services/delegationService.ts
@@ -1,0 +1,59 @@
+/**
+ * Delegation service — wraps /api/delegations endpoints.
+ *
+ * @author Luca Ostinelli
+ */
+
+import { ApiResponse } from '../types';
+import { getAuthHeaders, handleResponse, API_BASE_URL } from './apiUtils';
+
+const BASE = `${API_BASE_URL}/delegations`;
+
+export interface Delegation {
+  id: number;
+  delegatorId: number;
+  delegateeId: number;
+  permissionCodes: string[];
+  scopeOrgUnitId: number | null;
+  startsAt: string;
+  expiresAt: string;
+  isActive: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateDelegationBody {
+  delegateeId: number;
+  permissionCodes: string[];
+  expiresAt: string;
+  scopeOrgUnitId?: number | null;
+  justification?: string | null;
+}
+
+export const listDelegations = async (): Promise<ApiResponse<Delegation[]>> => {
+  const res = await fetch(BASE, { method: 'GET', ...getAuthHeaders() });
+  return handleResponse<Delegation[]>(res);
+};
+
+export const createDelegation = async (
+  body: CreateDelegationBody
+): Promise<ApiResponse<Delegation>> => {
+  const res = await fetch(BASE, {
+    method: 'POST',
+    ...getAuthHeaders(),
+    body: JSON.stringify(body),
+  });
+  return handleResponse<Delegation>(res);
+};
+
+export const revokeDelegation = async (
+  id: number,
+  justification?: string | null
+): Promise<ApiResponse<void>> => {
+  const res = await fetch(`${BASE}/${id}`, {
+    method: 'DELETE',
+    ...getAuthHeaders(),
+    body: JSON.stringify({ justification: justification ?? null }),
+  });
+  return handleResponse<void>(res);
+};

--- a/frontend/src/services/pendingApprovalService.ts
+++ b/frontend/src/services/pendingApprovalService.ts
@@ -9,7 +9,7 @@ import { getAuthHeaders, handleResponse, API_BASE_URL } from './apiUtils';
 
 const BASE = `${API_BASE_URL}/pending-approvals`;
 
-export type PendingApprovalStatus = 'pending' | 'approved' | 'rejected' | 'escalated';
+type PendingApprovalStatus = 'pending' | 'approved' | 'rejected' | 'escalated';
 
 export interface PendingApprovalItem {
   id: number;
@@ -44,11 +44,6 @@ export const listPendingApprovals = async (
   const qs = new URLSearchParams({ status });
   const res = await fetch(`${BASE}?${qs}`, { method: 'GET', ...getAuthHeaders() });
   return handleResponse<PendingApprovalListResponse>(res);
-};
-
-export const countPendingApprovals = async (): Promise<ApiResponse<{ count: number }>> => {
-  const res = await fetch(`${BASE}/count`, { method: 'GET', ...getAuthHeaders() });
-  return handleResponse<{ count: number }>(res);
 };
 
 export const approvePendingItem = async (

--- a/frontend/src/services/pendingApprovalService.ts
+++ b/frontend/src/services/pendingApprovalService.ts
@@ -1,0 +1,76 @@
+/**
+ * Pending approval service — wraps /api/pending-approvals endpoints.
+ *
+ * @author Luca Ostinelli
+ */
+
+import { ApiResponse } from '../types';
+import { getAuthHeaders, handleResponse, API_BASE_URL } from './apiUtils';
+
+const BASE = `${API_BASE_URL}/pending-approvals`;
+
+export type PendingApprovalStatus = 'pending' | 'approved' | 'rejected' | 'escalated';
+
+export interface PendingApprovalItem {
+  id: number;
+  changeRequestId: number;
+  workflowId: number;
+  stepId: number;
+  stepOrder: number;
+  assignedToUserId: number;
+  status: PendingApprovalStatus;
+  decidedAt: string | null;
+  decisionNote: string | null;
+  escalatedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+  // Context fields
+  changeType: string;
+  targetEntityType: string;
+  targetEntityId: number | null;
+  proposedPayload: Record<string, unknown>;
+  justification: string | null;
+  proposerUserId: number;
+}
+
+export interface PendingApprovalListResponse {
+  items: PendingApprovalItem[];
+  total: number;
+}
+
+export const listPendingApprovals = async (
+  status = 'pending'
+): Promise<ApiResponse<PendingApprovalListResponse>> => {
+  const qs = new URLSearchParams({ status });
+  const res = await fetch(`${BASE}?${qs}`, { method: 'GET', ...getAuthHeaders() });
+  return handleResponse<PendingApprovalListResponse>(res);
+};
+
+export const countPendingApprovals = async (): Promise<ApiResponse<{ count: number }>> => {
+  const res = await fetch(`${BASE}/count`, { method: 'GET', ...getAuthHeaders() });
+  return handleResponse<{ count: number }>(res);
+};
+
+export const approvePendingItem = async (
+  id: number,
+  note?: string
+): Promise<ApiResponse<PendingApprovalItem>> => {
+  const res = await fetch(`${BASE}/${id}/approve`, {
+    method: 'POST',
+    ...getAuthHeaders(),
+    body: JSON.stringify({ note: note ?? null }),
+  });
+  return handleResponse<PendingApprovalItem>(res);
+};
+
+export const rejectPendingItem = async (
+  id: number,
+  note?: string
+): Promise<ApiResponse<PendingApprovalItem>> => {
+  const res = await fetch(`${BASE}/${id}/reject`, {
+    method: 'POST',
+    ...getAuthHeaders(),
+    body: JSON.stringify({ note: note ?? null }),
+  });
+  return handleResponse<PendingApprovalItem>(res);
+};


### PR DESCRIPTION
## Summary

- **B1 Pending Approvals** (`/approvals/pending`): inbox for items assigned to the current user; approve/reject with optional note; row expansion shows payload
- **B2 Change Requests** (`/change-requests`): submit JSON-payload proposals; inline approve/reject for reviewers; cancel own pending requests; My/All tab split
- **B3 Delegations** (`/delegations`): grant permission subsets to a delegate for a time window; revoke with audit justification; permission-code tag builder

Supporting services: `pendingApprovalService.ts`, `delegationService.ts` (new); `changeRequestService.ts` already on main.

Routes wired in `App.tsx`; nav items added to `Sidebar.tsx`.

## Test plan

- [ ] 41 new tests across 3 test files — all green
- [ ] Full suite: 296 frontend + 1895 backend tests pass
- [ ] ESLint passes (lint-staged verified on commit)