### PR TITLE
feat(backend): C1 bulk role assign API + C4 OpenAPI gap-fill

### DIFF
--- a/backend/openapi/openapi.json
+++ b/backend/openapi/openapi.json
@@ -7768,6 +7768,274 @@
           }
         }
       }
+    },
+    "/roles/bulk-assign": {
+      "post": {
+        "tags": ["Roles"],
+        "summary": "Bulk assign role to users",
+        "description": "Assigns the same role to multiple users in a single request. Requires `role.manage`. Each assignment is individually audit-logged.",
+        "security": [{"bearerAuth": []}, {"cookieAuth": []}],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["roleId", "userIds"],
+                "properties": {
+                  "roleId": {"type": "integer", "description": "ID of the role to assign."},
+                  "userIds": {"type": "array", "items": {"type": "integer"}, "minItems": 1, "maxItems": 500, "description": "List of user IDs to assign the role to."},
+                  "scopeOrgUnitId": {"type": "integer", "nullable": true, "description": "Optional org-unit scope."},
+                  "expiresAt": {"type": "string", "format": "date-time", "nullable": true, "description": "Optional expiry."},
+                  "justification": {"type": "string", "maxLength": 1000, "nullable": true}
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Role assigned.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {"type": "boolean"},
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "assigned": {"type": "integer", "description": "Number of users who received the role."}
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {"$ref": "#/components/responses/ValidationError"},
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "403": {"$ref": "#/components/responses/Forbidden"}
+        }
+      }
+    },
+    "/responsibility-rules/matrix": {
+      "get": {
+        "tags": ["Responsibilities"],
+        "summary": "Get responsibility matrix",
+        "description": "Returns a matrix of all responsibility rules grouped by entity type and org unit. Requires `responsibility.read`.",
+        "security": [{"bearerAuth": []}, {"cookieAuth": []}],
+        "responses": {
+          "200": {
+            "description": "Responsibility matrix.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {"type": "boolean"},
+                    "data": {"type": "array"}
+                  }
+                }
+              }
+            }
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "403": {"$ref": "#/components/responses/Forbidden"}
+        }
+      }
+    },
+    "/responsibility-rules/my-responsibilities": {
+      "get": {
+        "tags": ["Responsibilities"],
+        "summary": "List my responsibilities",
+        "description": "Returns the responsibility rules that apply to the authenticated user based on their role and org-unit membership.",
+        "security": [{"bearerAuth": []}, {"cookieAuth": []}],
+        "responses": {
+          "200": {
+            "description": "Responsibilities for the current user.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {"type": "boolean"},
+                    "data": {"type": "array"}
+                  }
+                }
+              }
+            }
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"}
+        }
+      }
+    },
+    "/responsibility-rules/bulk": {
+      "post": {
+        "tags": ["Responsibilities"],
+        "summary": "Bulk create responsibility rules",
+        "description": "Creates multiple responsibility rules in one request. Requires `responsibility.manage`.",
+        "security": [{"bearerAuth": []}, {"cookieAuth": []}],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["rules"],
+                "properties": {
+                  "rules": {
+                    "type": "array",
+                    "items": {"type": "object"}
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {"description": "Rules created."},
+          "400": {"$ref": "#/components/responses/ValidationError"},
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "403": {"$ref": "#/components/responses/Forbidden"}
+        }
+      }
+    },
+    "/responsibility-rules/{id}/conflicts": {
+      "get": {
+        "tags": ["Responsibilities"],
+        "summary": "Get conflicts for a responsibility rule",
+        "description": "Returns other rules that conflict with (overlap) the given rule. Requires `responsibility.read`.",
+        "security": [{"bearerAuth": []}, {"cookieAuth": []}],
+        "parameters": [{"$ref": "#/components/parameters/id"}],
+        "responses": {
+          "200": {"description": "List of conflicting rules."},
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "403": {"$ref": "#/components/responses/Forbidden"},
+          "404": {"$ref": "#/components/responses/NotFound"}
+        }
+      }
+    },
+    "/pending-approvals": {
+      "get": {
+        "tags": ["Pending Approvals"],
+        "summary": "List pending approvals",
+        "description": "Returns approval items assigned to the current user. Filter by `status` query param.",
+        "security": [{"bearerAuth": []}, {"cookieAuth": []}],
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "schema": {"type": "string", "enum": ["pending", "approved", "rejected", "escalated"]},
+            "description": "Filter by approval status. Omit to return all."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated list of pending approval items.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {"type": "boolean"},
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "items": {"type": "array"},
+                        "total": {"type": "integer"}
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"}
+        }
+      }
+    },
+    "/pending-approvals/count": {
+      "get": {
+        "tags": ["Pending Approvals"],
+        "summary": "Count pending approvals",
+        "description": "Returns the count of approval items currently in `pending` status for the authenticated user.",
+        "security": [{"bearerAuth": []}, {"cookieAuth": []}],
+        "responses": {
+          "200": {
+            "description": "Pending count.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {"type": "boolean"},
+                    "data": {
+                      "type": "object",
+                      "properties": {"count": {"type": "integer"}}
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"}
+        }
+      }
+    },
+    "/pending-approvals/{id}/approve": {
+      "post": {
+        "tags": ["Pending Approvals"],
+        "summary": "Approve a pending item",
+        "description": "Records an approval decision for the given pending-approval item and advances the workflow step.",
+        "security": [{"bearerAuth": []}, {"cookieAuth": []}],
+        "parameters": [{"$ref": "#/components/parameters/id"}],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "note": {"type": "string", "nullable": true, "description": "Optional decision note recorded in audit log."}
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {"description": "Decision recorded."},
+          "400": {"$ref": "#/components/responses/ValidationError"},
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "404": {"$ref": "#/components/responses/NotFound"}
+        }
+      }
+    },
+    "/pending-approvals/{id}/reject": {
+      "post": {
+        "tags": ["Pending Approvals"],
+        "summary": "Reject a pending item",
+        "description": "Records a rejection decision for the given pending-approval item and closes the workflow step.",
+        "security": [{"bearerAuth": []}, {"cookieAuth": []}],
+        "parameters": [{"$ref": "#/components/parameters/id"}],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "note": {"type": "string", "nullable": true, "description": "Optional rejection note."}
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {"description": "Rejection recorded."},
+          "400": {"$ref": "#/components/responses/ValidationError"},
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "404": {"$ref": "#/components/responses/NotFound"}
+        }
+      }
     }
   }
 }

--- a/backend/src/__tests__/routes.rbac.test.ts
+++ b/backend/src/__tests__/routes.rbac.test.ts
@@ -393,3 +393,84 @@ describe('rbac DELETE /roles/users/:userId/:roleId', () => {
     expect(res.body.error.code).toBe('VALIDATION_ERROR');
   });
 });
+
+// ── POST /roles/bulk-assign ───────────────────────────────────────────────────
+
+describe('rbac POST /roles/bulk-assign', () => {
+  it('returns 201 with assigned count on success', async () => {
+    (RbacService.prototype.bulkAssignRole as jest.Mock) = jest
+      .fn()
+      .mockResolvedValue({ assigned: 3 });
+
+    const res = await request(mountApp())
+      .post('/api/roles/bulk-assign')
+      .send({ roleId: 2, userIds: [1, 2, 3] });
+
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.assigned).toBe(3);
+    expect(RbacService.prototype.bulkAssignRole).toHaveBeenCalledWith(
+      [1, 2, 3], 2, null, null, 1, null
+    );
+  });
+
+  it('passes optional fields through to service', async () => {
+    (RbacService.prototype.bulkAssignRole as jest.Mock) = jest
+      .fn()
+      .mockResolvedValue({ assigned: 2 });
+
+    await request(mountApp())
+      .post('/api/roles/bulk-assign')
+      .send({
+        roleId: 5,
+        userIds: [10, 20],
+        scopeOrgUnitId: 3,
+        expiresAt: '2027-06-01T00:00:00Z',
+        justification: 'Coverage assignment',
+      });
+
+    expect(RbacService.prototype.bulkAssignRole).toHaveBeenCalledWith(
+      [10, 20], 5, 3, '2027-06-01T00:00:00Z', 1, 'Coverage assignment'
+    );
+  });
+
+  it('returns 400 when userIds is empty', async () => {
+    const res = await request(mountApp())
+      .post('/api/roles/bulk-assign')
+      .send({ roleId: 1, userIds: [] });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns 400 when roleId is missing', async () => {
+    const res = await request(mountApp())
+      .post('/api/roles/bulk-assign')
+      .send({ userIds: [1, 2] });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns 400 on service error', async () => {
+    (RbacService.prototype.bulkAssignRole as jest.Mock) = jest
+      .fn()
+      .mockRejectedValue(new Error('Role not found'));
+
+    const res = await request(mountApp())
+      .post('/api/roles/bulk-assign')
+      .send({ roleId: 999, userIds: [1, 2] });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    authState.mode = 'reject401';
+    const res = await request(mountApp())
+      .post('/api/roles/bulk-assign')
+      .send({ roleId: 1, userIds: [1] });
+
+    expect(res.status).toBe(401);
+  });
+});

--- a/backend/src/routes/rbac.ts
+++ b/backend/src/routes/rbac.ts
@@ -35,6 +35,14 @@ const assignRoleBody = z.object({
   justification: z.string().max(1000).nullable().optional(),
 });
 
+const bulkAssignRoleBody = z.object({
+  roleId: z.number().int().positive(),
+  userIds: z.array(z.number().int().positive()).min(1).max(500),
+  scopeOrgUnitId: z.number().int().positive().nullable().optional(),
+  expiresAt: z.string().nullable().optional(),
+  justification: z.string().max(1000).nullable().optional(),
+});
+
 const respondError = (res: Response, status: number, code: string, message: string): void => {
   res.status(status).json({ success: false, error: { code, message } });
 };
@@ -120,6 +128,23 @@ export const createRbacRouter = (pool: Pool): { roles: Router; permissions: Rout
     } catch (err) {
       const msg = (err as Error).message;
       respondError(res, statusFor(msg), statusFor(msg) === 404 ? 'NOT_FOUND' : 'CONFLICT', msg);
+    }
+  });
+
+  roles.post('/bulk-assign', validateBody(bulkAssignRoleBody), async (req: Request, res: Response) => {
+    try {
+      const { roleId, userIds, scopeOrgUnitId, expiresAt, justification } = res.locals.body;
+      const result = await rbac.bulkAssignRole(
+        userIds,
+        roleId,
+        scopeOrgUnitId ?? null,
+        expiresAt ?? null,
+        req.user?.id,
+        justification ?? null
+      );
+      res.status(201).json({ success: true, data: result });
+    } catch (err) {
+      respondError(res, 400, 'VALIDATION_ERROR', (err as Error).message);
     }
   });
 

--- a/backend/src/services/RbacService.ts
+++ b/backend/src/services/RbacService.ts
@@ -311,6 +311,22 @@ export class RbacService {
     });
   }
 
+  async bulkAssignRole(
+    userIds: number[],
+    roleId: number,
+    scopeOrgUnitId: number | null = null,
+    expiresAt: string | null = null,
+    actorId?: number | null,
+    justification?: string | null
+  ): Promise<{ assigned: number }> {
+    let assigned = 0;
+    for (const userId of userIds) {
+      await this.assignRole(userId, roleId, scopeOrgUnitId, expiresAt, actorId, justification);
+      assigned++;
+    }
+    return { assigned };
+  }
+
   async removeRole(
     userId: number,
     roleId: number,


### PR DESCRIPTION
## Summary

- **C1** — `POST /api/roles/bulk-assign`: assigns the same role to an array of users (1–500) in one request. Each assignment is individually audit-logged. `RbacService.bulkAssignRole()` iterates and delegates to the existing `assignRole()` method.
- **C4** — OpenAPI documentation now covers previously undocumented endpoints:
  - `/roles/bulk-assign`
  - `/responsibility-rules/matrix`, `/my-responsibilities`, `/bulk`, `/{id}/conflicts`
  - `/pending-approvals`, `/pending-approvals/count`, `/{id}/approve`, `/{id}/reject`

C2 (responsibility matrix) and C3 (personal settings) were already fully implemented — no code changes needed.

## Test plan

- [ ] 6 new route tests for `POST /roles/bulk-assign` in `routes.rbac.test.ts` — all pass
- [ ] Full backend suite: 1901 tests pass
- [ ] OpenAPI JSON validated (Python `json.load` check)
- [ ] ESLint passes (lint-staged verified on commit)