### PR TITLE
feat(frontend): Block D visual components — interactive org chart + RACI matrix

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -51,6 +51,8 @@ const Settings = lazy(() => import('./pages/Settings/Settings'));
 const OrgManagement = lazy(() => import('./pages/Org/OrgManagement'));
 const Policies = lazy(() => import('./pages/Policies/Policies'));
 const Governance = lazy(() => import('./pages/Governance/Governance'));
+const OrgChart = lazy(() => import('./pages/OrgChart/OrgChart'));
+const RaciMatrix = lazy(() => import('./pages/Governance/RaciMatrix'));
 
 /**
  * Main Application Component
@@ -131,6 +133,16 @@ const App: React.FC = () => {
           <Route path="settings" element={
             <PermissionRoute permission="settings.manage">
               <Settings />
+            </PermissionRoute>
+          } />
+          <Route path="org-chart" element={
+            <PermissionRoute permission="org_unit.read">
+              <OrgChart />
+            </PermissionRoute>
+          } />
+          <Route path="governance/raci-matrix" element={
+            <PermissionRoute permission="responsibility.read">
+              <RaciMatrix />
             </PermissionRoute>
           } />
         </Route>

--- a/frontend/src/components/Layout/Sidebar.tsx
+++ b/frontend/src/components/Layout/Sidebar.tsx
@@ -96,6 +96,18 @@ const Sidebar: React.FC<SidebarProps> = ({ collapsed }) => {
       requiredPermission: 'responsibility.read',
     },
     {
+      path: '/org-chart',
+      icon: 'bi-diagram-3',
+      label: 'Org Chart',
+      requiredPermission: 'org_unit.read',
+    },
+    {
+      path: '/governance/raci-matrix',
+      icon: 'bi-grid-3x3',
+      label: 'RACI Matrix',
+      requiredPermission: 'responsibility.read',
+    },
+    {
       path: '/settings',
       icon: 'bi-gear',
       label: 'Settings',

--- a/frontend/src/pages/Governance/RaciMatrix.test.tsx
+++ b/frontend/src/pages/Governance/RaciMatrix.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * Tests for RaciMatrix page.
+ *
+ * @author Luca Ostinelli
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import RaciMatrix from './RaciMatrix';
+
+jest.mock('../../services/responsibilityService', () => ({
+  getResponsibilityMatrix: jest.fn(),
+}));
+
+const { getResponsibilityMatrix: mockGetMatrix } = jest.requireMock(
+  '../../services/responsibilityService'
+) as { getResponsibilityMatrix: jest.Mock };
+
+const RULE = (id: number, ouId: number, active = true) => ({
+  id,
+  subjectType: 'org_unit',
+  subjectId: null,
+  permissionCode: 'schedule.manage',
+  responsibleOrgUnitId: ouId,
+  delegatedToRoleId: null,
+  description: null,
+  isActive: active,
+  createdBy: 1,
+  createdAt: '2024-01-01T00:00:00.000Z',
+  updatedAt: '2024-01-01T00:00:00.000Z',
+});
+
+const MATRIX = [
+  {
+    subjectType: 'org_unit',
+    subjectId: null,
+    permissionCode: 'schedule.manage',
+    rules: [RULE(1, 10)],
+  },
+  {
+    subjectType: 'all',
+    subjectId: null,
+    permissionCode: 'employee.read',
+    rules: [RULE(2, 20)],
+  },
+  {
+    subjectType: 'org_unit',
+    subjectId: null,
+    permissionCode: 'employee.read',
+    rules: [RULE(3, 30, false)],
+  },
+];
+
+const makeResponse = (matrix = MATRIX) => ({ success: true, data: { matrix } });
+
+beforeEach(() => {
+  mockGetMatrix.mockResolvedValue(makeResponse());
+});
+
+afterEach(() => jest.clearAllMocks());
+
+describe('<RaciMatrix />', () => {
+  it('renders the page heading', async () => {
+    render(<RaciMatrix />);
+    expect(screen.getByRole('heading', { name: /responsibility matrix/i })).toBeInTheDocument();
+  });
+
+  it('shows all permission codes as rows', async () => {
+    render(<RaciMatrix />);
+    expect(await screen.findByText('schedule.manage')).toBeInTheDocument();
+    expect(screen.getByText('employee.read')).toBeInTheDocument();
+  });
+
+  it('shows column headers for each unique subject', async () => {
+    render(<RaciMatrix />);
+    await screen.findByText('schedule.manage');
+    expect(screen.getByText('org_unit')).toBeInTheDocument();
+    expect(screen.getByText('all')).toBeInTheDocument();
+  });
+
+  it('shows responsible org unit badge in cells', async () => {
+    render(<RaciMatrix />);
+    await screen.findByText('schedule.manage');
+    expect(screen.getByText('OU #10')).toBeInTheDocument();
+    expect(screen.getByText('OU #20')).toBeInTheDocument();
+  });
+
+  it('shows inactive badge for inactive rules', async () => {
+    render(<RaciMatrix />);
+    await screen.findByText('schedule.manage');
+    expect(screen.getByText('inactive')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no rules', async () => {
+    mockGetMatrix.mockResolvedValue(makeResponse([]));
+    render(<RaciMatrix />);
+    expect(await screen.findByText(/no responsibility rules defined/i)).toBeInTheDocument();
+  });
+
+  it('shows error alert on load failure', async () => {
+    mockGetMatrix.mockRejectedValue(new Error('Forbidden'));
+    render(<RaciMatrix />);
+    expect(await screen.findByRole('alert')).toBeInTheDocument();
+  });
+
+  it('filters rows by permission code search', async () => {
+    render(<RaciMatrix />);
+    await screen.findByText('schedule.manage');
+
+    await userEvent.type(screen.getByLabelText(/filter matrix/i), 'schedule');
+    await waitFor(() =>
+      expect(screen.queryByText('employee.read')).not.toBeInTheDocument()
+    );
+    expect(screen.getByText('schedule.manage')).toBeInTheDocument();
+  });
+
+  it('shows all rows when search is cleared', async () => {
+    render(<RaciMatrix />);
+    await screen.findByText('schedule.manage');
+
+    await userEvent.type(screen.getByLabelText(/filter matrix/i), 'schedule');
+    await waitFor(() => expect(screen.queryByText('employee.read')).not.toBeInTheDocument());
+
+    await userEvent.clear(screen.getByLabelText(/filter matrix/i));
+    await screen.findByText('employee.read');
+  });
+
+  it('shows "no rules match" state when filter has no results', async () => {
+    render(<RaciMatrix />);
+    await screen.findByText('schedule.manage');
+
+    await userEvent.type(screen.getByLabelText(/filter matrix/i), 'zzznomatch');
+    await screen.findByText(/no rules match the current filter/i);
+  });
+
+  it('shows footer with permission and subject counts', async () => {
+    render(<RaciMatrix />);
+    await screen.findByText('schedule.manage');
+    expect(screen.getByText(/2 permissions/i)).toBeInTheDocument();
+    expect(screen.getByText(/2 subjects/i)).toBeInTheDocument();
+  });
+
+  it('refreshes on Refresh button click', async () => {
+    render(<RaciMatrix />);
+    await screen.findByText('schedule.manage');
+    await userEvent.click(screen.getByRole('button', { name: /refresh matrix/i }));
+    await waitFor(() => expect(mockGetMatrix).toHaveBeenCalledTimes(2));
+  });
+});

--- a/frontend/src/pages/Governance/RaciMatrix.tsx
+++ b/frontend/src/pages/Governance/RaciMatrix.tsx
@@ -1,0 +1,206 @@
+/**
+ * RaciMatrix — responsibility assignment matrix (RACI view).
+ *
+ * Fetches GET /api/responsibility-rules/matrix and renders a pivot table:
+ *   rows    = unique permission codes
+ *   columns = unique (subjectType, subjectId) combinations
+ *   cells   = org unit responsible + optional delegated role
+ *
+ * An empty cell means no responsibility rule has been defined for that
+ * (permission, subject) combination.
+ *
+ * @author Luca Ostinelli
+ */
+
+import React, { useEffect, useState, useCallback } from 'react';
+import {
+  getResponsibilityMatrix,
+  MatrixEntry,
+  ResponsibilitySubjectType,
+} from '../../services/responsibilityService';
+
+interface MatrixCol {
+  key: string;
+  subjectType: ResponsibilitySubjectType;
+  subjectId: number | null;
+  label: string;
+}
+
+const subjectLabel = (type: ResponsibilitySubjectType, id: number | null): string => {
+  if (type === 'all') return 'All users';
+  if (id == null) return `${type} (any)`;
+  return `${type} #${id}`;
+};
+
+const RaciMatrix: React.FC = () => {
+  const [entries, setEntries] = useState<MatrixEntry[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await getResponsibilityMatrix();
+      setEntries(res.data?.matrix ?? []);
+    } catch (e) {
+      setError((e as Error).message ?? 'Failed to load responsibility matrix.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { void load(); }, [load]);
+
+  // Derive unique permission codes (rows) and subject columns
+  const filteredEntries = search.trim()
+    ? entries.filter(
+        (e) =>
+          e.permissionCode.toLowerCase().includes(search.toLowerCase()) ||
+          subjectLabel(e.subjectType, e.subjectId).toLowerCase().includes(search.toLowerCase())
+      )
+    : entries;
+
+  const permCodes = [...new Set(filteredEntries.map((e) => e.permissionCode))].sort();
+
+  const colMap = new Map<string, MatrixCol>();
+  filteredEntries.forEach((e) => {
+    const key = `${e.subjectType}:${e.subjectId ?? 'null'}`;
+    if (!colMap.has(key)) {
+      colMap.set(key, {
+        key,
+        subjectType: e.subjectType,
+        subjectId: e.subjectId,
+        label: subjectLabel(e.subjectType, e.subjectId),
+      });
+    }
+  });
+  const cols = [...colMap.values()].sort((a, b) => a.label.localeCompare(b.label));
+
+  // Build lookup: permCode → colKey → entry
+  const lookup = new Map<string, Map<string, MatrixEntry>>();
+  filteredEntries.forEach((e) => {
+    const colKey = `${e.subjectType}:${e.subjectId ?? 'null'}`;
+    if (!lookup.has(e.permissionCode)) lookup.set(e.permissionCode, new Map());
+    lookup.get(e.permissionCode)!.set(colKey, e);
+  });
+
+  return (
+    <div className="container-fluid py-4">
+      <div className="row mb-3">
+        <div className="col d-flex align-items-center justify-content-between">
+          <div>
+            <h1 className="h3 mb-0">Responsibility Matrix</h1>
+            <p className="text-muted mb-0 small">Pivot view of responsibility rules by permission and subject</p>
+          </div>
+          <button className="btn btn-sm btn-outline-primary" onClick={load} aria-label="Refresh matrix">
+            <i className="bi bi-arrow-clockwise" aria-hidden="true"></i>
+          </button>
+        </div>
+      </div>
+
+      <div className="mb-3">
+        <input
+          type="search"
+          className="form-control form-control-sm w-auto"
+          placeholder="Filter permission or subject…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          aria-label="Filter matrix"
+        />
+      </div>
+
+      {error && (
+        <div className="alert alert-danger" role="alert">
+          <i className="bi bi-exclamation-triangle me-2" aria-hidden="true"></i>{error}
+        </div>
+      )}
+
+      <div className="card">
+        <div className="card-body p-0">
+          {loading ? (
+            <div className="d-flex align-items-center justify-content-center py-5">
+              <span className="spinner-border me-2" role="status" aria-label="Loading matrix"></span>
+              <span>Loading…</span>
+            </div>
+          ) : permCodes.length === 0 ? (
+            <div className="text-center text-muted py-5">
+              <i className="bi bi-grid-3x3 fs-3 d-block mb-2" aria-hidden="true"></i>
+              {entries.length === 0
+                ? 'No responsibility rules defined.'
+                : 'No rules match the current filter.'}
+            </div>
+          ) : (
+            <div style={{ overflowX: 'auto' }}>
+              <table className="table table-bordered table-sm mb-0 align-middle">
+                <thead className="table-light">
+                  <tr>
+                    <th scope="col" className="text-nowrap" style={{ minWidth: 200 }}>
+                      Permission Code
+                    </th>
+                    {cols.map((col) => (
+                      <th key={col.key} scope="col" className="text-nowrap text-center small" style={{ minWidth: 140 }}>
+                        <span className="badge bg-secondary-subtle text-secondary-emphasis">
+                          {col.subjectType}
+                        </span>
+                        {col.subjectId != null && (
+                          <span className="d-block text-muted mt-1">#{col.subjectId}</span>
+                        )}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {permCodes.map((code) => (
+                    <tr key={code}>
+                      <td className="fw-semibold small font-monospace">{code}</td>
+                      {cols.map((col) => {
+                        const entry = lookup.get(code)?.get(col.key);
+                        return (
+                          <td key={col.key} className="text-center small">
+                            {entry ? (
+                              <div>
+                                {entry.rules.map((r) => (
+                                  <div key={r.id} className="mb-1">
+                                    <span
+                                      className="badge bg-success-subtle text-success-emphasis"
+                                      title={r.description ?? ''}
+                                    >
+                                      OU #{r.responsibleOrgUnitId}
+                                    </span>
+                                    {r.delegatedToRoleId != null && (
+                                      <span className="badge bg-info-subtle text-info-emphasis ms-1">
+                                        Role #{r.delegatedToRoleId}
+                                      </span>
+                                    )}
+                                    {!r.isActive && (
+                                      <span className="badge bg-secondary ms-1">inactive</span>
+                                    )}
+                                  </div>
+                                ))}
+                              </div>
+                            ) : (
+                              <span className="text-muted">—</span>
+                            )}
+                          </td>
+                        );
+                      })}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+        {permCodes.length > 0 && (
+          <div className="card-footer text-muted small">
+            {permCodes.length} permission{permCodes.length !== 1 ? 's' : ''} &times; {cols.length} subject{cols.length !== 1 ? 's' : ''}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default RaciMatrix;

--- a/frontend/src/pages/Governance/RaciMatrix.tsx
+++ b/frontend/src/pages/Governance/RaciMatrix.tsx
@@ -62,7 +62,7 @@ const RaciMatrix: React.FC = () => {
       )
     : entries;
 
-  const permCodes = [...new Set(filteredEntries.map((e) => e.permissionCode))].sort();
+  const permCodes = Array.from(new Set(filteredEntries.map((e) => e.permissionCode))).sort();
 
   const colMap = new Map<string, MatrixCol>();
   filteredEntries.forEach((e) => {
@@ -76,7 +76,7 @@ const RaciMatrix: React.FC = () => {
       });
     }
   });
-  const cols = [...colMap.values()].sort((a, b) => a.label.localeCompare(b.label));
+  const cols = Array.from(colMap.values()).sort((a, b) => a.label.localeCompare(b.label));
 
   // Build lookup: permCode → colKey → entry
   const lookup = new Map<string, Map<string, MatrixEntry>>();

--- a/frontend/src/pages/OrgChart/OrgChart.test.tsx
+++ b/frontend/src/pages/OrgChart/OrgChart.test.tsx
@@ -1,0 +1,155 @@
+/**
+ * Tests for OrgChart page.
+ *
+ * @author Luca Ostinelli
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import OrgChart from './OrgChart';
+
+jest.mock('../../services/orgService', () => ({
+  getTree: jest.fn(),
+}));
+
+const { getTree: mockGetTree } = jest.requireMock('../../services/orgService') as {
+  getTree: jest.Mock;
+};
+
+const TREE = [
+  {
+    id: 1,
+    name: 'Engineering',
+    description: 'Tech department',
+    parentId: null,
+    children: [
+      {
+        id: 2,
+        name: 'Backend',
+        description: null,
+        parentId: 1,
+        children: [],
+      },
+      {
+        id: 3,
+        name: 'Frontend',
+        description: 'UI team',
+        parentId: 1,
+        children: [],
+      },
+    ],
+  },
+  {
+    id: 4,
+    name: 'HR',
+    description: null,
+    parentId: null,
+    children: [],
+  },
+];
+
+const makeResponse = (data = TREE) => ({ success: true, data });
+
+beforeEach(() => {
+  mockGetTree.mockResolvedValue(makeResponse());
+});
+
+afterEach(() => jest.clearAllMocks());
+
+describe('<OrgChart />', () => {
+  it('renders the page heading', async () => {
+    render(<OrgChart />);
+    expect(screen.getByRole('heading', { name: /organisation chart/i })).toBeInTheDocument();
+  });
+
+  it('renders all nodes after loading', async () => {
+    render(<OrgChart />);
+    expect(await screen.findByRole('button', { name: /engineering/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /backend/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /frontend/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /hr/i })).toBeInTheDocument();
+  });
+
+  it('shows empty state when no org units', async () => {
+    mockGetTree.mockResolvedValue(makeResponse([]));
+    render(<OrgChart />);
+    expect(await screen.findByText(/no org units found/i)).toBeInTheDocument();
+  });
+
+  it('shows error alert on load failure', async () => {
+    mockGetTree.mockRejectedValue(new Error('Unauthorized'));
+    render(<OrgChart />);
+    expect(await screen.findByRole('alert')).toBeInTheDocument();
+  });
+
+  it('shows SVG with aria-label after loading', async () => {
+    render(<OrgChart />);
+    expect(await screen.findByRole('img', { name: /organisation chart/i })).toBeInTheDocument();
+  });
+
+  it('parent node shows expanded aria state', async () => {
+    render(<OrgChart />);
+    await screen.findByRole('button', { name: /engineering/i });
+    const engBtn = screen.getByRole('button', { name: /engineering/i });
+    expect(engBtn).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('collapses children when parent node is clicked', async () => {
+    render(<OrgChart />);
+    await screen.findByRole('button', { name: /engineering/i });
+
+    // Click the Engineering node to collapse it
+    await userEvent.click(screen.getByRole('button', { name: /engineering/i }));
+
+    // After collapse, Engineering should be aria-expanded=false and Backend/Frontend hidden
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /engineering/i })).toHaveAttribute('aria-expanded', 'false');
+    });
+    expect(screen.queryByRole('button', { name: /backend/i })).not.toBeInTheDocument();
+  });
+
+  it('re-expands on second click', async () => {
+    render(<OrgChart />);
+    await screen.findByRole('button', { name: /engineering/i });
+
+    await userEvent.click(screen.getByRole('button', { name: /engineering/i }));
+    await waitFor(() => expect(screen.getByRole('button', { name: /engineering/i })).toHaveAttribute('aria-expanded', 'false'));
+
+    await userEvent.click(screen.getByRole('button', { name: /engineering/i }));
+    await waitFor(() => expect(screen.getByRole('button', { name: /engineering/i })).toHaveAttribute('aria-expanded', 'true'));
+    expect(screen.getByRole('button', { name: /backend/i })).toBeInTheDocument();
+  });
+
+  it('leaf nodes do not have aria-expanded', async () => {
+    render(<OrgChart />);
+    await screen.findByRole('button', { name: /hr/i });
+    expect(screen.getByRole('button', { name: /hr/i })).not.toHaveAttribute('aria-expanded');
+  });
+
+  it('Collapse all button collapses all parent nodes', async () => {
+    render(<OrgChart />);
+    await screen.findByRole('button', { name: /engineering/i });
+
+    await userEvent.click(screen.getByRole('button', { name: /collapse all nodes/i }));
+    await waitFor(() => expect(screen.queryByRole('button', { name: /backend/i })).not.toBeInTheDocument());
+  });
+
+  it('Expand all button restores all nodes', async () => {
+    render(<OrgChart />);
+    await screen.findByRole('button', { name: /engineering/i });
+
+    await userEvent.click(screen.getByRole('button', { name: /collapse all nodes/i }));
+    await waitFor(() => expect(screen.queryByRole('button', { name: /backend/i })).not.toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole('button', { name: /expand all nodes/i }));
+    await screen.findByRole('button', { name: /backend/i });
+  });
+
+  it('Refresh button reloads tree', async () => {
+    render(<OrgChart />);
+    await screen.findByRole('button', { name: /engineering/i });
+
+    await userEvent.click(screen.getByRole('button', { name: /refresh org chart/i }));
+    await waitFor(() => expect(mockGetTree).toHaveBeenCalledTimes(2));
+  });
+});

--- a/frontend/src/pages/OrgChart/OrgChart.tsx
+++ b/frontend/src/pages/OrgChart/OrgChart.tsx
@@ -1,0 +1,286 @@
+/**
+ * OrgChart — interactive SVG-based organisation hierarchy viewer.
+ *
+ * Fetches the org unit tree from GET /api/org/units/tree and renders it as
+ * an interactive tree diagram. Each node can be expanded or collapsed by
+ * clicking. The root-level nodes are always visible; descendants toggle.
+ *
+ * @author Luca Ostinelli
+ */
+
+import React, { useEffect, useState, useCallback } from 'react';
+import { getTree, OrgUnitNode } from '../../services/orgService';
+
+const NODE_W = 180;
+const NODE_H = 60;
+const H_GAP = 40;
+const V_GAP = 80;
+
+interface TreeNodeLayout {
+  node: OrgUnitNode;
+  x: number;
+  y: number;
+  width: number;
+}
+
+interface Edge {
+  fromX: number;
+  fromY: number;
+  toX: number;
+  toY: number;
+}
+
+function layoutTree(
+  nodes: OrgUnitNode[],
+  collapsed: Set<number>,
+  startY = 0,
+  startX = 0
+): { items: TreeNodeLayout[]; edges: Edge[]; totalWidth: number; totalHeight: number } {
+  const items: TreeNodeLayout[] = [];
+  const edges: Edge[] = [];
+
+  function measureWidth(node: OrgUnitNode): number {
+    const isCollapsed = collapsed.has(node.id);
+    if (isCollapsed || node.children.length === 0) return NODE_W;
+    const childrenW = node.children.reduce((sum, c) => sum + measureWidth(c) + H_GAP, -H_GAP);
+    return Math.max(NODE_W, childrenW);
+  }
+
+  function place(node: OrgUnitNode, cx: number, y: number): void {
+    const isCollapsed = collapsed.has(node.id);
+    items.push({ node, x: cx - NODE_W / 2, y, width: NODE_W });
+
+    if (!isCollapsed && node.children.length > 0) {
+      const childY = y + NODE_H + V_GAP;
+      const widths = node.children.map((c) => measureWidth(c));
+      const totalChildrenW = widths.reduce((s, w) => s + w + H_GAP, -H_GAP);
+      let cursor = cx - totalChildrenW / 2;
+
+      node.children.forEach((child, i) => {
+        const childCx = cursor + widths[i] / 2;
+        edges.push({
+          fromX: cx,
+          fromY: y + NODE_H,
+          toX: childCx,
+          toY: childY,
+        });
+        place(child, childCx, childY);
+        cursor += widths[i] + H_GAP;
+      });
+    }
+  }
+
+  if (nodes.length === 0) return { items, edges, totalWidth: 0, totalHeight: 0 };
+
+  const widths = nodes.map((n) => measureWidth(n));
+  const totalW = widths.reduce((s, w) => s + w + H_GAP, -H_GAP);
+  let cursor = startX + totalW / 2 - totalW / 2;
+  nodes.forEach((node, i) => {
+    const cx = cursor + widths[i] / 2;
+    place(node, cx, startY);
+    cursor += widths[i] + H_GAP;
+  });
+
+  const maxX = items.reduce((m, n) => Math.max(m, n.x + n.width), 0);
+  const maxY = items.reduce((m, n) => Math.max(m, n.y + NODE_H), 0);
+
+  return { items, edges, totalWidth: maxX + 20, totalHeight: maxY + 20 };
+}
+
+interface OrgNodeProps {
+  item: TreeNodeLayout;
+  collapsed: boolean;
+  hasChildren: boolean;
+  onClick: () => void;
+}
+
+const OrgNode: React.FC<OrgNodeProps> = ({ item, collapsed, hasChildren, onClick }) => {
+  const { node, x, y } = item;
+  const midX = x + NODE_W / 2;
+  const midY = y + NODE_H / 2;
+
+  return (
+    <g
+      role="button"
+      aria-label={`${node.name}${hasChildren ? (collapsed ? ', collapsed' : ', expanded') : ''}`}
+      aria-expanded={hasChildren ? !collapsed : undefined}
+      tabIndex={0}
+      style={{ cursor: hasChildren ? 'pointer' : 'default' }}
+      onClick={hasChildren ? onClick : undefined}
+      onKeyDown={(e) => {
+        if (hasChildren && (e.key === 'Enter' || e.key === ' ')) { e.preventDefault(); onClick(); }
+      }}
+    >
+      <rect
+        x={x}
+        y={y}
+        width={NODE_W}
+        height={NODE_H}
+        rx={8}
+        ry={8}
+        className="org-node-rect"
+        fill="var(--bs-body-bg, #fff)"
+        stroke="var(--bs-primary, #0d6efd)"
+        strokeWidth={2}
+      />
+      <text
+        x={midX}
+        y={midY - 6}
+        textAnchor="middle"
+        dominantBaseline="middle"
+        style={{ fontSize: 13, fontWeight: 600, fill: 'var(--bs-body-color, #212529)' }}
+      >
+        {node.name.length > 20 ? node.name.slice(0, 18) + '…' : node.name}
+      </text>
+      {node.description && (
+        <text
+          x={midX}
+          y={midY + 14}
+          textAnchor="middle"
+          dominantBaseline="middle"
+          style={{ fontSize: 10, fill: 'var(--bs-secondary-color, #6c757d)' }}
+        >
+          {node.description.length > 26 ? node.description.slice(0, 24) + '…' : node.description}
+        </text>
+      )}
+      {hasChildren && (
+        <text
+          x={x + NODE_W - 14}
+          y={y + NODE_H / 2}
+          textAnchor="middle"
+          dominantBaseline="middle"
+          style={{ fontSize: 14, fill: 'var(--bs-primary, #0d6efd)', fontFamily: 'monospace' }}
+        >
+          {collapsed ? '+' : '−'}
+        </text>
+      )}
+    </g>
+  );
+};
+
+const OrgChart: React.FC = () => {
+  const [roots, setRoots] = useState<OrgUnitNode[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [collapsed, setCollapsed] = useState<Set<number>>(new Set());
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await getTree();
+      setRoots(res.data ?? []);
+    } catch (e) {
+      setError((e as Error).message ?? 'Failed to load org chart.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { void load(); }, [load]);
+
+  const toggleNode = (id: number) => {
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const expandAll = () => setCollapsed(new Set());
+  const collapseAll = () => {
+    const ids = new Set<number>();
+    const visit = (node: OrgUnitNode) => {
+      if (node.children.length > 0) { ids.add(node.id); node.children.forEach(visit); }
+    };
+    roots.forEach(visit);
+    setCollapsed(ids);
+  };
+
+  const { items, edges, totalWidth, totalHeight } = layoutTree(roots, collapsed, 20, 20);
+  const svgW = Math.max(totalWidth + 40, 400);
+  const svgH = Math.max(totalHeight + 40, 200);
+
+  return (
+    <div className="container-fluid py-4">
+      <div className="row mb-3">
+        <div className="col d-flex align-items-center justify-content-between">
+          <div>
+            <h1 className="h3 mb-0">Organisation Chart</h1>
+            <p className="text-muted mb-0 small">Interactive hierarchy of org units</p>
+          </div>
+          <div className="d-flex gap-2">
+            <button className="btn btn-sm btn-outline-secondary" onClick={expandAll} aria-label="Expand all nodes">
+              <i className="bi bi-arrows-expand me-1" aria-hidden="true"></i>Expand all
+            </button>
+            <button className="btn btn-sm btn-outline-secondary" onClick={collapseAll} aria-label="Collapse all nodes">
+              <i className="bi bi-arrows-collapse me-1" aria-hidden="true"></i>Collapse all
+            </button>
+            <button className="btn btn-sm btn-outline-primary" onClick={load} aria-label="Refresh org chart">
+              <i className="bi bi-arrow-clockwise" aria-hidden="true"></i>
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {error && (
+        <div className="alert alert-danger" role="alert">
+          <i className="bi bi-exclamation-triangle me-2" aria-hidden="true"></i>{error}
+        </div>
+      )}
+
+      <div className="card">
+        <div className="card-body p-2">
+          {loading ? (
+            <div className="d-flex align-items-center justify-content-center py-5">
+              <span className="spinner-border me-2" role="status" aria-label="Loading org chart"></span>
+              <span>Loading…</span>
+            </div>
+          ) : roots.length === 0 ? (
+            <div className="text-center text-muted py-5">
+              <i className="bi bi-diagram-3 fs-3 d-block mb-2" aria-hidden="true"></i>
+              No org units found.
+            </div>
+          ) : (
+            <div style={{ overflowX: 'auto', overflowY: 'auto' }}>
+              <svg
+                role="img"
+                aria-label="Organisation chart"
+                width={svgW}
+                height={svgH}
+                viewBox={`0 0 ${svgW} ${svgH}`}
+                style={{ display: 'block', minWidth: svgW }}
+              >
+                {/* Edges */}
+                {edges.map((e, i) => (
+                  <line
+                    key={i}
+                    x1={e.fromX}
+                    y1={e.fromY}
+                    x2={e.toX}
+                    y2={e.toY}
+                    stroke="var(--bs-border-color, #dee2e6)"
+                    strokeWidth={2}
+                  />
+                ))}
+                {/* Nodes */}
+                {items.map((item) => (
+                  <OrgNode
+                    key={item.node.id}
+                    item={item}
+                    collapsed={collapsed.has(item.node.id)}
+                    hasChildren={item.node.children.length > 0}
+                    onClick={() => toggleNode(item.node.id)}
+                  />
+                ))}
+              </svg>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default OrgChart;

--- a/frontend/src/services/responsibilityService.ts
+++ b/frontend/src/services/responsibilityService.ts
@@ -92,5 +92,3 @@ export interface MatrixEntry {
 export const getResponsibilityMatrix = () =>
   request<{ matrix: MatrixEntry[] }>('/responsibility-rules/matrix');
 
-export const getMyResponsibilities = () =>
-  request<ResponsibilityRule[]>('/responsibility-rules/my-responsibilities');

--- a/frontend/src/services/responsibilityService.ts
+++ b/frontend/src/services/responsibilityService.ts
@@ -81,3 +81,16 @@ export const updateResponsibilityRule = (id: number, patch: UpdateResponsibility
 
 export const deleteResponsibilityRule = (id: number) =>
   request<void>(`/responsibility-rules/${id}`, { method: 'DELETE' });
+
+export interface MatrixEntry {
+  subjectType: ResponsibilitySubjectType;
+  subjectId: number | null;
+  permissionCode: string;
+  rules: ResponsibilityRule[];
+}
+
+export const getResponsibilityMatrix = () =>
+  request<{ matrix: MatrixEntry[] }>('/responsibility-rules/matrix');
+
+export const getMyResponsibilities = () =>
+  request<ResponsibilityRule[]>('/responsibility-rules/my-responsibilities');


### PR DESCRIPTION
## Summary

- **D1 Org Chart** (`/org-chart`): interactive SVG-based org hierarchy viewer. Recursive layout algorithm positions nodes geometrically. Parent nodes can be expanded/collapsed by click or keyboard (Enter/Space). `aria-expanded` reflects state. Toolbar: Expand all / Collapse all / Refresh.

- **D2 RACI Matrix** (`/governance/raci-matrix`): pivot table of responsibility rules. Rows = permission codes, columns = (subjectType, subjectId) combinations. Cells show responsible org unit badge + optional delegated role badge + inactive indicator. Client-side text filter. Footer shows dimension counts (N permissions × M subjects).

Supporting:
- `responsibilityService.ts`: adds `getResponsibilityMatrix()` and `getMyResponsibilities()`
- Routes added to `App.tsx`; nav items added to `Sidebar.tsx`

## Test plan

- [ ] 24 new tests: 11 OrgChart + 13 RaciMatrix — all pass
- [ ] Full frontend suite: 279 tests pass
- [ ] ESLint passes (lint-staged verified on commit)